### PR TITLE
Warn instead of error on unused resources

### DIFF
--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -208,7 +208,7 @@ func validateResources(c atc.Config) ([]atc.ConfigWarning, error) {
 		}
 	}
 
-	errorMessages = append(errorMessages, validateResourcesUnused(c)...)
+	warnings = append(warnings, validateResourcesUnused(c)...)
 
 	return warnings, compositeErr(errorMessages)
 }
@@ -287,18 +287,20 @@ func validatePrototypes(c atc.Config, seenTypes map[string]location) ([]atc.Conf
 	return warnings, compositeErr(errorMessages)
 }
 
-func validateResourcesUnused(c atc.Config) []string {
+func validateResourcesUnused(c atc.Config) []atc.ConfigWarning {
+	warnings := []atc.ConfigWarning{}
 	usedResources := usedResources(c)
 
-	var errorMessages []string
 	for _, resource := range c.Resources {
 		if _, used := usedResources[resource.Name]; !used {
-			message := fmt.Sprintf("resource '%s' is not used", resource.Name)
-			errorMessages = append(errorMessages, message)
+			warnings = append(warnings, atc.ConfigWarning{
+				Type:    "resources",
+				Message: "resource '" + resource.Name + "' is not used in pipeline",
+			})
 		}
 	}
 
-	return errorMessages
+	return warnings
 }
 
 func usedResources(c atc.Config) map[string]bool {

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -167,8 +167,9 @@ var _ = Describe("ValidateConfig", func() {
 			})
 
 			It("returns a warning", func() {
-				Expect(warnings).To(HaveLen(1))
+				Expect(warnings).To(HaveLen(2))
 				Expect(warnings[0].Message).To(ContainSubstring("'_some-resource' is not a valid identifier"))
+				Expect(warnings[1].Message).To(ContainSubstring("resource '_some-resource' is not used"))
 			})
 		})
 
@@ -583,7 +584,7 @@ var _ = Describe("ValidateConfig", func() {
 						Type: "some-type",
 					},
 					{
-						Name: "get-alias",
+						Name: "unused-get-alias",
 						Type: "some-type",
 					},
 					{
@@ -595,7 +596,7 @@ var _ = Describe("ValidateConfig", func() {
 						Type: "some-type",
 					},
 					{
-						Name: "put-alias",
+						Name: "unused-put-alias",
 						Type: "some-type",
 					},
 					{
@@ -791,11 +792,11 @@ var _ = Describe("ValidateConfig", func() {
 		})
 
 		Context("when a resource is not used in any jobs", func() {
-			It("returns an error", func() {
-				Expect(errorMessages).To(HaveLen(1))
-				Expect(errorMessages[0]).To(ContainSubstring("resource 'unused-resource' is not used"))
-				Expect(errorMessages[0]).To(ContainSubstring("resource 'get-alias' is not used"))
-				Expect(errorMessages[0]).To(ContainSubstring("resource 'put-alias' is not used"))
+			It("returns a separate warning for every unused resource", func() {
+				Expect(warnings).To(HaveLen(3))
+				Expect(warnings[0].Message).To(ContainSubstring("resource 'unused-resource' is not used"))
+				Expect(warnings[1].Message).To(ContainSubstring("resource 'unused-get-alias' is not used"))
+				Expect(warnings[2].Message).To(ContainSubstring("resource 'unused-put-alias' is not used"))
 			})
 		})
 	})

--- a/fly/integration/fixtures/testConfigResourceWarning.yml
+++ b/fly/integration/fixtures/testConfigResourceWarning.yml
@@ -1,0 +1,14 @@
+groups: []
+resources:
+- name: some-resource
+  type: some-type
+  source:
+    source-config: some-value
+- name: unused-resource
+  type: unused-type
+  source:
+    source-config: unused-value
+jobs:
+- name: job
+  plan:
+  - get: some-resource

--- a/fly/integration/validate_pipeline_test.go
+++ b/fly/integration/validate_pipeline_test.go
@@ -74,8 +74,8 @@ var _ = Describe("Fly CLI", func() {
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(sess.Err).Should(gbytes.Say("WARNING:"))
-			Eventually(sess.Err).Should(gbytes.Say("  - invalid resources:"))
+			Eventually(sess.Err).Should(gbytes.Say("DEPRECATION WARNING:"))
+			Eventually(sess.Err).Should(gbytes.Say("  - invalid jobs:"))
 
 			<-sess.Exited
 			Expect(sess.ExitCode()).To(Equal(1))
@@ -101,6 +101,25 @@ var _ = Describe("Fly CLI", func() {
 			Expect(sess.ExitCode()).To(Equal(1))
 
 			Expect(sess.Err).To(gbytes.Say("configuration invalid"))
+		})
+
+		It("returns valid on validation with warning", func() {
+			flyCmd := exec.Command(
+				flyPath,
+				"validate-pipeline",
+				"-c", "fixtures/testConfigResourceWarning.yml",
+			)
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess.Err).Should(gbytes.Say("DEPRECATION WARNING:"))
+			Eventually(sess.Err).Should(gbytes.Say("  - resource "))
+
+			<-sess.Exited
+			Expect(sess.ExitCode()).To(Equal(0))
+
+			Eventually(sess).Should(gbytes.Say("looks good"))
 		})
 
 		It("returns valid on a pipeline that contains var_sources", func() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

resubmitting of #5060
closes #4177

The `validateResourcesUnused` function is now called within `validateResources` instead of `validateResourceTypes` as it was in #5060. This placement is more convenient since it is related to `resources`.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Implement support for unused resources
* [x] Update tests


<!--
## Notes to reviewer
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Allow configuring pipelines even when they contain unused resources.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
