### PR TITLE
Switch use of md5 hashing to sha256

### DIFF
--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -3,7 +3,7 @@ package db_test
 import (
 	"code.cloudfoundry.org/clock/fakeclock"
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -544,19 +544,19 @@ var _ = Describe("Build", func() {
 
 			expectedOutputs = []db.AlgorithmVersion{
 				{
-					Version:    db.ResourceVersion(convertToMD5(atc.Version{"ver": "1"})),
+					Version:    db.ResourceVersion(convertToSHA256(atc.Version{"ver": "1"})),
 					ResourceID: scenario.Resource("some-resource").ID(),
 				},
 				{
-					Version:    db.ResourceVersion(convertToMD5(atc.Version{"ver": "3"})),
+					Version:    db.ResourceVersion(convertToSHA256(atc.Version{"ver": "3"})),
 					ResourceID: scenario.Resource("some-other-resource").ID(),
 				},
 				{
-					Version:    db.ResourceVersion(convertToMD5(atc.Version{"ver": "2"})),
+					Version:    db.ResourceVersion(convertToSHA256(atc.Version{"ver": "2"})),
 					ResourceID: scenario.Resource("some-resource").ID(),
 				},
 				{
-					Version:    db.ResourceVersion(convertToMD5(atc.Version{"ver": "3"})),
+					Version:    db.ResourceVersion(convertToSHA256(atc.Version{"ver": "3"})),
 					ResourceID: scenario.Resource("some-resource").ID(),
 				},
 			}
@@ -1464,9 +1464,9 @@ var _ = Describe("Build", func() {
 				res, err := psql.Update("build_resource_config_version_inputs").
 					Set("first_occurrence", nil).
 					Where(sq.Eq{
-						"build_id":    build.ID(),
-						"resource_id": inputResource.ID(),
-						"version_md5": convertToMD5(atc.Version{"ver": "1"}),
+						"build_id":       build.ID(),
+						"resource_id":    inputResource.ID(),
+						"version_sha256": convertToSHA256(atc.Version{"ver": "1"}),
 					}).
 					RunWith(dbConn).
 					Exec()
@@ -1509,9 +1509,9 @@ var _ = Describe("Build", func() {
 					res, err := psql.Update("build_resource_config_version_inputs").
 						Set("first_occurrence", nil).
 						Where(sq.Eq{
-							"build_id":    newBuild.ID(),
-							"resource_id": inputResource.ID(),
-							"version_md5": convertToMD5(atc.Version{"ver": "1"}),
+							"build_id":       newBuild.ID(),
+							"resource_id":    inputResource.ID(),
+							"version_sha256": convertToSHA256(atc.Version{"ver": "1"}),
 						}).
 						RunWith(dbConn).
 						Exec()
@@ -2558,11 +2558,11 @@ func envelope(ev atc.Event, eventID string) event.Envelope {
 	}
 }
 
-func convertToMD5(version atc.Version) string {
+func convertToSHA256(version atc.Version) string {
 	versionJSON, err := json.Marshal(version)
 	Expect(err).ToNot(HaveOccurred())
 
-	hasher := md5.New()
+	hasher := sha256.New()
 	hasher.Write([]byte(versionJSON))
 	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -2,7 +2,7 @@ package dbtest
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -619,7 +619,7 @@ func (builder Builder) WithNextInputMapping(jobName string, inputs JobInputs) Se
 			mapping[input.Name] = db.InputResult{
 				Input: &db.AlgorithmInput{
 					AlgorithmVersion: db.AlgorithmVersion{
-						Version:    db.ResourceVersion(md5Version(i.Version)),
+						Version:    db.ResourceVersion(sha256Version(i.Version)),
 						ResourceID: input.ResourceID,
 					},
 					FirstOccurrence: i.FirstOccurrence,
@@ -1006,13 +1006,13 @@ func unique(kind string) string {
 	return kind + "-" + id.String()
 }
 
-func md5Version(version atc.Version) string {
+func sha256Version(version atc.Version) string {
 	versionJSON, err := json.Marshal(version)
 	if err != nil {
 		panic(err)
 	}
 
-	hasher := md5.New()
+	hasher := sha256.New()
 	hasher.Write([]byte(versionJSON))
 	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -1469,7 +1469,7 @@ var _ = Describe("Job", func() {
 					"some-input-1": db.InputResult{
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToMD5(versions[0].Version)),
+								Version:    db.ResourceVersion(convertToSHA256(versions[0].Version)),
 								ResourceID: scenario.Resource("some-resource").ID(),
 							},
 							FirstOccurrence: false,
@@ -1479,7 +1479,7 @@ var _ = Describe("Job", func() {
 					"some-input-2": db.InputResult{
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToMD5(versions[1].Version)),
+								Version:    db.ResourceVersion(convertToSHA256(versions[1].Version)),
 								ResourceID: scenario.Resource("some-resource").ID(),
 							},
 							FirstOccurrence: false,
@@ -1489,7 +1489,7 @@ var _ = Describe("Job", func() {
 					"some-input-3": db.InputResult{
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToMD5(versions[2].Version)),
+								Version:    db.ResourceVersion(convertToSHA256(versions[2].Version)),
 								ResourceID: scenario.Resource("some-resource").ID(),
 							},
 							FirstOccurrence: false,
@@ -1608,7 +1608,7 @@ var _ = Describe("Job", func() {
 				"some-input-1": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(versions[0].Version)),
+							Version:    db.ResourceVersion(convertToSHA256(versions[0].Version)),
 							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: false,
@@ -1618,7 +1618,7 @@ var _ = Describe("Job", func() {
 				"some-input-2": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(versions[1].Version)),
+							Version:    db.ResourceVersion(convertToSHA256(versions[1].Version)),
 							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
@@ -1633,7 +1633,7 @@ var _ = Describe("Job", func() {
 				"some-input-3": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(versions[2].Version)),
+							Version:    db.ResourceVersion(convertToSHA256(versions[2].Version)),
 							ResourceID: scenarioPipeline2.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: false,
@@ -1670,7 +1670,7 @@ var _ = Describe("Job", func() {
 				"some-input-2": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(versions[2].Version)),
+							Version:    db.ResourceVersion(convertToSHA256(versions[2].Version)),
 							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: false,
@@ -1680,7 +1680,7 @@ var _ = Describe("Job", func() {
 				"some-input-3": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(versions[2].Version)),
+							Version:    db.ResourceVersion(convertToSHA256(versions[2].Version)),
 							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,

--- a/atc/db/migration/migrations/1743084615_switch_md5_to_sha256.down.sql
+++ b/atc/db/migration/migrations/1743084615_switch_md5_to_sha256.down.sql
@@ -1,0 +1,133 @@
+SELECT clock_timestamp(); -- Start time
+
+-- Step 1: Revert column renames from version_sha256 back to version_md5
+ALTER TABLE resource_config_versions
+RENAME COLUMN version_sha256 TO version_md5;
+
+ALTER TABLE build_resource_config_version_inputs
+RENAME COLUMN version_sha256 TO version_md5;
+
+ALTER TABLE build_resource_config_version_outputs
+RENAME COLUMN version_sha256 TO version_md5;
+
+ALTER TABLE next_build_inputs
+RENAME COLUMN version_sha256 TO version_md5;
+
+ALTER TABLE resource_caches
+RENAME COLUMN version_sha256 TO version_md5;
+
+ALTER TABLE resource_disabled_versions
+RENAME COLUMN version_sha256 TO version_md5;
+
+--- Drop Indexes
+-- resource_config_versions
+ALTER TABLE resource_config_versions 
+    DROP CONSTRAINT IF EXISTS resource_config_scope_id_and_version_sha_unique;
+DROP INDEX IF EXISTS resource_config_versions_check_order_idx;
+DROP INDEX IF EXISTS resource_config_versions_version;
+
+-- resource_disabled_versions
+DROP INDEX IF EXISTS resource_disabled_versions_resource_id_version_sha_uniq; 
+
+-- resource_caches
+DROP INDEX IF EXISTS resource_caches_resource_config_id_version_sha_params_hash_uniq;
+DROP INDEX IF EXISTS resource_caches_resource_config_id;
+
+-- build_resource_config_version_inputs
+DROP INDEX IF EXISTS build_inputs_resource_versions_idx;
+DROP INDEX IF EXISTS build_resource_config_version_inputs_uniq;
+
+-- build_resource_config_version_outputs
+DROP INDEX IF EXISTS build_resource_config_version_outputs_build_id_idx;
+DROP INDEX IF EXISTS build_resource_config_version_outputs_resource_id_idx;
+DROP INDEX IF EXISTS build_resource_config_version_outputs_uniq;
+
+-- next_build_inputs
+ALTER TABLE next_build_inputs 
+    DROP CONSTRAINT IF EXISTS next_build_inputs_unique_job_id_input_name;
+DROP INDEX IF EXISTS next_build_inputs_job_id;
+
+-- Step 2: Revert all rows to their original md5 values
+WITH json_string_cte AS (
+    SELECT 
+        rcv.id,
+        rcv.version_md5 AS old_version_md5,
+        '{' || string_agg('"' || kv.key || '":"' || kv.value || '"', ',' ORDER BY kv.key) || '}' AS json_string
+    FROM resource_config_versions rcv
+    JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true
+    WHERE jsonb_typeof(rcv.version::jsonb) = 'object'
+    GROUP BY rcv.id, rcv.version_md5
+),
+hashed_json_string_cte AS (
+    SELECT 
+        json_string_cte.id,
+        json_string_cte.old_version_md5,
+        md5(json_string_cte.json_string) AS new_version_md5
+    FROM json_string_cte
+),
+update_resource_versions AS (
+    UPDATE resource_config_versions rcv
+    SET version_md5 = hjs.new_version_md5
+    FROM hashed_json_string_cte hjs
+    WHERE rcv.id = hjs.id
+),
+update_resource_disabled_versions AS (
+    UPDATE resource_disabled_versions rdv
+    SET version_md5 = hjs.new_version_md5
+    FROM hashed_json_string_cte hjs
+    WHERE rdv.version_md5 = hjs.old_version_md5
+),
+update_build_resource_config_version_inputs AS (
+    UPDATE build_resource_config_version_inputs bri
+    SET version_md5 = hjs.new_version_md5
+    FROM hashed_json_string_cte hjs
+    WHERE bri.version_md5 = hjs.old_version_md5
+),
+update_build_resource_config_version_outputs AS (
+    UPDATE build_resource_config_version_outputs bro
+    SET version_md5 = hjs.new_version_md5
+    FROM hashed_json_string_cte hjs
+    WHERE bro.version_md5 = hjs.old_version_md5
+),
+update_resource_caches AS (
+    UPDATE resource_caches rc
+    SET version_md5 = hjs.new_version_md5
+    FROM hashed_json_string_cte hjs
+    WHERE rc.version_md5 = hjs.old_version_md5
+)
+UPDATE next_build_inputs nbi
+SET version_md5 = hjs.new_version_md5
+FROM hashed_json_string_cte hjs
+WHERE nbi.version_md5 = hjs.old_version_md5;
+
+--- Recreate Indexes
+-- resource_config_versions
+ALTER TABLE resource_config_versions
+    ADD CONSTRAINT resource_config_scope_id_and_version_md5_unique UNIQUE (resource_config_scope_id, version_md5);
+CREATE INDEX resource_config_versions_check_order_idx ON resource_config_versions (resource_config_scope_id, check_order DESC);
+CREATE INDEX resource_config_versions_version ON resource_config_versions USING gin(version jsonb_path_ops) WITH (FASTUPDATE = false);
+
+-- build_resource_config_version_inputs
+CREATE INDEX build_inputs_resource_versions_idx ON build_resource_config_version_inputs (resource_id, version_md5);
+CREATE UNIQUE INDEX build_resource_config_version_inputs_uniq
+ON build_resource_config_version_inputs (build_id, resource_id, version_md5, name);
+
+-- build_resource_config_version_outputs
+CREATE INDEX build_resource_config_version_outputs_build_id_idx ON build_resource_config_version_outputs (build_id);
+CREATE INDEX build_resource_config_version_outputs_resource_id_idx ON build_resource_config_version_outputs (resource_id);
+CREATE UNIQUE INDEX build_resource_config_version_outputs_uniq
+ON build_resource_config_version_outputs (build_id, resource_id, version_md5, name);
+
+-- next_build_inputs
+CREATE INDEX next_build_inputs_job_id ON next_build_inputs USING btree (job_id);
+ALTER TABLE ONLY next_build_inputs
+    ADD CONSTRAINT next_build_inputs_unique_job_id_input_name UNIQUE (job_id, input_name);
+
+-- resource_caches
+CREATE INDEX resource_caches_resource_config_id ON resource_caches USING btree (resource_config_id);
+CREATE UNIQUE INDEX resource_caches_resource_config_id_version_md5_params_hash_uniq
+ON resource_caches (resource_config_id, version_md5, params_hash);
+
+-- resource_disabled_versions
+CREATE UNIQUE INDEX resource_disabled_versions_resource_id_version_md5_uniq
+ON resource_disabled_versions (resource_id, version_md5);

--- a/atc/db/migration/migrations/1743084615_switch_md5_to_sha256.down.sql
+++ b/atc/db/migration/migrations/1743084615_switch_md5_to_sha256.down.sql
@@ -1,5 +1,3 @@
-SELECT clock_timestamp(); -- Start time
-
 -- Step 1: Revert column renames from version_sha256 back to version_md5
 ALTER TABLE resource_config_versions
 RENAME COLUMN version_sha256 TO version_md5;

--- a/atc/db/migration/migrations/1743084615_switch_md5_to_sha256.up.sql
+++ b/atc/db/migration/migrations/1743084615_switch_md5_to_sha256.up.sql
@@ -1,0 +1,138 @@
+-- Ensure the pgcrypto extension is available for hashing
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Rename columns from version_md5 to version_sha256
+ALTER TABLE resource_config_versions
+RENAME COLUMN version_md5 TO version_sha256;
+
+ALTER TABLE build_resource_config_version_inputs
+RENAME COLUMN version_md5 TO version_sha256;
+
+ALTER TABLE build_resource_config_version_outputs
+RENAME COLUMN version_md5 TO version_sha256;
+
+ALTER TABLE next_build_inputs
+RENAME COLUMN version_md5 TO version_sha256;
+
+ALTER TABLE resource_caches
+RENAME COLUMN version_md5 TO version_sha256;
+
+ALTER TABLE resource_disabled_versions
+RENAME COLUMN version_md5 TO version_sha256;
+
+--- Drop Indexes
+-- resource_config_versions
+ALTER TABLE resource_config_versions 
+    DROP CONSTRAINT IF EXISTS resource_config_scope_id_and_version_md5_unique;
+DROP INDEX IF EXISTS resource_config_versions_check_order_idx;
+DROP INDEX IF EXISTS resource_config_versions_version;
+
+-- resource_disabled_versions
+DROP INDEX IF EXISTS resource_disabled_versions_resource_id_version_md5_uniq; 
+
+-- resource_caches
+DROP INDEX IF EXISTS resource_caches_resource_config_id_version_md5_params_hash_uniq;
+DROP INDEX IF EXISTS resource_caches_resource_config_id;
+
+-- build_resource_config_version_inputs
+DROP INDEX IF EXISTS build_inputs_resource_versions_idx;
+DROP INDEX IF EXISTS build_resource_config_version_inputs_uniq;
+
+-- build_resource_config_version_outputs
+DROP INDEX IF EXISTS build_resource_config_version_outputs_build_id_idx;
+DROP INDEX IF EXISTS build_resource_config_version_outputs_resource_id_idx;
+DROP INDEX IF EXISTS build_resource_config_version_outputs_uniq;
+
+-- next_build_inputs
+ALTER TABLE next_build_inputs 
+    DROP CONSTRAINT IF EXISTS next_build_inputs_unique_job_id_input_name;
+DROP INDEX IF EXISTS next_build_inputs_job_id;
+
+-- Convert all rows to their new sha256 values
+WITH json_string_cte AS (
+    SELECT 
+        rcv.id,
+        rcv.version_sha256 AS old_version_sha256,
+        '{' || string_agg('"' || kv.key || '":"' || kv.value || '"', ',' ORDER BY kv.key) || '}' AS json_string
+    FROM resource_config_versions rcv
+    JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true
+    WHERE jsonb_typeof(rcv.version::jsonb) = 'object'
+    GROUP BY rcv.id, rcv.version_sha256
+),
+hashed_json_string_cte AS (
+    SELECT 
+        json_string_cte.id,
+        json_string_cte.old_version_sha256,
+        encode(digest(json_string_cte.json_string, 'sha256'), 'hex') AS new_version_sha256
+    FROM json_string_cte
+),
+
+update_resource_versions AS (
+    UPDATE resource_config_versions rcv
+    SET version_sha256 = hjs.new_version_sha256
+    FROM hashed_json_string_cte hjs
+    WHERE rcv.id = hjs.id
+),
+update_resource_disabled_versions AS (
+    UPDATE resource_disabled_versions rdv
+    SET version_sha256 = hjs.new_version_sha256
+    FROM hashed_json_string_cte hjs
+    WHERE rdv.version_sha256 = hjs.old_version_sha256
+),
+update_build_resource_config_version_inputs AS (
+    UPDATE build_resource_config_version_inputs bri
+    SET version_sha256 = hjs.new_version_sha256
+    FROM hashed_json_string_cte hjs
+    WHERE bri.version_sha256 = hjs.old_version_sha256
+),
+update_build_resource_config_version_outputs AS (
+    UPDATE build_resource_config_version_outputs bro
+    SET version_sha256 = hjs.new_version_sha256
+    FROM hashed_json_string_cte hjs
+    WHERE bro.version_sha256 = hjs.old_version_sha256
+),
+update_resource_caches AS (
+    UPDATE resource_caches rc
+    SET version_sha256 = hjs.new_version_sha256
+    FROM hashed_json_string_cte hjs
+    WHERE rc.version_sha256 = hjs.old_version_sha256
+)
+
+UPDATE next_build_inputs nbi
+SET version_sha256 = hjs.new_version_sha256
+FROM hashed_json_string_cte hjs
+WHERE nbi.version_sha256 = hjs.old_version_sha256;
+
+--- Recreate indexes
+-- resource_config_versions
+ALTER TABLE resource_config_versions
+    ADD CONSTRAINT resource_config_scope_id_and_version_sha_unique UNIQUE (resource_config_scope_id, version_sha256);
+
+CREATE INDEX resource_config_versions_check_order_idx ON resource_config_versions (resource_config_scope_id, check_order DESC);
+CREATE INDEX resource_config_versions_version ON resource_config_versions USING gin(version jsonb_path_ops) WITH (FASTUPDATE = false);
+
+-- build_resource_config_version_inputs
+CREATE INDEX build_inputs_resource_versions_idx ON build_resource_config_version_inputs (resource_id, version_sha256);
+CREATE UNIQUE INDEX build_resource_config_version_inputs_uniq
+ON build_resource_config_version_inputs (build_id, resource_id, version_sha256, name);
+
+-- build_resource_config_version_outputs
+CREATE INDEX build_resource_config_version_outputs_build_id_idx ON build_resource_config_version_outputs (build_id);
+CREATE INDEX build_resource_config_version_outputs_resource_id_idx ON build_resource_config_version_outputs (resource_id);
+
+CREATE UNIQUE INDEX build_resource_config_version_outputs_uniq
+ON build_resource_config_version_outputs (build_id, resource_id, version_sha256, name);
+
+-- next_build_inputs
+CREATE INDEX next_build_inputs_job_id ON next_build_inputs USING btree (job_id);
+ALTER TABLE ONLY next_build_inputs
+    ADD CONSTRAINT next_build_inputs_unique_job_id_input_name UNIQUE (job_id, input_name);
+
+-- resource_caches
+CREATE INDEX resource_caches_resource_config_id ON resource_caches USING btree (resource_config_id);
+CREATE UNIQUE INDEX resource_caches_resource_config_id_version_sha_params_hash_uniq
+ON resource_caches (resource_config_id, version_sha256, params_hash);
+
+-- resource_disabled_versions
+CREATE UNIQUE INDEX resource_disabled_versions_resource_id_version_sha_uniq
+ON resource_disabled_versions (resource_id, version_sha256);

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -988,7 +988,7 @@ var _ = Describe("Pipeline", func() {
 					"some-input-name": db.InputResult{
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToMD5(atc.Version{"version": "1"})),
+								Version:    db.ResourceVersion(convertToSHA256(atc.Version{"version": "1"})),
 								ResourceID: resource.ID(),
 							},
 							FirstOccurrence: true,
@@ -1163,7 +1163,7 @@ var _ = Describe("Pipeline", func() {
 				"build-input": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(atc.Version{"key": "value"})),
+							Version:    db.ResourceVersion(convertToSHA256(atc.Version{"key": "value"})),
 							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
@@ -1589,7 +1589,7 @@ var _ = Describe("Pipeline", func() {
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(atc.Version{"version": "v1"})),
+							Version:    db.ResourceVersion(convertToSHA256(atc.Version{"version": "v1"})),
 							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
@@ -1617,7 +1617,7 @@ var _ = Describe("Pipeline", func() {
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(atc.Version{"version": "v1"})),
+							Version:    db.ResourceVersion(convertToSHA256(atc.Version{"version": "v1"})),
 							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
@@ -1627,7 +1627,7 @@ var _ = Describe("Pipeline", func() {
 				"some-other-input": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToMD5(atc.Version{"version": "v3"})),
+							Version:    db.ResourceVersion(convertToSHA256(atc.Version{"version": "v3"})),
 							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -42,12 +42,12 @@ const (
 WITH RECURSIVE build_ids AS (
 		SELECT DISTINCT i.build_id
 		FROM build_resource_config_version_inputs i
-		WHERE i.resource_id=$1 AND i.version_md5=$2
+		WHERE i.resource_id=$1 AND i.version_sha256=$2
 	UNION
 		SELECT i.build_id
 		FROM build_ids bi
 		INNER JOIN build_resource_config_version_outputs o ON o.build_id = bi.build_id
-		INNER JOIN build_resource_config_version_inputs i ON i.resource_id = o.resource_id AND i.version_md5 = o.version_md5
+		INNER JOIN build_resource_config_version_inputs i ON i.resource_id = o.resource_id AND i.version_sha256 = o.version_sha256
 		WHERE i.resource_id!=$1
 )
 `
@@ -56,12 +56,12 @@ WITH RECURSIVE build_ids AS (
 WITH RECURSIVE build_ids AS (
 		SELECT DISTINCT o.build_id
 		FROM build_resource_config_version_outputs o
-		WHERE o.resource_id=$1 AND o.version_md5=$2
+		WHERE o.resource_id=$1 AND o.version_sha256=$2
 	UNION
 		SELECT o.build_id
 		FROM build_ids bi
 		INNER JOIN build_resource_config_version_inputs i ON i.build_id = bi.build_id
-		INNER JOIN build_resource_config_version_outputs o ON o.resource_id = i.resource_id AND o.version_md5 = i.version_md5
+		INNER JOIN build_resource_config_version_outputs o ON o.resource_id = i.resource_id AND o.version_sha256 = i.version_sha256
 		WHERE i.resource_id!=$1
 )
 `
@@ -412,7 +412,7 @@ func (r *resource) UpdateMetadata(version atc.Version, metadata ResourceConfigMe
 			"resource_config_scope_id": r.ResourceConfigScopeID(),
 		}).
 		Where(sq.Expr(
-			"version_md5 = md5(?)", versionJSON,
+			"version_sha256 = encode(digest(?, 'sha256'), 'hex')", versionJSON,
 		)).
 		RunWith(r.conn).
 		Exec()
@@ -445,7 +445,7 @@ func (r *resource) FindVersion(v atc.Version) (ResourceConfigVersion, bool, erro
 		Where(sq.Eq{
 			"v.resource_config_scope_id": r.resourceConfigScopeID,
 		}).
-		Where(sq.Expr("v.version_md5 = md5(?)", versionByte)).
+		Where(sq.Expr("v.version_sha256 = encode(digest(?, 'sha256'), 'hex')", versionByte)).
 		RunWith(r.conn).
 		QueryRow()
 
@@ -514,7 +514,7 @@ func (r *resource) Versions(page Page, versionFilter atc.Version) ([]atc.Resourc
 			NOT EXISTS (
 				SELECT 1
 				FROM resource_disabled_versions d
-				WHERE v.version_md5 = d.version_md5
+				WHERE v.version_sha256 = d.version_sha256
 				AND r.resource_config_scope_id = v.resource_config_scope_id
 				AND r.id = d.resource_id
 			)
@@ -783,12 +783,12 @@ func (r *resource) toggleVersion(rcvID int, enable bool) error {
 		results, err = tx.Exec(`
 			DELETE FROM resource_disabled_versions
 			WHERE resource_id = $1
-			AND version_md5 = (SELECT version_md5 FROM resource_config_versions rcv WHERE rcv.id = $2)
+			AND version_sha256 = (SELECT version_sha256 FROM resource_config_versions rcv WHERE rcv.id = $2)
 			`, r.id, rcvID)
 	} else {
 		results, err = tx.Exec(`
-			INSERT INTO resource_disabled_versions (resource_id, version_md5)
-			SELECT $1, rcv.version_md5
+			INSERT INTO resource_disabled_versions (resource_id, version_sha256)
+			SELECT $1, rcv.version_sha256
 			FROM resource_config_versions rcv
 			WHERE rcv.id = $2
 			`, r.id, rcvID)
@@ -839,7 +839,7 @@ func (r *resource) ClearResourceCache(version atc.Version) (int64, error) {
 		}
 
 		selectStatement = selectStatement.Where(
-			sq.Expr("version_md5 = md5(?)", versionJson),
+			sq.Expr("version_sha256 = encode(digest(?, 'sha256'), 'hex')", versionJson),
 		)
 	}
 
@@ -1184,11 +1184,11 @@ type resourceVersionKey struct {
 // causalityBuilds figures out all the builds that are related to a particular resource version
 // This can include builds that were used the resource version (and its descendents) as an input,
 // and builds that generated some ancestor of the build that generated the resource version itself.
-func causalityBuilds(tx Tx, resourceID int, versionMD5 string, direction CausalityDirection) (map[int]*atc.CausalityBuild, map[int]*atc.CausalityJob, error) {
+func causalityBuilds(tx Tx, resourceID int, versionSHA256 string, direction CausalityDirection) (map[int]*atc.CausalityBuild, map[int]*atc.CausalityJob, error) {
 	query := causalityQuery(direction)
 	// construct the job and build nodes. These are placed into a map for easy access down the line
 	rows, err := psql.Select("b.id", "b.name", "b.status", "j.id", "j.name").
-		Prefix(query, resourceID, versionMD5).
+		Prefix(query, resourceID, versionSHA256).
 		From("build_ids bi").
 		Join("builds b ON b.id = bi.build_id").
 		Join("jobs j ON b.job_id = j.id").
@@ -1241,7 +1241,7 @@ func causalityBuilds(tx Tx, resourceID int, versionMD5 string, direction Causali
 	return builds, jobs, nil
 }
 
-func causalityResourceVersions(tx Tx, resourceID int, versionMD5 string, direction CausalityDirection, result *atc.Causality) error {
+func causalityResourceVersions(tx Tx, resourceID int, versionSHA256 string, direction CausalityDirection, result *atc.Causality) error {
 	// Bitmap to filter out resources that are not part of a output-input chain. This is done to filter out any other "root" resources.
 	// For now, the causality view is only intersted in the "downstream" resources, not neccessarily "parallel input" resources
 	// (reverse is true for upstream causality). If this ever changes in the future, it would be trivial to remove this filtering and get
@@ -1276,7 +1276,7 @@ func causalityResourceVersions(tx Tx, resourceID int, versionMD5 string, directi
 		handleOutput = buildAsChild
 	}
 
-	builds, jobs, err := causalityBuilds(tx, resourceID, versionMD5, direction)
+	builds, jobs, err := causalityBuilds(tx, resourceID, versionSHA256, direction)
 	if err != nil {
 		return err
 	}
@@ -1285,18 +1285,18 @@ func causalityResourceVersions(tx Tx, resourceID int, versionMD5 string, directi
 	SELECT r.id, rcv.id, r.name, rcv.version, i.build_id, 'input' AS type
 	FROM build_resource_config_version_inputs i
 	JOIN resources r ON r.id = i.resource_id
-	JOIN resource_config_versions rcv ON rcv.version_md5 = i.version_md5 AND rcv.resource_config_scope_id = r.resource_config_scope_id
+	JOIN resource_config_versions rcv ON rcv.version_sha256 = i.version_sha256 AND rcv.resource_config_scope_id = r.resource_config_scope_id
 	JOIN build_ids bi ON i.build_id = bi.build_id
 UNION ALL
 	SELECT r.id, rcv.id, r.name, rcv.version, o.build_id, 'output' AS type
 	FROM build_resource_config_version_outputs o
 	JOIN resources r ON r.id = o.resource_id
-	JOIN resource_config_versions rcv ON rcv.version_md5 = o.version_md5 AND rcv.resource_config_scope_id = r.resource_config_scope_id
+	JOIN resource_config_versions rcv ON rcv.version_sha256 = o.version_sha256 AND rcv.resource_config_scope_id = r.resource_config_scope_id
 	JOIN build_ids bi ON o.build_id = bi.build_id
 LIMIT $3
 `
 
-	rows, err := tx.Query(query, resourceID, versionMD5, causalityMaxInputsOutputs)
+	rows, err := tx.Query(query, resourceID, versionSHA256, causalityMaxInputsOutputs)
 	if err != nil {
 		return err
 	}
@@ -1407,17 +1407,17 @@ func (r *resource) Causality(rcvID int, direction CausalityDirection) (atc.Causa
 
 	defer Rollback(tx) // everything is readonly, so no need to commit
 
-	var versionMD5 string
-	err = psql.Select("version_md5").
+	var versionSHA256 string
+	err = psql.Select("version_sha256").
 		From("resource_config_versions").
 		Where(sq.Eq{"id": rcvID}).
 		RunWith(tx).
-		Scan(&versionMD5)
+		Scan(&versionSHA256)
 	if err != nil {
 		return result, false, err
 	}
 
-	err = causalityResourceVersions(tx, r.id, versionMD5, direction, &result)
+	err = causalityResourceVersions(tx, r.id, versionSHA256, direction, &result)
 	if err != nil {
 		return result, false, err
 	}

--- a/atc/db/resource_cache_factory.go
+++ b/atc/db/resource_cache_factory.go
@@ -77,7 +77,7 @@ func (f *resourceCacheFactory) FindOrCreateResourceCache(
 			"resource_config_id": rc.id,
 			"params_hash":        paramsHash(params),
 		}).
-		Where(sq.Expr("version_md5 = md5(?)", cacheVersion)).
+		Where(sq.Expr("version_sha256 = encode(digest(?, 'sha256'), 'hex')", cacheVersion)).
 		Suffix("FOR SHARE").
 		RunWith(tx).
 		QueryRow().
@@ -95,20 +95,20 @@ func (f *resourceCacheFactory) FindOrCreateResourceCache(
 			Columns(
 				"resource_config_id",
 				"version",
-				"version_md5",
+				"version_sha256",
 				"params_hash",
 			).
 			Values(
 				rc.id,
 				cacheVersion,
-				sq.Expr("md5(?)", cacheVersion),
+				sq.Expr("encode(digest(?, 'sha256'), 'hex')", cacheVersion),
 				paramsHash(params),
 			).
 			Suffix(`
-				ON CONFLICT (resource_config_id, version_md5, params_hash) DO UPDATE SET
+				ON CONFLICT (resource_config_id, version_sha256, params_hash) DO UPDATE SET
 				resource_config_id = EXCLUDED.resource_config_id,
 				version = EXCLUDED.version,
-				version_md5 = EXCLUDED.version_md5,
+				version_sha256 = EXCLUDED.version_sha256,
 				params_hash = EXCLUDED.params_hash
 				RETURNING id
 			`).

--- a/atc/db/resource_cache_lifecycle.go
+++ b/atc/db/resource_cache_lifecycle.go
@@ -105,8 +105,8 @@ func (f *resourceCacheLifecycle) CleanUpInvalidCaches(logger lager.Logger) error
 		Select("r_cache.id").
 		From("next_build_inputs nbi").
 		Join("resources r ON r.id = nbi.resource_id").
-		Join("resource_config_versions rcv ON rcv.version_md5 = nbi.version_md5 AND rcv.resource_config_scope_id = r.resource_config_scope_id").
-		Join("resource_caches r_cache ON r_cache.resource_config_id = r.resource_config_id AND r_cache.version_md5 = rcv.version_md5").
+		Join("resource_config_versions rcv ON rcv.version_sha256 = nbi.version_sha256 AND rcv.resource_config_scope_id = r.resource_config_scope_id").
+		Join("resource_caches r_cache ON r_cache.resource_config_id = r.resource_config_id AND r_cache.version_sha256 = rcv.version_sha256").
 		Join("jobs j ON nbi.job_id = j.id").
 		Join("pipelines p ON j.pipeline_id = p.id").
 		Where(sq.Expr("p.paused = false")).

--- a/atc/db/resource_cache_lifecycle_test.go
+++ b/atc/db/resource_cache_lifecycle_test.go
@@ -349,7 +349,7 @@ var _ = Describe("ResourceCacheLifecycle", func() {
 					"some-resource": db.InputResult{
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToMD5(atc.Version(resourceConfigVersion.Version()))),
+								Version:    db.ResourceVersion(convertToSHA256(atc.Version(resourceConfigVersion.Version()))),
 								ResourceID: scenario.Resource("some-resource").ID(),
 							},
 						},

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -149,7 +149,7 @@ func (r *resourceConfigScope) FindVersion(v atc.Version) (ResourceConfigVersion,
 		Where(sq.Eq{
 			"v.resource_config_scope_id": r.id,
 		}).
-		Where(sq.Expr("v.version_md5 = md5(?)", versionByte)).
+		Where(sq.Expr("v.version_sha256 = encode(digest(?, 'sha256'), 'hex')", versionByte)).
 		RunWith(r.conn).
 		QueryRow()
 
@@ -276,9 +276,9 @@ func saveResourceVersion(tx Tx, rcsID int, version atc.Version, metadata Resourc
 
 	var checkOrder int
 	err = tx.QueryRow(`
-		INSERT INTO resource_config_versions (resource_config_scope_id, version, version_md5, metadata, span_context)
-		SELECT $1, $2, md5($3), $4, $5
-		ON CONFLICT (resource_config_scope_id, version_md5)
+		INSERT INTO resource_config_versions (resource_config_scope_id, version, version_sha256, metadata, span_context)
+		SELECT $1, $2, encode(digest($3, 'sha256'), 'hex'), $4, $5
+		ON CONFLICT (resource_config_scope_id, version_sha256)
 		DO UPDATE SET metadata = COALESCE(NULLIF(excluded.metadata, 'null'::jsonb), resource_config_versions.metadata)
 		RETURNING check_order
 		`, rcsID, string(versionJSON), string(versionJSON), string(metadataJSON), string(spanContextJSON)).Scan(&checkOrder)
@@ -305,7 +305,7 @@ func incrementCheckOrder(tx Tx, rcsID int, version string) error {
 		SET check_order = mc.co + 1
 		FROM max_checkorder mc
 		WHERE resource_config_scope_id = $1
-		AND version_md5 = md5($2)
+		AND version_sha256 = encode(digest($2, 'sha256'), 'hex')
 		AND check_order <= mc.co;`, rcsID, version)
 	return err
 }

--- a/atc/db/versions_db_test.go
+++ b/atc/db/versions_db_test.go
@@ -757,9 +757,9 @@ var _ = Describe("VersionsDB", func() {
 				queryVersion = atc.Version{"tag": "v1"}
 			})
 
-			It("return the version md5", func() {
+			It("return the version sha256", func() {
 				Expect(found).To(BeTrue())
-				Expect(string(resourceVersion)).To(Equal(convertToMD5(dbVersion)))
+				Expect(string(resourceVersion)).To(Equal(convertToSHA256(dbVersion)))
 			})
 		})
 	})

--- a/atc/gc/resource_cache_collector_test.go
+++ b/atc/gc/resource_cache_collector_test.go
@@ -124,20 +124,20 @@ var _ = Describe("ResourceCacheCollector", func() {
 
 				Context("when the cache is an input to a job", func() {
 					BeforeEach(func() {
-						var versionMD5 string
+						var versionSHA256 string
 						version := `{"some":"version"}`
 						err = psql.Insert("resource_config_versions").
-							Columns("version", "version_md5", "metadata", "resource_config_scope_id").
+							Columns("version", "version_sha256", "metadata", "resource_config_scope_id").
 							Values(version, sq.Expr(fmt.Sprintf("md5('%s')", version)), `null`, jobCache.ResourceConfig().ID()).
-							Suffix("RETURNING version_md5").
-							RunWith(dbConn).QueryRow().Scan(&versionMD5)
+							Suffix("RETURNING version_sha256").
+							RunWith(dbConn).QueryRow().Scan(&versionSHA256)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(scenario.Job("some-job").SaveNextInputMapping(db.InputMapping{
 							"whatever": db.InputResult{
 								Input: &db.AlgorithmInput{
 									AlgorithmVersion: db.AlgorithmVersion{
-										Version:    db.ResourceVersion(versionMD5),
+										Version:    db.ResourceVersion(versionSHA256),
 										ResourceID: scenario.Resource("some-resource").ID(),
 									},
 								},

--- a/atc/gc/resource_cache_collector_test.go
+++ b/atc/gc/resource_cache_collector_test.go
@@ -128,7 +128,7 @@ var _ = Describe("ResourceCacheCollector", func() {
 						version := `{"some":"version"}`
 						err = psql.Insert("resource_config_versions").
 							Columns("version", "version_sha256", "metadata", "resource_config_scope_id").
-							Values(version, sq.Expr(fmt.Sprintf("md5('%s')", version)), `null`, jobCache.ResourceConfig().ID()).
+							Values(version, sq.Expr(fmt.Sprintf("encode(digest('%s', 'sha256'), 'hex')", version)), `null`, jobCache.ResourceConfig().ID()).
 							Suffix("RETURNING version_sha256").
 							RunWith(dbConn).QueryRow().Scan(&versionSHA256)
 						Expect(err).NotTo(HaveOccurred())

--- a/atc/scheduler/algorithm/migration_test.go
+++ b/atc/scheduler/algorithm/migration_test.go
@@ -1,7 +1,7 @@
 package algorithm_test
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 
@@ -109,43 +109,43 @@ var _ = DescribeTable("Migrating build inputs and outputs into successful build 
 			},
 			ExpectedMigrated: map[int]map[int][]string{
 				2: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv2")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv2")},
 				},
 				3: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv3")},
+					1: []string{migratorConvertToSHA256("rxv3"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv3")},
 				},
 				4: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv2")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv2")},
 				},
 				5: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv4"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv4")},
+					1: []string{migratorConvertToSHA256("rxv4"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv4")},
 				},
 				6: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv1"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv1")},
+					1: []string{migratorConvertToSHA256("rxv1"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv1")},
 				},
 				7: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv2")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv2")},
 				},
 				8: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv3")},
+					1: []string{migratorConvertToSHA256("rxv3"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv3")},
 				},
 				9: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv2")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv2")},
 				},
 				10: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv4"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv4")},
+					1: []string{migratorConvertToSHA256("rxv4"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv4")},
 				},
 				11: map[int][]string{
-					2: []string{migratorConvertToMD5("ryv4")},
+					2: []string{migratorConvertToSHA256("ryv4")},
 				},
 			},
 		},
@@ -241,47 +241,47 @@ var _ = DescribeTable("Migrating build inputs and outputs into successful build 
 			},
 			ExpectedMigrated: map[int]map[int][]string{
 				1: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv1"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv1")},
+					1: []string{migratorConvertToSHA256("rxv1"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv1")},
 				},
 				2: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv2")},
-					2: []string{migratorConvertToMD5("ryv2")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv2")},
+					2: []string{migratorConvertToSHA256("ryv2")},
 				},
 				3: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3"), migratorConvertToMD5("rxv3")},
-					2: []string{migratorConvertToMD5("ryv3")},
+					1: []string{migratorConvertToSHA256("rxv3"), migratorConvertToSHA256("rxv3")},
+					2: []string{migratorConvertToSHA256("ryv3")},
 				},
 				4: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv2")},
-					2: []string{migratorConvertToMD5("ryv2")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv2")},
+					2: []string{migratorConvertToSHA256("ryv2")},
 				},
 				5: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv4"), migratorConvertToMD5("rxv4")},
-					2: []string{migratorConvertToMD5("ryv4")},
+					1: []string{migratorConvertToSHA256("rxv4"), migratorConvertToSHA256("rxv4")},
+					2: []string{migratorConvertToSHA256("ryv4")},
 				},
 				6: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv1"), migratorConvertToMD5("rxv1")},
-					2: []string{migratorConvertToMD5("ryv1")},
+					1: []string{migratorConvertToSHA256("rxv1"), migratorConvertToSHA256("rxv1")},
+					2: []string{migratorConvertToSHA256("ryv1")},
 				},
 				7: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv2")},
-					2: []string{migratorConvertToMD5("ryv2")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv2")},
+					2: []string{migratorConvertToSHA256("ryv2")},
 				},
 				8: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3"), migratorConvertToMD5("rxv3")},
-					2: []string{migratorConvertToMD5("ryv3")},
+					1: []string{migratorConvertToSHA256("rxv3"), migratorConvertToSHA256("rxv3")},
+					2: []string{migratorConvertToSHA256("ryv3")},
 				},
 				9: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv2")},
-					2: []string{migratorConvertToMD5("ryv2")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv2")},
+					2: []string{migratorConvertToSHA256("ryv2")},
 				},
 				10: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv4"), migratorConvertToMD5("rxv4")},
-					2: []string{migratorConvertToMD5("ryv4")},
+					1: []string{migratorConvertToSHA256("rxv4"), migratorConvertToSHA256("rxv4")},
+					2: []string{migratorConvertToSHA256("ryv4")},
 				},
 				11: map[int][]string{
-					2: []string{migratorConvertToMD5("ryv5")},
+					2: []string{migratorConvertToSHA256("ryv5")},
 				},
 			},
 		},
@@ -333,13 +333,13 @@ var _ = DescribeTable("Migrating build inputs and outputs into successful build 
 			},
 			ExpectedMigrated: map[int]map[int][]string{
 				2: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2")},
+					1: []string{migratorConvertToSHA256("rxv2")},
 				},
 				3: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3")},
+					1: []string{migratorConvertToSHA256("rxv3")},
 				},
 				6: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3")},
+					1: []string{migratorConvertToSHA256("rxv3")},
 				},
 			},
 		},
@@ -390,13 +390,13 @@ var _ = DescribeTable("Migrating build inputs and outputs into successful build 
 			},
 			ExpectedMigrated: map[int]map[int][]string{
 				4: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv4")},
+					1: []string{migratorConvertToSHA256("rxv4")},
 				},
 				3: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3")},
+					1: []string{migratorConvertToSHA256("rxv3")},
 				},
 				5: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3")},
+					1: []string{migratorConvertToSHA256("rxv3")},
 				},
 			},
 		},
@@ -438,13 +438,13 @@ var _ = DescribeTable("Migrating build inputs and outputs into successful build 
 			},
 			ExpectedMigrated: map[int]map[int][]string{
 				3: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3")},
+					1: []string{migratorConvertToSHA256("rxv3")},
 				},
 				4: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv4")},
+					1: []string{migratorConvertToSHA256("rxv4")},
 				},
 				6: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3")},
+					1: []string{migratorConvertToSHA256("rxv3")},
 				},
 			},
 		},
@@ -483,7 +483,7 @@ var _ = DescribeTable("Migrating build inputs and outputs into successful build 
 			},
 			ExpectedMigrated: map[int]map[int][]string{
 				1: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2"), migratorConvertToMD5("rxv1")},
+					1: []string{migratorConvertToSHA256("rxv2"), migratorConvertToSHA256("rxv1")},
 				},
 			},
 		},
@@ -538,19 +538,19 @@ var _ = DescribeTable("Migrating build inputs and outputs into successful build 
 			},
 			ExpectedMigrated: map[int]map[int][]string{
 				2: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv2")},
+					1: []string{migratorConvertToSHA256("rxv2")},
 				},
 				4: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv4")},
+					1: []string{migratorConvertToSHA256("rxv4")},
 				},
 				6: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv1")},
+					1: []string{migratorConvertToSHA256("rxv1")},
 				},
 				8: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3")},
+					1: []string{migratorConvertToSHA256("rxv3")},
 				},
 				9: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv4")},
+					1: []string{migratorConvertToSHA256("rxv4")},
 				},
 			},
 		},
@@ -600,17 +600,17 @@ var _ = DescribeTable("Migrating build inputs and outputs into successful build 
 			},
 			ExpectedMigrated: map[int]map[int][]string{
 				4: map[int][]string{
-					1: []string{migratorConvertToMD5("rxv3")},
+					1: []string{migratorConvertToSHA256("rxv3")},
 				},
 			},
 		},
 	}),
 )
 
-func migratorConvertToMD5(version string) string {
+func migratorConvertToSHA256(version string) string {
 	versionJSON, _ := json.Marshal(atc.Version{"ver": version})
 
-	hasher := md5.New()
+	hasher := sha256.New()
 	hasher.Write([]byte(versionJSON))
 	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/atc/scheduler/algorithm/table_helpers_test.go
+++ b/atc/scheduler/algorithm/table_helpers_test.go
@@ -280,7 +280,7 @@ func (example Example) importVersionsDB(ctx context.Context, setup setupDB, cach
 			txn, err := pgxConn.Begin(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
-			cols := []string{"id", "resource_config_scope_id", "version", "version_md5", "check_order"}
+			cols := []string{"id", "resource_config_scope_id", "version", "version_sha256", "check_order"}
 			copyCount, err := txn.CopyFrom(ctx,
 				pgx.Identifier{"resource_config_versions"},
 				cols, pgx.CopyFromSlice(len(debugDB.ResourceVersions), func(i int) (row []any, err error) {
@@ -441,7 +441,7 @@ func (example Example) importVersionsDB(ctx context.Context, setup setupDB, cach
 			txn, err := pgxConn.Begin(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
-			cols := []string{"build_id", "resource_id", "version_md5", "name", "first_occurrence"}
+			cols := []string{"build_id", "resource_id", "version_sha256", "name", "first_occurrence"}
 			copyCount, err := txn.CopyFrom(ctx,
 				pgx.Identifier{"build_resource_config_version_inputs"},
 				cols, pgx.CopyFromSlice(len(debugDB.BuildInputs), func(i int) (row []any, err error) {
@@ -483,7 +483,7 @@ func (example Example) importVersionsDB(ctx context.Context, setup setupDB, cach
 			txn, err := pgxConn.Begin(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
-			cols := []string{"build_id", "resource_id", "version_md5", "name"}
+			cols := []string{"build_id", "resource_id", "version_sha256", "name"}
 			copyCount, err := txn.CopyFrom(ctx,
 				pgx.Identifier{"build_resource_config_version_outputs"},
 				cols, pgx.CopyFromSlice(len(debugDB.BuildOutputs), func(i int) (row []any, err error) {
@@ -538,8 +538,8 @@ func (example Example) setupVersionsDB(ctx context.Context, setup setupDB, cache
 		Expect(err).ToNot(HaveOccurred())
 
 		_, err = setup.psql.Insert("build_resource_config_version_outputs").
-			Columns("build_id", "resource_id", "version_md5", "name").
-			Values(row.BuildID, resourceID, sq.Expr("md5(?)", versionJSON), row.Resource).
+			Columns("build_id", "resource_id", "version_sha256", "name").
+			Values(row.BuildID, resourceID, sq.Expr("encode(digest(?, 'sha256'), 'hex')", versionJSON), row.Resource).
 			Exec()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -552,7 +552,7 @@ func (example Example) setupVersionsDB(ctx context.Context, setup setupDB, cache
 
 			key := strconv.Itoa(resourceID)
 
-			outputs[key] = append(outputs[key], convertToMD5(row.Version))
+			outputs[key] = append(outputs[key], convertToSHA256(row.Version))
 			buildToJobID[row.BuildID] = setup.jobIDs.ID(row.Job)
 
 			if row.RerunOfBuildID != 0 {
@@ -571,8 +571,8 @@ func (example Example) setupVersionsDB(ctx context.Context, setup setupDB, cache
 		Expect(err).ToNot(HaveOccurred())
 
 		_, err = setup.psql.Insert("build_resource_config_version_inputs").
-			Columns("build_id", "resource_id", "version_md5", "name", "first_occurrence").
-			Values(row.BuildID, resourceID, sq.Expr("md5(?)", versionJSON), row.Resource, false).
+			Columns("build_id", "resource_id", "version_sha256", "name", "first_occurrence").
+			Values(row.BuildID, resourceID, sq.Expr("encode(digest(?, 'sha256'), 'hex')", versionJSON), row.Resource, false).
 			Exec()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -585,7 +585,7 @@ func (example Example) setupVersionsDB(ctx context.Context, setup setupDB, cache
 
 			key := strconv.Itoa(resourceID)
 
-			outputs[key] = append(outputs[key], convertToMD5(row.Version))
+			outputs[key] = append(outputs[key], convertToSHA256(row.Version))
 			buildToJobID[row.BuildID] = setup.jobIDs.ID(row.Job)
 
 			if row.RerunOfBuildID != 0 {
@@ -668,8 +668,8 @@ func (example Example) assert(
 						From("resource_config_versions v").
 						Join("resources r ON r.resource_config_scope_id = v.resource_config_scope_id").
 						Where(sq.Eq{
-							"v.version_md5": inputSource.Input.AlgorithmVersion.Version,
-							"r.id":          inputSource.Input.ResourceID,
+							"v.version_sha256": inputSource.Input.AlgorithmVersion.Version,
+							"r.id":             inputSource.Input.ResourceID,
 						}).
 						QueryRow().
 						Scan(&versionID)
@@ -867,16 +867,16 @@ func (s setupDB) insertRowVersion(resources map[string]atc.ResourceConfig, row D
 	Expect(err).ToNot(HaveOccurred())
 
 	_, err = s.psql.Insert("resource_config_versions").
-		Columns("id", "resource_config_scope_id", "version", "version_md5", "check_order").
-		Values(versionID, resourceID, versionJSON, sq.Expr("md5(?)", versionJSON), row.CheckOrder).
+		Columns("id", "resource_config_scope_id", "version", "version_sha256", "check_order").
+		Values(versionID, resourceID, versionJSON, sq.Expr("encode(digest(?, 'sha256'), 'hex')", versionJSON), row.CheckOrder).
 		Suffix("ON CONFLICT DO NOTHING").
 		Exec()
 	Expect(err).ToNot(HaveOccurred())
 
 	if row.Disabled {
 		_, err = s.psql.Insert("resource_disabled_versions").
-			Columns("resource_id", "version_md5").
-			Values(resourceID, sq.Expr("md5(?)", versionJSON)).
+			Columns("resource_id", "version_sha256").
+			Values(resourceID, sq.Expr("encode(digest(?, 'sha256'), 'hex')", versionJSON)).
 			Suffix("ON CONFLICT DO NOTHING").
 			Exec()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

Related to #9021 and #9133

closes #9122

FIPS-compliant PostgreSQL instances restrict the use of `md5` hashing, requiring a transition to `sha256`. To accommodate this, a migration has been implemented to convert all existing `md5` hashes in the affected tables to `sha256`. For large databases, this process may take some time to complete.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Replace MD5 with SHA-256 in all relevant areas
* [x] Update test cases accordingly
* [x] Perform manual testing to ensure UI functionality remains intact, including features like disabling resources and pinning specific resource versions

## Notes to reviewer
Results from tests on highly loaded database:
#### Setup

| **Component**         | **Details**             |
|----------------------|------------------------|
| **Database Instance** | PostgreSQL on AWS      |
| **Instance Class**    | `db.t4g.xlarge`        |
| **vCPU**             | 4                       |
| **RAM**              | 16 GB                   |
| **Engine Version**   | 16.8                    |
| **Storage**          | 250 GiB                 |

#### Data
Tables | Rows
-- | --
resource_config_versions | 10 337 812
build_resource_config_version_inputs | 18 626 661
build_resource_config_version_outputs | 2 745 473
next_build_inputs | 41 482
resource_caches | 531
resource_disabled_versions | 46
builds | 9 804 696
jobs | 40 006

Migration was done in ~19 mins.

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Must be executed during a scheduled downtime window. Depending on the size of your database the migration could take ten's of minutes or even a few hours. Plan accordingly.
* Replaces MD5 with SHA-256 across the codebase
* Migrates all existing MD5-hashed data to SHA-256 in the database

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
