### PR TITLE
Invalidate access token on Logout

### DIFF
--- a/atc/api/accessor/accessorfakes/fake_access_token_fetcher.go
+++ b/atc/api/accessor/accessorfakes/fake_access_token_fetcher.go
@@ -9,6 +9,17 @@ import (
 )
 
 type FakeAccessTokenFetcher struct {
+	DeleteAccessTokenStub        func(string) error
+	deleteAccessTokenMutex       sync.RWMutex
+	deleteAccessTokenArgsForCall []struct {
+		arg1 string
+	}
+	deleteAccessTokenReturns struct {
+		result1 error
+	}
+	deleteAccessTokenReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetAccessTokenStub        func(string) (db.AccessToken, bool, error)
 	getAccessTokenMutex       sync.RWMutex
 	getAccessTokenArgsForCall []struct {
@@ -26,6 +37,67 @@ type FakeAccessTokenFetcher struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeAccessTokenFetcher) DeleteAccessToken(arg1 string) error {
+	fake.deleteAccessTokenMutex.Lock()
+	ret, specificReturn := fake.deleteAccessTokenReturnsOnCall[len(fake.deleteAccessTokenArgsForCall)]
+	fake.deleteAccessTokenArgsForCall = append(fake.deleteAccessTokenArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.DeleteAccessTokenStub
+	fakeReturns := fake.deleteAccessTokenReturns
+	fake.recordInvocation("DeleteAccessToken", []interface{}{arg1})
+	fake.deleteAccessTokenMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeAccessTokenFetcher) DeleteAccessTokenCallCount() int {
+	fake.deleteAccessTokenMutex.RLock()
+	defer fake.deleteAccessTokenMutex.RUnlock()
+	return len(fake.deleteAccessTokenArgsForCall)
+}
+
+func (fake *FakeAccessTokenFetcher) DeleteAccessTokenCalls(stub func(string) error) {
+	fake.deleteAccessTokenMutex.Lock()
+	defer fake.deleteAccessTokenMutex.Unlock()
+	fake.DeleteAccessTokenStub = stub
+}
+
+func (fake *FakeAccessTokenFetcher) DeleteAccessTokenArgsForCall(i int) string {
+	fake.deleteAccessTokenMutex.RLock()
+	defer fake.deleteAccessTokenMutex.RUnlock()
+	argsForCall := fake.deleteAccessTokenArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeAccessTokenFetcher) DeleteAccessTokenReturns(result1 error) {
+	fake.deleteAccessTokenMutex.Lock()
+	defer fake.deleteAccessTokenMutex.Unlock()
+	fake.DeleteAccessTokenStub = nil
+	fake.deleteAccessTokenReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeAccessTokenFetcher) DeleteAccessTokenReturnsOnCall(i int, result1 error) {
+	fake.deleteAccessTokenMutex.Lock()
+	defer fake.deleteAccessTokenMutex.Unlock()
+	fake.DeleteAccessTokenStub = nil
+	if fake.deleteAccessTokenReturnsOnCall == nil {
+		fake.deleteAccessTokenReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteAccessTokenReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeAccessTokenFetcher) GetAccessToken(arg1 string) (db.AccessToken, bool, error) {
@@ -98,6 +170,8 @@ func (fake *FakeAccessTokenFetcher) GetAccessTokenReturnsOnCall(i int, result1 d
 func (fake *FakeAccessTokenFetcher) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.deleteAccessTokenMutex.RLock()
+	defer fake.deleteAccessTokenMutex.RUnlock()
 	fake.getAccessTokenMutex.RLock()
 	defer fake.getAccessTokenMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/api/accessor/claims_cacher.go
+++ b/atc/api/accessor/claims_cacher.go
@@ -70,3 +70,12 @@ func (c *claimsCacher) GetAccessToken(rawToken string) (db.AccessToken, bool, er
 
 	return token, true, nil
 }
+
+func (c *claimsCacher) DeleteAccessToken(rawToken string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache.Remove(rawToken)
+
+	return nil
+}

--- a/atc/api/accessor/claims_cacher_test.go
+++ b/atc/api/accessor/claims_cacher_test.go
@@ -112,7 +112,7 @@ var _ = Describe("ClaimsCacher", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("fetching the token again, should refetch from DB due to deletion")
-		_, _, err = claimsCacher.GetAccessToken("token1")
+		claimsCacher.GetAccessToken("token1")
 		Expect(fakeAccessTokenFetcher.GetAccessTokenCallCount()).To(Equal(2), "expected to refetch after delete")
 	})
 })

--- a/atc/api/accessor/claims_cacher_test.go
+++ b/atc/api/accessor/claims_cacher_test.go
@@ -99,6 +99,22 @@ var _ = Describe("ClaimsCacher", func() {
 		go claimsCacher.GetAccessToken("token3")
 		Eventually(fakeAccessTokenFetcher.GetAccessTokenCallCount).Should(Equal(3))
 	})
+
+	It("deletes token from cache", func() {
+		fakeAccessTokenFetcher.GetAccessTokenReturns(db.AccessToken{}, true, nil)
+
+		By("fetching the token for the first time (populates cache)")
+		_, _, err := claimsCacher.GetAccessToken("token1")
+		Expect(fakeAccessTokenFetcher.GetAccessTokenCallCount()).To(Equal(1))
+
+		By("deleting the token from the cache")
+		err = claimsCacher.DeleteAccessToken("token1")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("fetching the token again, should refetch from DB due to deletion")
+		_, _, err = claimsCacher.GetAccessToken("token1")
+		Expect(fakeAccessTokenFetcher.GetAccessTokenCallCount()).To(Equal(2), "expected to refetch after delete")
+	})
 })
 
 func stringWithLen(l int) string {

--- a/atc/api/accessor/verifier.go
+++ b/atc/api/accessor/verifier.go
@@ -21,6 +21,7 @@ var (
 //counterfeiter:generate . AccessTokenFetcher
 type AccessTokenFetcher interface {
 	GetAccessToken(rawToken string) (db.AccessToken, bool, error)
+	DeleteAccessToken(rawToken string) error
 }
 
 func NewVerifier(accessTokenFetcher AccessTokenFetcher, audience []string) *verifier {

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -851,7 +851,8 @@ func (cmd *RunCommand) constructAPIMembers(
 	dbClock := db.NewClock()
 	dbWall := db.NewWall(dbConn, &dbClock)
 
-	claimsCacher := accessor.NewClaimsCacher(dbAccessTokenFactory, 1*1024*1024)
+	MiB := 1024 * 1024
+	claimsCacher := accessor.NewClaimsCacher(dbAccessTokenFactory, 1*MiB)
 	tokenVerifier := cmd.constructTokenVerifier(claimsCacher)
 
 	teamsCacher := accessor.NewTeamsCacher(

--- a/atc/db/access_token_factory_test.go
+++ b/atc/db/access_token_factory_test.go
@@ -76,4 +76,22 @@ var _ = Describe("Access Token Factory", func() {
 			},
 		}))
 	})
+	It("can delete access tokens", func() {
+		err := factory.CreateAccessToken("my-delete-token", db.Claims{
+			RawClaims: map[string]any{"sub": "subject"},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		token, ok, err := factory.GetAccessToken("my-delete-token")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+		Expect(token.Token).To(Equal("my-delete-token"))
+
+		err = factory.DeleteAccessToken("my-delete-token")
+		Expect(err).ToNot(HaveOccurred())
+
+		_, ok, err = factory.GetAccessToken("my-delete-token")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeFalse())
+	})
 })

--- a/atc/db/dbfakes/fake_access_token_factory.go
+++ b/atc/db/dbfakes/fake_access_token_factory.go
@@ -20,6 +20,17 @@ type FakeAccessTokenFactory struct {
 	createAccessTokenReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteAccessTokenStub        func(string) error
+	deleteAccessTokenMutex       sync.RWMutex
+	deleteAccessTokenArgsForCall []struct {
+		arg1 string
+	}
+	deleteAccessTokenReturns struct {
+		result1 error
+	}
+	deleteAccessTokenReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetAccessTokenStub        func(string) (db.AccessToken, bool, error)
 	getAccessTokenMutex       sync.RWMutex
 	getAccessTokenArgsForCall []struct {
@@ -101,6 +112,67 @@ func (fake *FakeAccessTokenFactory) CreateAccessTokenReturnsOnCall(i int, result
 	}{result1}
 }
 
+func (fake *FakeAccessTokenFactory) DeleteAccessToken(arg1 string) error {
+	fake.deleteAccessTokenMutex.Lock()
+	ret, specificReturn := fake.deleteAccessTokenReturnsOnCall[len(fake.deleteAccessTokenArgsForCall)]
+	fake.deleteAccessTokenArgsForCall = append(fake.deleteAccessTokenArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.DeleteAccessTokenStub
+	fakeReturns := fake.deleteAccessTokenReturns
+	fake.recordInvocation("DeleteAccessToken", []interface{}{arg1})
+	fake.deleteAccessTokenMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeAccessTokenFactory) DeleteAccessTokenCallCount() int {
+	fake.deleteAccessTokenMutex.RLock()
+	defer fake.deleteAccessTokenMutex.RUnlock()
+	return len(fake.deleteAccessTokenArgsForCall)
+}
+
+func (fake *FakeAccessTokenFactory) DeleteAccessTokenCalls(stub func(string) error) {
+	fake.deleteAccessTokenMutex.Lock()
+	defer fake.deleteAccessTokenMutex.Unlock()
+	fake.DeleteAccessTokenStub = stub
+}
+
+func (fake *FakeAccessTokenFactory) DeleteAccessTokenArgsForCall(i int) string {
+	fake.deleteAccessTokenMutex.RLock()
+	defer fake.deleteAccessTokenMutex.RUnlock()
+	argsForCall := fake.deleteAccessTokenArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeAccessTokenFactory) DeleteAccessTokenReturns(result1 error) {
+	fake.deleteAccessTokenMutex.Lock()
+	defer fake.deleteAccessTokenMutex.Unlock()
+	fake.DeleteAccessTokenStub = nil
+	fake.deleteAccessTokenReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeAccessTokenFactory) DeleteAccessTokenReturnsOnCall(i int, result1 error) {
+	fake.deleteAccessTokenMutex.Lock()
+	defer fake.deleteAccessTokenMutex.Unlock()
+	fake.DeleteAccessTokenStub = nil
+	if fake.deleteAccessTokenReturnsOnCall == nil {
+		fake.deleteAccessTokenReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteAccessTokenReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeAccessTokenFactory) GetAccessToken(arg1 string) (db.AccessToken, bool, error) {
 	fake.getAccessTokenMutex.Lock()
 	ret, specificReturn := fake.getAccessTokenReturnsOnCall[len(fake.getAccessTokenArgsForCall)]
@@ -173,6 +245,8 @@ func (fake *FakeAccessTokenFactory) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.createAccessTokenMutex.RLock()
 	defer fake.createAccessTokenMutex.RUnlock()
+	fake.deleteAccessTokenMutex.RLock()
+	defer fake.deleteAccessTokenMutex.RUnlock()
 	fake.getAccessTokenMutex.RLock()
 	defer fake.getAccessTokenMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/fly/commands/logout.go
+++ b/fly/commands/logout.go
@@ -23,7 +23,9 @@ func (command *LogoutCommand) Execute(args []string) error {
 		}
 
 		for targetName := range targets {
-			return command.logoutSingleTarget(targetName)
+			if err := command.logoutSingleTarget(targetName); err != nil {
+				return err
+			}
 		}
 
 		fmt.Println("logged out of all targets")
@@ -41,12 +43,10 @@ func (cmd *LogoutCommand) logoutSingleTarget(targetName rc.TargetName) error {
 	}
 
 	targetToken := target.Token()
-	if targetToken == nil || targetToken.Type == "" || targetToken.Value == "" {
-		return errors.New("no valid token found for target `" + string(targetName) + "`, cannot logout")
-	}
-
-	if err := cmd.logoutAPI(target.URL(), targetToken); err != nil {
-		return fmt.Errorf("failed to logout from API: %w", err)
+	if targetToken != nil && targetToken.Type != "" && targetToken.Value != "" {
+		if err := cmd.logoutAPI(target.URL(), targetToken); err != nil {
+			return fmt.Errorf("failed to logout from API: %w", err)
+		}
 	}
 
 	if err := rc.LogoutTarget(targetName); err != nil {

--- a/skymarshal/skyserver/skyserver.go
+++ b/skymarshal/skyserver/skyserver.go
@@ -211,21 +211,21 @@ func (s *SkyServer) Logout(w http.ResponseWriter, r *http.Request) {
 	parts := strings.Split(tokenString, " ")
 
 	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
-		logger.Info("failed-to-parse-cookie")
+		logger.Info("failed-to-parse-auth-token")
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
 
 	err := s.config.ClaimsCacher.DeleteAccessToken(parts[1])
 	if err != nil {
-		logger.Error("delete-access-token-from-cache", err)
+		logger.Error("delete-auth-token-from-cache", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	err = s.config.AccessTokenFactory.DeleteAccessToken(parts[1])
 	if err != nil {
-		logger.Error("delete-access-token-from-db", err)
+		logger.Error("delete-auth-token-from-db", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

Previously, the logout endpoint of the Concourse API only removed the `skymarshal_auth` and `skymarshal_csrf` cookies from the browser, without invalidating the access tokens issued to the user. As a result, users could still use their tokens to interact with the Concourse API even after logging out.

With this implementation, tokens are now explicitly removed from both the local cache and the database. This ensures that after logging out, users can no longer use their tokens to authenticate API requests.

I am opening the PR as a draft since I want to confirm this changes in SkyServer and I need to add tests cases as well.

closes #9215

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Implement cleaning of tokens from Database 
* [x] Implement cleaning of tokens from cache
* [x] Call Logout Endpoint on fly logout
* [x] Test Logout API
* [x] Test FLY logout

## Notes to reviewer

I’ve renamed loginHandler to skyHandler to better reflect its broader responsibility, as it handles more than just login logic.
Details on how to reproduce the issue can be found in the linked issue.

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Ensures tokens are removed from local cache and database, preventing post-logout API access.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
