### PR TITLE
remove --time-format flag when using guardian runtime

### DIFF
--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -75,8 +75,6 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 		"--depot", depotDir,
 		"--properties-path", filepath.Join(cmd.WorkDir.Path(), "garden-properties.json"),
 
-		"--time-format", "rfc3339",
-
 		// disable graph and grootfs setup; all images passed to Concourse
 		// containers are raw://
 		"--no-image-plugin",


### PR DESCRIPTION
## Changes proposed by this PR

The flag was removed in the latest Guardian release by:
https://github.com/cloudfoundry/guardian/pull/474

This change by them results in RFC3339 always being used now.

Trying to start Guardian with this flag resulted in the following error:

```
unknown flag `time-format'
```