### PR TITLE
refactor: simplify hasPermission method in accessor

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -182,10 +182,8 @@ func (a *access) TeamNames() []string {
 }
 
 func (a *access) hasPermission(roles []string) bool {
-	allow := false
 	for _, role := range roles {
-		allow = allow || a.hasRequiredRole(role)
-		if allow {
+		if a.hasRequiredRole(role) {
 			return true
 		}
 	}


### PR DESCRIPTION
Improve code readability by removing redundant boolean operation and temporary variable in the hasPermission method. No functional change as this simplification would likely be performed by the compiler anyway.
