### PR TITLE
Restrict algorithms for host key exchange

### DIFF
--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"sync"
@@ -281,7 +280,7 @@ func (cmd *TSACommand) configureSSHServer(sessionAuthTeam *sessionTeam, authoriz
 
 	signerWithAlgorithms, err := ssh.NewSignerWithAlgorithms(signer.(ssh.AlgorithmSigner), []string{ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSASHA512})
 	if err != nil {
-		log.Fatal("Failed to create private key with restricted algorithms: ", err)
+		return nil, fmt.Errorf("failed to create private key with restricted algorithms: %s", err)
 	}
 
 	config.AddHostKey(signerWithAlgorithms)

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"sync"
@@ -278,7 +279,12 @@ func (cmd *TSACommand) configureSSHServer(sessionAuthTeam *sessionTeam, authoriz
 		return nil, fmt.Errorf("failed to create signer from host key: %s", err)
 	}
 
-	config.AddHostKey(signer)
+	signerWithAlgorithms, err := ssh.NewSignerWithAlgorithms(signer.(ssh.AlgorithmSigner), []string{ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSASHA512})
+	if err != nil {
+		log.Fatal("Failed to create private key with restricted algorithms: ", err)
+	}
+
+	config.AddHostKey(signerWithAlgorithms)
 
 	return config, nil
 }


### PR DESCRIPTION
Currently, "ssh-rsa" is offered as host key algorithm by TSA for worker registration on port 2222. This seems to be flagged at least by some security scanners as "using deprecated SHA1 cryptographic settings to communicate."

This can be verified with:

nmap -Pn --script ssh2-enum-algos -sV -p 2222 tsa.example.com

And results in:

|   server_host_key_algorithms: (3)
|       rsa-sha2-256
|       rsa-sha2-512
|       ssh-rsa

This can be addressed by specifying the allowed host key algorithms on the server side as outlined here:

https://github.com/golang/go/issues/52132

## Changes proposed by this PR

closes https://github.com/concourse/concourse/issues/9212
