### PR TITLE
Remove use of deprecated package github.com/pkg/errors

### DIFF
--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -1,17 +1,18 @@
 package vault
 
 import (
-	"code.cloudfoundry.org/lager/v3"
 	"crypto/tls"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/hashicorp/go-rootcerts"
 	"net/http"
 	"os"
 	"path"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"code.cloudfoundry.org/lager/v3"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/hashicorp/go-rootcerts"
 
 	vaultapi "github.com/hashicorp/vault/api"
 )

--- a/atc/db/build_being_watched_marker.go
+++ b/atc/db/build_being_watched_marker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -62,11 +63,8 @@ func (m *beingWatchedBuildEventChannelMap) store(key string, value time.Time) {
 }
 
 func (m *beingWatchedBuildEventChannelMap) clone() map[string]time.Time {
-	c := map[string]time.Time{}
 	m.RLock()
-	for k, v := range m.internal {
-		c[k] = v
-	}
+	c := maps.Clone(m.internal)
 	m.RUnlock()
 	return c
 }

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"code.cloudfoundry.org/lager/v3"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/pkg/errors"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/creds"
@@ -1133,7 +1133,7 @@ func (p *pipeline) Variables(logger lager.Logger, globalSecrets creds.Secrets, v
 		// Interpolate variables in pipeline credential manager's config
 		newConfig, err := creds.NewParams(allVars, atc.Params{"config": cm.Config}).Evaluate()
 		if err != nil {
-			return nil, errors.Wrapf(err, "evaluate var_source '%s' error", cm.Name)
+			return nil, fmt.Errorf("evaluate var_source '%s' error: %w", cm.Name, err)
 		}
 
 		config, ok := newConfig["config"].(map[string]any)
@@ -1142,7 +1142,7 @@ func (p *pipeline) Variables(logger lager.Logger, globalSecrets creds.Secrets, v
 		}
 		secrets, err := varSourcePool.FindOrCreate(logger, config, factory)
 		if err != nil {
-			return nil, errors.Wrapf(err, "create var_source '%s' error", cm.Name)
+			return nil, fmt.Errorf("create var_source '%s' error: %w", cm.Name, err)
 		}
 		namedVarsMap[cm.Name] = creds.NewVariables(secrets, p.TeamName(), p.Name(), true)
 	}

--- a/atc/engine/build_step_delegate.go
+++ b/atc/engine/build_step_delegate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 	"time"
 
@@ -57,9 +58,7 @@ func (delegate *buildStepDelegate) StartSpan(
 	extraAttrs tracing.Attrs,
 ) (context.Context, trace.Span) {
 	attrs := delegate.build.TracingAttrs()
-	for k, v := range extraAttrs {
-		attrs[k] = v
-	}
+	maps.Copy(attrs, extraAttrs)
 
 	return tracing.StartSpan(ctx, component, attrs)
 }

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -275,8 +276,7 @@ func (s setPipelineSource) FetchPipelineConfig() (atc.Config, error) {
 		}
 
 		sv := vars.StaticVariables{}
-		err = yaml.Unmarshal(bytes, &sv)
-		if err != nil {
+		if err = yaml.Unmarshal(bytes, &sv); err != nil {
 			return atc.Config{}, err
 		}
 
@@ -284,11 +284,7 @@ func (s setPipelineSource) FetchPipelineConfig() (atc.Config, error) {
 	}
 
 	if len(s.step.plan.InstanceVars) > 0 {
-		iv := vars.StaticVariables{}
-		for k, v := range s.step.plan.InstanceVars {
-			iv[k] = v
-		}
-		staticVars = append(staticVars, iv)
+		staticVars = append(staticVars, vars.StaticVariables(maps.Clone(s.step.plan.InstanceVars)))
 	}
 
 	if len(staticVars) > 0 {
@@ -299,8 +295,7 @@ func (s setPipelineSource) FetchPipelineConfig() (atc.Config, error) {
 	}
 
 	atcConfig := atc.Config{}
-	err = atc.UnmarshalConfig(config, &atcConfig)
-	if err != nil {
+	if err := atc.UnmarshalConfig(config, &atcConfig); err != nil {
 		return atc.Config{}, err
 	}
 

--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -2,6 +2,7 @@ package metric
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -170,15 +171,10 @@ func (m *Monitor) emit(logger lager.Logger, event Event) {
 	event.Host = m.eventHost
 	event.Time = time.Now()
 
-	mergedAttributes := map[string]string{}
-	for k, v := range m.eventAttributes {
-		mergedAttributes[k] = v
-	}
+	mergedAttributes := maps.Clone(m.eventAttributes)
 
 	if event.Attributes != nil {
-		for k, v := range event.Attributes {
-			mergedAttributes[k] = v
-		}
+		maps.Copy(mergedAttributes, event.Attributes)
 	}
 
 	event.Attributes = mergedAttributes

--- a/atc/metric/emitter/dogstatsd.go
+++ b/atc/metric/emitter/dogstatsd.go
@@ -9,7 +9,6 @@ import (
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/concourse/concourse/atc/metric"
-	"github.com/pkg/errors"
 )
 
 type DogstatsdEmitter struct {
@@ -76,7 +75,7 @@ func (emitter *DogstatsdEmitter) Emit(logger lager.Logger, event metric.Event) {
 	err := emitter.client.Gauge(name, event.Value, tags, 1)
 	if err != nil {
 		logger.Error("failed-to-send-metric",
-			errors.Wrap(metric.ErrFailedToEmit, err.Error()))
+			fmt.Errorf("%w, %v", metric.ErrFailedToEmit, err))
 		return
 	}
 }

--- a/atc/metric/emitter/influxdb.go
+++ b/atc/metric/emitter/influxdb.go
@@ -1,11 +1,11 @@
 package emitter
 
 import (
+	"fmt"
 	"time"
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/concourse/concourse/atc/metric"
-	"github.com/pkg/errors"
 
 	influxclient "github.com/influxdata/influxdb1-client/v2"
 )
@@ -106,7 +106,7 @@ func emitBatch(emitter *InfluxDBEmitter, logger lager.Logger, events []metric.Ev
 	err = emitter.Client.Write(bp)
 	if err != nil {
 		logger.Error("failed-to-send-points",
-			errors.Wrap(metric.ErrFailedToEmit, err.Error()))
+			fmt.Errorf("%w, %v", metric.ErrFailedToEmit, err))
 		return
 	}
 }

--- a/atc/metric/emitter/influxdb.go
+++ b/atc/metric/emitter/influxdb.go
@@ -2,6 +2,7 @@ package emitter
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -83,9 +84,7 @@ func emitBatch(emitter *InfluxDBEmitter, logger lager.Logger, events []metric.Ev
 			"host": event.Host,
 		}
 
-		for k, v := range event.Attributes {
-			tags[k] = v
-		}
+		maps.Copy(tags, event.Attributes)
 
 		point, err := influxclient.NewPoint(
 			event.Name,

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -13,7 +13,6 @@ import (
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/concourse/concourse/atc/metric"
 	"github.com/klauspost/compress/gzip"
-	"github.com/pkg/errors"
 )
 
 type (
@@ -227,7 +226,7 @@ func (emitter *NewRelicEmitter) emitBatch(logger lager.Logger, payload []NewReli
 	resp, err := emitter.Client.Do(req)
 	if err != nil {
 		logger.Error("failed-to-send-request",
-			errors.Wrap(metric.ErrFailedToEmit, err.Error()))
+			fmt.Errorf("%w, %v", metric.ErrFailedToEmit, err))
 		return
 	}
 	defer resp.Body.Close()

--- a/atc/metric/emitter/prometheus_test.go
+++ b/atc/metric/emitter/prometheus_test.go
@@ -3,6 +3,7 @@ package emitter_test
 import (
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -100,10 +101,7 @@ var _ = Describe("PrometheusEmitter garbage collector", func() {
 		}
 
 		// Deep copy the labels so we can use them to verify the test results later
-		labels := make(prometheus.Labels)
-		for k, v := range labelsLong {
-			labels[k] = v
-		}
+		labels := maps.Clone(labelsLong)
 		fake.WorkerContainers().With(labels).Set(42.0)
 		fake.WorkerContainersLabels()["foo"] = make(map[string]prometheus.Labels)
 		fake.WorkerContainersLabels()["foo"]["foo_linux_main__"] = labels
@@ -112,10 +110,7 @@ var _ = Describe("PrometheusEmitter garbage collector", func() {
 		fake.WorkerVolumesLabels()["foo"] = make(map[string]prometheus.Labels)
 		fake.WorkerVolumesLabels()["foo"]["foo_linux_main__"] = labels
 
-		labels = make(prometheus.Labels)
-		for k, v := range labelsShort {
-			labels[k] = v
-		}
+		labels = maps.Clone(labelsShort)
 		fake.WorkerTasks().With(labels).Set(42.0)
 		fake.WorkerTasksLabels()["foo"] = make(map[string]prometheus.Labels)
 		fake.WorkerTasksLabels()["foo"]["foo_linux"] = labels

--- a/atc/metric/error_sink_collector.go
+++ b/atc/metric/error_sink_collector.go
@@ -1,8 +1,9 @@
 package metric
 
 import (
+	"errors"
+	
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/pkg/errors"
 )
 
 type ErrorSinkCollector struct {
@@ -22,7 +23,7 @@ func (c *ErrorSinkCollector) Log(f lager.LogFormat) {
 		return
 	}
 
-	if errors.Cause(f.Error) == ErrFailedToEmit {
+	if errors.Is(f.Error, ErrFailedToEmit) {
 		return
 	}
 

--- a/atc/resource_types.go
+++ b/atc/resource_types.go
@@ -3,6 +3,7 @@ package atc
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 )
 
@@ -33,16 +34,12 @@ func (src Source) Merge(other Source) Source {
 		return nil
 	}
 
-	newSource := Source{}
-	// if src is nil or empty, range will not loop
-	for k, v := range src {
-		newSource[k] = v
+	if src == nil {
+		return maps.Clone(other)
 	}
 
-	// if other is nil or empty, range will not loop
-	for k, v := range other {
-		newSource[k] = v
-	}
+	newSource := maps.Clone(src)
+	maps.Copy(newSource, other)
 
 	return newSource
 }

--- a/atc/runtime/runtimetest/container.go
+++ b/atc/runtime/runtimetest/container.go
@@ -3,6 +3,7 @@ package runtimetest
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"sync"
 
@@ -96,19 +97,11 @@ func (c *Container) Properties() (map[string]string, error) {
 }
 
 func (c *Container) SetProperty(name string, value string) error {
-	c.Props = cloneProps(c.Props)
+	c.Props = maps.Clone(c.Props)
 	c.Props[name] = value
 	return nil
 }
 
 func (c *Container) DBContainer() db.CreatedContainer {
 	return c.DBContainer_
-}
-
-func cloneProps(m map[string]string) map[string]string {
-	m2 := make(map[string]string, len(m))
-	for k, v := range m {
-		m2[k] = v
-	}
-	return m2
 }

--- a/atc/step_recursor.go
+++ b/atc/step_recursor.go
@@ -89,8 +89,7 @@ func (recursor StepRecursor) VisitTry(step *TryStep) error {
 // VisitDo recurses through to the wrapped steps.
 func (recursor StepRecursor) VisitDo(step *DoStep) error {
 	for _, sub := range step.Steps {
-		err := sub.Config.Visit(recursor)
-		if err != nil {
+		if err := sub.Config.Visit(recursor); err != nil {
 			return err
 		}
 	}
@@ -101,8 +100,7 @@ func (recursor StepRecursor) VisitDo(step *DoStep) error {
 // VisitInParallel recurses through to the wrapped steps.
 func (recursor StepRecursor) VisitInParallel(step *InParallelStep) error {
 	for _, sub := range step.Config.Steps {
-		err := sub.Config.Visit(recursor)
-		if err != nil {
+		if err := sub.Config.Visit(recursor); err != nil {
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/peterhellberg/link v1.2.0
-	github.com/pkg/errors v0.9.1
 	github.com/pkg/term v1.2.0-beta.2.0.20211217091447-1a4a3b719465
 	github.com/prometheus/client_golang v1.21.1
 	github.com/racksec/srslog v0.0.0-20180709174129-a4725f04ec91
@@ -251,6 +250,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
 	github.com/petermattis/goid v0.0.0-20250319124200-ccd6737f222a // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/worker/baggageclaim/volume/properties.go
+++ b/worker/baggageclaim/volume/properties.go
@@ -1,5 +1,7 @@
 package volume
 
+import "maps"
+
 type Properties map[string]string
 
 func (p Properties) HasProperties(other Properties) bool {
@@ -18,11 +20,7 @@ func (p Properties) HasProperties(other Properties) bool {
 }
 
 func (p Properties) UpdateProperty(name string, value string) Properties {
-	updatedProperties := Properties{}
-
-	for k, v := range p {
-		updatedProperties[k] = v
-	}
+	updatedProperties := maps.Clone(p)
 
 	updatedProperties[name] = value
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

No functional change. This simply removes the `github.com/pkg/errors` package in favour of `errors`. The former has been deprecated for a while.

There's a small bonus change - a demonstration of using the new `maps` package to to simplify some code. There are probably other places in the code base where use of `maps` or `slices` would simplify things.

## Notes to reviewer

N/A
