### PR TITLE
Remove hardcoded AlwaysSample from OpenTelemetry tracing configuration

### DIFF
--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -63,7 +63,6 @@ func (c Config) traceProvider(exporter func() (sdktrace.SpanExporter, []sdktrace
 	}
 
 	options := append([]sdktrace.TracerProviderOption{
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exp),
 		sdktrace.WithResource(c.resource()),
 	}, exporterOptions...)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

This pull request is a follow on the discussion raised here: https://github.com/concourse/concourse/discussions/9227

Concourse currently hardcodes an `AlwaysSample` sampler in the OpenTelemetry SDK setup which generally means that this will always hold true. Any attempts to customise the sample rate via environment variables will not work as [Go treats explicit SDK configuration as having precedent](https://github.com/open-telemetry/opentelemetry-specification/issues/4413#issuecomment-2657925215) over anything else.

This should not change any existing behaviour as the [default setting for sampling is to use the AlwaysOn sampler](https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler) but it should become possible to set other samples + custom sample rate via the `OTEL_TRACES_SAMPLER` environment variable.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Removed `AlwaysSample` clause

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

It's worth nothing that I haven't tested this out to confirm that it behaviour as I would assume it does. I need to get Concourse set up so I can do some local experiments and so on but at a glance, it should do what it says on the tin if the OpenTelemetry documentation is to be trusted.

Happy to have this PR in pending until I properly set it up locally though.

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Remove explicit OpenTelemetry 100% sample rate in order to support sample rate customisation via the `OTEL_TRACES_SAMPLER` environment variable.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
