### PR TITLE
Increase containerd runner ready state timeout

### DIFF
--- a/integration/worker/registration_test.go
+++ b/integration/worker/registration_test.go
@@ -22,6 +22,6 @@ func TestRegistration_GardenServerFails(t *testing.T) {
 		require.Eventually(t, func() bool {
 			services := dc.Output(t, "ps", "-a", "--services", "--status=exited")
 			return strings.Contains(services, "worker")
-		}, 30*time.Second, 1*time.Second, "worker process never exited, but should have")
+		}, 90*time.Second, 1*time.Second, "worker process never exited, but should have")
 	})
 }

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -246,7 +246,7 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 					}
 					return err == nil
 				},
-				Timeout: 10 * time.Second,
+				Timeout: 60 * time.Second,
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #9228 

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Increase containerd runner ready timeout

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Bumping the timeout for setting up the containerd runtime from 10 seconds to 60 seconds.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
