### PR TITLE
Improve idtoken credential provider compatibility (with AWS and Azure)

### DIFF
--- a/atc/api/idtokenserver/openid_discovery.go
+++ b/atc/api/idtokenserver/openid_discovery.go
@@ -3,18 +3,28 @@ package idtokenserver
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/go-jose/go-jose/v3"
 )
 
 func (s *Server) OpenIDConfiguration(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Session("openid_configuration")
 
 	resp := struct {
-		Issuer  string `json:"issuer"`
-		JWKSUri string `json:"jwks_uri"`
+		Issuer                           string   `json:"issuer"`
+		JWKSUri                          string   `json:"jwks_uri"`
+		ClaimsSupported                  []string `json:"claims_supported"`
+		ResponseTypesSupported           []string `json:"response_types_supported"`
+		IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+		SubjectTypesSupported            []string `json:"subject_types_supported"`
 	}{
 		// externalURL is used for the iss-claim of idtokens
-		Issuer:  s.externalURL,
-		JWKSUri: s.externalURL + "/.well-known/jwks.json",
+		Issuer:                           s.externalURL,
+		JWKSUri:                          s.externalURL + "/.well-known/jwks.json",
+		ClaimsSupported:                  []string{"aud", "iat", "iss", "sub"},
+		ResponseTypesSupported:           []string{"idtoken"},
+		IDTokenSigningAlgValuesSupported: []string{string(jose.RS256), string(jose.ES256)},
+		SubjectTypesSupported:            []string{"public"},
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/atc/creds/idtoken/lifecycle.go
+++ b/atc/creds/idtoken/lifecycle.go
@@ -124,7 +124,7 @@ func generateNewRSAKey() (*jose.JSONWebKey, error) {
 		KeyID:     generateRandomNumericString(),
 		Algorithm: "RS256",
 		Key:       privateKey,
-		Use:       "sign",
+		Use:       "sig",
 	}, nil
 }
 
@@ -138,7 +138,7 @@ func generateNewECDSAKey() (*jose.JSONWebKey, error) {
 		KeyID:     generateRandomNumericString(),
 		Algorithm: "ES256",
 		Key:       privateKey,
-		Use:       "sign",
+		Use:       "sig",
 	}, nil
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

While working on the documentation for the new idtoken credential provider (and testing the provided examples) I discovered that it has compatibility issues with AWS and Azure.

This PR aims to fix these.

- Azure requires the key-usage of the JWKs to be "sig". Currently it is set to "sign" (which is incorrect according to the [RFC](https://datatracker.ietf.org/doc/html/rfc7517#section-4.2) )

- AWS requires more details in the OIDC-Discovery-Endpoint: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html#manage-oidc-provider-prerequisites

With the changes proposed in this PR, compatibility with AWS and Azure is ensured and the examples provided in the upcoming docs ( https://github.com/concourse/docs/pull/563 ) work flawlessly.

