### PR TITLE
Re-enable manual token entry when a fly command fails due to auth

### DIFF
--- a/fly/main.go
+++ b/fly/main.go
@@ -32,7 +32,7 @@ func loginAndRetry(parser *flags.Parser, err error) error {
 	if err == concourse.ErrUnauthorized && stdoutIsTTY && stdinIsTTY {
 		fmt.Fprintln(ui.Stderr, "could not find a valid token.")
 
-		login := &commands.LoginCommand{BrowserOnly: true}
+		login := &commands.LoginCommand{}
 		err = login.Execute([]string{})
 
 		if err == nil {

--- a/fly/pty/open_raw_term_unix.go
+++ b/fly/pty/open_raw_term_unix.go
@@ -6,17 +6,17 @@ package pty
 import (
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
-	"github.com/pkg/term"
+	pkgterm "github.com/pkg/term"
 )
 
 func IsTerminal() bool {
-	return terminal.IsTerminal(int(os.Stdin.Fd()))
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func OpenRawTerm() (Term, error) {
-	t, err := term.Open(os.Stdin.Name(), term.RawMode)
+	t, err := pkgterm.Open(os.Stdin.Name(), pkgterm.RawMode)
 	if err != nil {
 		return nil, err
 	}

--- a/fly/pty/open_raw_term_windows.go
+++ b/fly/pty/open_raw_term_windows.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func IsTerminal() bool {
-	return terminal.IsTerminal(int(os.Stdin.Fd()))
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func OpenRawTerm() (Term, error) {

--- a/fly/pty/readline.go
+++ b/fly/pty/readline.go
@@ -1,6 +1,7 @@
 package pty
 
 import (
+	"context"
 	"errors"
 	"io"
 )
@@ -12,36 +13,54 @@ const (
 	keyBackspace = 127
 )
 
-func ReadLine(reader io.Reader) ([]byte, error) {
+func ReadLine(ctx context.Context, reader io.Reader) ([]byte, error) {
 	var buf [1]byte
 	var ret []byte
 
+	readCh := make(chan readResult)
+
 	for {
-		n, err := reader.Read(buf[:])
-		if n > 0 {
-			switch buf[0] {
-			case '\b', keyBackspace:
-				if len(ret) > 0 {
-					ret = ret[:len(ret)-1]
+		go func() {
+			n, err := reader.Read(buf[:])
+			readCh <- readResult{n: n, err: err}
+		}()
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case result := <-readCh:
+			n, err := result.n, result.err
+
+			if n > 0 {
+				switch buf[0] {
+				case '\b', keyBackspace:
+					if len(ret) > 0 {
+						ret = ret[:len(ret)-1]
+					}
+				case '\r', '\n':
+					return ret, nil
+				case keyCtrlC:
+					return nil, ErrInterrupted
+				default:
+					if isPrintableChar(buf[0]) {
+						ret = append(ret, buf[0])
+					}
 				}
-			case '\r', '\n':
-				return ret, nil
-			case keyCtrlC:
-				return nil, ErrInterrupted
-			default:
-				if isPrintableChar(buf[0]) {
-					ret = append(ret, buf[0])
+				continue
+			}
+			if err != nil {
+				if err == io.EOF && len(ret) > 0 {
+					return ret, nil
 				}
+				return ret, err
 			}
-			continue
-		}
-		if err != nil {
-			if err == io.EOF && len(ret) > 0 {
-				return ret, nil
-			}
-			return ret, err
 		}
 	}
+}
+
+type readResult struct {
+	n   int
+	err error
 }
 
 func isPrintableChar(b byte) bool {

--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
 	golang.org/x/mod v0.26.0 // indirect
 	golang.org/x/net v0.42.0 // indirect
-	golang.org/x/term v0.33.0 // indirect
+	golang.org/x/term v0.33.0
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/tools v0.35.0 // indirect
 	google.golang.org/api v0.243.0 // indirect


### PR DESCRIPTION
## Changes proposed by this PR

closes #9244 and properly resolves #2414 instead of patching around it by disabling manual token entry.

## Notes to reviewer

`BrowserOnly` on the `LoginCommand` struct was initially added to fix https://github.com/concourse/concourse/issues/2414

This PR fixes that issue. The Reader will now close after a successful login, even if it wasn't used.

I tested this change on macOS, linux, and Windows (Powershell). I ran `fly set-pipeline` so there would always be a second prompt (the `yN` prompt) after logging in. I was always able to interact with the `yN` prompt after logging in using manual entry or with the automatic browser flow.

I did notice that I had to press a key to "focus" onto the `yN` prompt after logging in with the automated browser flow. Not exactly sure why that happens, but after pressing any key, I was able to fully interact with the `yN` prompt. I threw some temporary debug statements in while testing to confirm that the `pty.ReadLine()` did exit. If someone wants to figure out that last little hiccup, they can make a PR addressing that.