### PR TITLE
containerd: add flag to add additional-hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,4 +87,3 @@ services:
 
       # work with docker-compose's dns
       CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE: "true"
-      CONCOURSE_CONTAINERD_ADDITIONAL_HOSTS: ["1.2.3.4 example.com", "5.6.7.8 another-example.com"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,3 +87,4 @@ services:
 
       # work with docker-compose's dns
       CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE: "true"
+      CONCOURSE_CONTAINERD_ADDITIONAL_HOSTS: ["1.2.3.4 example.com", "5.6.7.8 another-example.com"]

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -500,10 +500,7 @@ func (n cniNetwork) generateResolvConfContents() ([]byte, error) {
 func (n cniNetwork) addHostsFileEntries(handle string) {
 	if len(n.additionalHosts) > 0 {
 		for _, entry := range n.additionalHosts {
-			err := n.store.Append(filepath.Join(handle, "/hosts"), []byte(entry+"\n"))
-			if err != nil {
-				fmt.Errorf("appending entry to /etc/hosts: %w", err)
-			}
+			n.store.Append(filepath.Join(handle, "/hosts"), []byte(entry+"\n"))
 		}
 	}
 }

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -505,7 +505,7 @@ func (n cniNetwork) addHostsFileEntries(handle string) error {
 		if len(fields) < 2 {
 			return fmt.Errorf("invalid host entry %q: must have IP and hostname", entry)
 		}
-		ip := fields[1]
+		ip := fields[0]
 		if net.ParseIP(ip) == nil {
 			return fmt.Errorf("invalid IP in host entry: %q", entry)
 		}

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -503,7 +503,7 @@ func (n cniNetwork) addHostsFileEntries(handle string) error {
 	for _, entry := range n.additionalHosts {
 		fields := strings.Fields(entry)
 		if len(fields) < 2 {
-			return fmt.Errorf("invalid host entry %q: must have IP and hostname", entry)
+			return fmt.Errorf("invalid host entry %q: must have IP and hostname separated by a space", entry)
 		}
 		ip := fields[0]
 		if net.ParseIP(ip) == nil {

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -505,9 +505,9 @@ func (n cniNetwork) addHostsFileEntries(handle string) error {
 		if len(fields) < 2 {
 			return fmt.Errorf("invalid host entry %q: must have IP and hostname", entry)
 		}
-		ip := fields[0]
+		ip := fields[1]
 		if net.ParseIP(ip) == nil {
-			return fmt.Errorf("invalid IP in host entry %q", entry)
+			return fmt.Errorf("invalid IP in host entry: %q", entry)
 		}
 		if err := n.store.Append(filepath.Join(handle, "hosts"), []byte(entry+"\n")); err != nil {
 			return fmt.Errorf("failed to append host entry %q: %w", entry, err)

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -416,7 +416,9 @@ func (n cniNetwork) SetupMounts(handle string) ([]specs.Mount, error) {
 
 	// Adding Additional hosts as in guardian original implementation
 	// https://github.com/cloudfoundry/guardian/blob/main/kawasaki/dns/hosts_file_compiler.go
-	n.addHostsFileEntries(handle)
+	if err := n.addHostsFileEntries(handle); err != nil {
+		return nil, fmt.Errorf("adding additional hosts: %w", err)
+	}
 
 	etcHostName, err := n.store.Create(
 		filepath.Join(handle, "/hostname"),
@@ -497,12 +499,21 @@ func (n cniNetwork) generateResolvConfContents() ([]byte, error) {
 	return []byte(contents), err
 }
 
-func (n cniNetwork) addHostsFileEntries(handle string) {
-	if len(n.additionalHosts) > 0 {
-		for _, entry := range n.additionalHosts {
-			n.store.Append(filepath.Join(handle, "/hosts"), []byte(entry+"\n"))
+func (n cniNetwork) addHostsFileEntries(handle string) error {
+	for _, entry := range n.additionalHosts {
+		fields := strings.Fields(entry)
+		if len(fields) < 2 {
+			return fmt.Errorf("invalid host entry %q: must have IP and hostname", entry)
+		}
+		ip := fields[0]
+		if net.ParseIP(ip) == nil {
+			return fmt.Errorf("invalid IP in host entry %q", entry)
+		}
+		if err := n.store.Append(filepath.Join(handle, "hosts"), []byte(entry+"\n")); err != nil {
+			return fmt.Errorf("failed to append host entry %q: %w", entry, err)
 		}
 	}
+	return nil
 }
 
 func (n cniNetwork) restrictHostAccess() error {

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -210,11 +210,10 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutAdditionalHosts() {
 }
 
 func (s *CNINetworkSuite) TestSetupMountsFailsToAppendAdditionalHost() {
-	// Arrange: set up a network with additional hosts
 	network, err := runtime.NewCNINetwork(
 		runtime.WithDefaultsForTesting(),
 		runtime.WithCNIFileStore(s.store),
-		runtime.WithAdditionalHosts([]string{"1.2.3.4 myhost"}),
+		runtime.WithAdditionalHosts([]string{"example 1.2.3.4"}),
 		runtime.WithIptables(s.iptables),
 	)
 	s.NoError(err)
@@ -227,8 +226,7 @@ func (s *CNINetworkSuite) TestSetupMountsFailsToAppendAdditionalHost() {
 
 	// Assert
 	s.Error(err)
-	s.Contains(err.Error(), "failed to append host entry")
-	s.Contains(err.Error(), "append-error")
+	s.EqualError(errors.Unwrap(err), "failed to append host entry \"example 1.2.3.4\": append-error")
 }
 
 func (s *CNINetworkSuite) TestSetupHostNetwork() {

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -105,6 +105,10 @@ func (cmd *WorkerCommand) buildUpNetworkOpts(logger lager.Logger, dnsServers []s
 		networkOpts = append(networkOpts, runtime.WithNameServers(dnsServers))
 	}
 
+	if len(cmd.Containerd.Network.AdditionalHosts) > 0 {
+		networkOpts = append(networkOpts, runtime.WithAdditionalHosts(cmd.Containerd.Network.AdditionalHosts))
+	}
+
 	if len(cmd.Containerd.Network.RestrictedNetworks) > 0 {
 		networkOpts = append(networkOpts, runtime.WithRestrictedNetworks(cmd.Containerd.Network.RestrictedNetworks))
 	}

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -47,6 +47,7 @@ type ContainerdRuntime struct {
 		//TODO can DNSConfig be simplifed to just a bool rather than struct with a bool?
 		DNS                DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 		DNSServers         []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
+		AdditionalHosts    []string  `long:"additional-hosts" description:"Additional entries to add to /etc/hosts in containers."`
 		RestrictedNetworks []string  `long:"restricted-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
 		Pool               string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host."`

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -47,7 +47,7 @@ type ContainerdRuntime struct {
 		//TODO can DNSConfig be simplifed to just a bool rather than struct with a bool?
 		DNS                DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 		DNSServers         []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
-		AdditionalHosts    []string  `long:"additional-hosts" description:"Additional entries to add to /etc/hosts in containers."`
+		AdditionalHosts    []string  `long:"additional-hosts" description:"Additional entries to add to /etc/hosts in containers. Can be specified multiple times or as a comma separated list. IP and Hostname should be separated by a space."`
 		RestrictedNetworks []string  `long:"restricted-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
 		Pool               string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host."`


### PR DESCRIPTION
## Changes proposed by this PR

Based on #6549, we want to maintain the adopt the functionally of adding additional DNS host entries to the `/etc/hosts` file of the container.

* [x] main functionallity
* [x] docker-compose local test of the env variable `CONCOURSE_CONTAINERD_ADDITIONAL_HOSTS`
* [x] unit/integration tests
* [x] bosh deployment introduction of env variable - https://github.com/concourse/concourse-bosh-release/pull/185
* [x] helm chart introduction of env variable - https://github.com/concourse/concourse-chart/pull/381
* [x] documentation in the runtime section of configuring worker - https://github.com/concourse/docs/pull/566

## Notes to reviewer
N/A

