### PR TITLE
runtime: remove guardian as a runtime option for linux/arm64

### DIFF
--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -24,10 +24,6 @@ type Certs struct {
 	Dir string `long:"certs-dir" description:"Directory to use when creating the resource certificates volume."`
 }
 
-type RuntimeConfiguration struct {
-	Runtime string `long:"runtime" default:"guardian" choice:"guardian" choice:"containerd" choice:"houdini" description:"Runtime to use with the worker. Please note that Houdini is insecure and doesn't run 'tasks' in containers."`
-}
-
 type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden server executable (non-absolute names get resolved from $PATH)."`
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`

--- a/worker/workercmd/worker_linux_amd64.go
+++ b/worker/workercmd/worker_linux_amd64.go
@@ -1,0 +1,5 @@
+package workercmd
+
+type RuntimeConfiguration struct {
+	Runtime string `long:"runtime" default:"guardian" choice:"guardian" choice:"containerd" choice:"houdini" description:"Runtime to use with the worker. Please note that Houdini is insecure and doesn't run 'tasks' in containers."`
+}

--- a/worker/workercmd/worker_linux_arm64.go
+++ b/worker/workercmd/worker_linux_arm64.go
@@ -1,0 +1,7 @@
+package workercmd
+
+// The Guardian runtime is not available for linux/arm64
+// See: https://github.com/cloudfoundry/garden-runc-release/issues/378
+type RuntimeConfiguration struct {
+	Runtime string `long:"runtime" default:"containerd" choice:"containerd" choice:"houdini" description:"Runtime to use with the worker. Guardian is not available for linux/arm64. Please note that Houdini is insecure and doesn't run 'tasks' in containers."`
+}


### PR DESCRIPTION
## Changes proposed by this PR

Related: https://github.com/cloudfoundry/garden-runc-release/issues/378

Guardian does not currently ship a working linux/arm64 version. Therefore the linux/arm64 version of Concourse cannot offer Guardian as a runtime option for the worker and will instead default to using `containerd` as its runtime. The `houdini` option is still available for both.

