### PR TITLE
fix k8s-topgun prometheus integration tests

### DIFF
--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Prometheus integration", func() {
 		helmDeploy(prometheusReleaseName,
 			namespace,
 			path.Join(Environment.HelmChartsDir, "stable/prometheus"),
-			"--set=nodeExporter.enabled=false",
+			"--set=prometheus-node-exporter.enabled=false",
 			"--set=kubeStateMetrics.enabled=false",
 			"--set=pushgateway.enabled=false",
 			"--set=alertmanager.enabled=false",

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -32,8 +32,8 @@ var _ = Describe("Prometheus integration", func() {
 			namespace,
 			path.Join(Environment.HelmChartsDir, "stable/prometheus"),
 			"--set=prometheus-node-exporter.enabled=false",
-			"--set=kubeStateMetrics.enabled=false",
-			"--set=pushgateway.enabled=false",
+			"--set=kube-state-metrics.enabled=false",
+			"--set=prometheus-pushgateway.enabled=false",
 			"--set=alertmanager.enabled=false",
 			"--set=server.persistentVolume.enabled=false")
 


### PR DESCRIPTION
The prometheus chart changed `nodeExporter` to `prometheus-node-exporter`.

EDIT: Found a few more too to fix. Source: https://github.com/prometheus-community/helm-charts/blob/bbae3ecb238b94f17eec0d3be8b07c1147b121d0/charts/prometheus/values.yaml