### PR TITLE
fly: harmonize strictness for set and validate

### DIFF
--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -47,7 +47,7 @@ func (atcConfig ATCConfig) ApplyConfigInteraction() bool {
 }
 
 func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTemplateWithParams) error {
-	evaluatedTemplate, err := yamlTemplateWithParams.Evaluate(false)
+	evaluatedTemplate, err := yamlTemplateWithParams.Evaluate(true)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 	}
 
 	var newConfig atc.Config
-	err = yaml.Unmarshal([]byte(evaluatedTemplate), &newConfig)
+	err = yaml.Unmarshal(evaluatedTemplate, &newConfig)
 	if err != nil {
 		return err
 	}

--- a/fly/commands/internal/templatehelpers/yaml_template.go
+++ b/fly/commands/internal/templatehelpers/yaml_template.go
@@ -45,7 +45,6 @@ func (yamlTemplate YamlTemplateWithParams) Evaluate(strict bool) ([]byte, error)
 		// (else a template string may cause an error when a struct is expected)
 		// If we don't check Strict now, then the subsequent steps will mask any
 		// duplicate key errors.
-		// We should consider being strict throughout the entire stack by default.
 		err = yaml.UnmarshalStrict(config, make(map[string]any))
 		if err != nil {
 			return nil, fmt.Errorf("error parsing yaml before applying templates: %s", err.Error())

--- a/fly/commands/internal/templatehelpers/yaml_template_test.go
+++ b/fly/commands/internal/templatehelpers/yaml_template_test.go
@@ -74,5 +74,21 @@ var _ = Describe("YAML Template With Params", func() {
     nested: ((param3))
 `))
 		})
+
+		When("strict", func() {
+			It("errors on duplicates", func() {
+				writeErr := os.WriteFile(
+					filepath.Join(tmpdir, "duplicate.yml"),
+					[]byte(`{ dupe: overriden, dupe: overriding }`),
+					0644,
+				)
+				Expect(writeErr).NotTo(HaveOccurred())
+				duplicateYaml := templatehelpers.NewYamlTemplateWithParams(atc.PathFlag(filepath.Join(tmpdir, "duplicate.yml")), nil, nil, nil, nil)
+				_, evalErr := duplicateYaml.Evaluate(true)
+				Expect(evalErr).To(HaveOccurred())
+				Expect(evalErr.Error()).To(HavePrefix("error parsing yaml"))
+			})
+		})
+
 	})
 })

--- a/fly/commands/internal/validatepipelinehelpers/validate.go
+++ b/fly/commands/internal/validatepipelinehelpers/validate.go
@@ -14,22 +14,20 @@ import (
 )
 
 func Validate(yamlTemplate templatehelpers.YamlTemplateWithParams, strict bool, output bool, enableAcrossStep bool) error {
-	evaluatedTemplate, err := yamlTemplate.Evaluate(strict)
+	evaluatedTemplate, err := yamlTemplate.Evaluate(true)
 	if err != nil {
 		return err
 	}
 
 	var unmarshalledTemplate atc.Config
 	if strict {
-		// UnmarshalStrict will pick up fields in structs that have the wrong names, as well as any duplicate keys in maps
-		// we should consider always using this everywhere in a later release...
-		if err := yaml.UnmarshalStrict([]byte(evaluatedTemplate), &unmarshalledTemplate); err != nil {
-			return err
-		}
+		// additionally catches unknown keys
+		err = yaml.UnmarshalStrict(evaluatedTemplate, &unmarshalledTemplate)
 	} else {
-		if err := yaml.Unmarshal([]byte(evaluatedTemplate), &unmarshalledTemplate); err != nil {
-			return err
-		}
+		err = yaml.Unmarshal(evaluatedTemplate, &unmarshalledTemplate)
+	}
+	if err != nil {
+		return err
 	}
 
 	if enableAcrossStep {

--- a/fly/integration/fixtures/testConfigDuplicate.yml
+++ b/fly/integration/fixtures/testConfigDuplicate.yml
@@ -1,0 +1,15 @@
+groups: []
+resources:
+- name: shadowed-resource
+  type: some-type
+  source:
+    source-config: some-value
+resources:
+- name: some-resource
+  type: some-type
+  source:
+    source-config: some-value
+jobs:
+- name: job
+  plan:
+  - get: some-resource

--- a/fly/integration/fixtures/testConfigUnknownKeys.yml
+++ b/fly/integration/fixtures/testConfigUnknownKeys.yml
@@ -1,0 +1,11 @@
+user_key: useful for yaml anchors
+groups: []
+resources:
+- name: some-resource
+  type: some-type
+  source:
+    source-config: some-value
+jobs:
+- name: job
+  plan:
+  - get: some-resource


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #9026

Duplicate keys are never allowed.
Unknown keys are allowed, except for strict validation. These are generally useful for setting yaml anchors.

`execute` remains the same.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] ensure strict templating rejects duplicates
* [x] change `set` and `validate` flow to template strictly
* [x] add integration tests

## Notes to reviewer

I did some small cleanups, let me know if that's not according to style.
Also, I was tempted to make use of `When("strict)` to group tests, but I chose to blend in instead. I can do it if that's preferable though.

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Normal `validate` and `set-pipeline` now behave the same way: allow unknown keys, but reject duplicate ones. `validate --strict` still rejects unknown keys.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
