### PR TITLE
Adding the db connection parameter to dev docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       POSTGRES_PASSWORD: dev
       POSTGRES_HOST_AUTH_METHOD: ${AUTH_METHOD:-trust}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U dev"]
+      test: ["CMD-SHELL", "pg_isready -U dev -d concourse"]
       interval: 3s
       timeout: 3s
       retries: 5

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: dev
       POSTGRES_PASSWORD: dev
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U dev"]
+      test: ["CMD-SHELL", "pg_isready -U dev -d concourse"]
       interval: 3s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Changes proposed by this PR

Fixes newly introduced health check, as by default pg, uses the username as db_name we are seeing health check failueres as seen bellow:
```
db-1      | 2025-05-08 11:32:58.515 UTC [58] FATAL:  database "dev" does not exist
```
![Screenshot 2025-05-08 at 14 33 26](https://github.com/user-attachments/assets/d5806e27-7584-4b79-b036-96947350d2e8)