### PR TITLE
Add broadcast message to Concourse cluster

### DIFF
--- a/atc/api/wall_test.go
+++ b/atc/api/wall_test.go
@@ -113,6 +113,23 @@ var _ = Describe("Wall API", func() {
 					Expect(dbWall.SetWallCallCount()).To(Equal(1))
 					Expect(dbWall.SetWallArgsForCall(0)).To(Equal(expectedWall))
 				})
+
+				Context("when message is empty", func() {
+					BeforeEach(func() {
+						expectedWall = atc.Wall{
+							Message: "",
+							TTL:     time.Minute,
+						}
+					})
+
+					It("returns 400 Bad Request", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+					})
+
+					It("does not call SetWall", func() {
+						Expect(dbWall.SetWallCallCount()).To(Equal(0))
+					})
+				})
 			})
 
 			Context("and is not admin", func() {

--- a/atc/api/wallserver/wall.go
+++ b/atc/api/wallserver/wall.go
@@ -38,6 +38,12 @@ func (s *Server) SetWall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if wall.Message == "" {
+		logger.Error("empty-message-string", nil)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	err = s.wall.SetWall(wall)
 	if err != nil {
 		logger.Error("failed-to-set-wall-message", err)

--- a/fly/commands/clear_wall.go
+++ b/fly/commands/clear_wall.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/concourse/concourse/fly/rc"
+)
+
+type ClearWallCommand struct{}
+
+func (command *ClearWallCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	err = target.Client().ClearWall()
+	if err != nil {
+		return fmt.Errorf("failed to clear wall message: %w", err)
+	}
+
+	fmt.Println("Wall message cleared successfully")
+	return nil
+}

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -90,9 +90,9 @@ type FlyCommand struct {
 
 	Curl CurlCommand `command:"curl" alias:"c" description:"curl the api"`
 
-	GetWall   GetWallCommand   `command:"get-wall" description:"Get the current wall message"`
-	SetWall   SetWallCommand   `command:"set-wall" description:"Set a wall message"`
-	ClearWall ClearWallCommand `command:"clear-wall" description:"Clear the wall message"`
+	GetWall   GetWallCommand   `command:"get-wall" alias:"gw" description:"Get the current wall message"`
+	SetWall   SetWallCommand   `command:"set-wall" alias:"sw" description:"Set a wall message"`
+	ClearWall ClearWallCommand `command:"clear-wall" alias:"cw" description:"Clear the wall message"`
 
 	Completion CompletionCommand `command:"completion" description:"generate shell completion code"`
 }

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -90,6 +90,10 @@ type FlyCommand struct {
 
 	Curl CurlCommand `command:"curl" alias:"c" description:"curl the api"`
 
+	GetWall   GetWallCommand   `command:"get-wall" description:"Get the current wall message"`
+	SetWall   SetWallCommand   `command:"set-wall" description:"Set a wall message"`
+	ClearWall ClearWallCommand `command:"clear-wall" description:"Clear the wall message"`
+
 	Completion CompletionCommand `command:"completion" description:"generate shell completion code"`
 }
 

--- a/fly/commands/get_wall.go
+++ b/fly/commands/get_wall.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/concourse/concourse/fly/rc"
+)
+
+type GetWallCommand struct{}
+
+func (command *GetWallCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	wall, err := target.Client().GetWall()
+	if err != nil {
+		return fmt.Errorf("failed to get wall message: %w", err)
+	}
+
+	if wall.Message == "" {
+		fmt.Println("No wall message is currently set")
+		return nil
+	}
+
+	fmt.Printf("Wall Message: %s\n", wall.Message)
+	fmt.Printf("Expires in: %v\n", wall.TTL)
+
+	return nil
+}

--- a/fly/commands/get_wall.go
+++ b/fly/commands/get_wall.go
@@ -30,7 +30,11 @@ func (command *GetWallCommand) Execute([]string) error {
 	}
 
 	fmt.Printf("Wall Message: %s\n", wall.Message)
-	fmt.Printf("Expires in: %v\n", wall.TTL)
+	if wall.TTL == 0 {
+		fmt.Println("No expiration set")
+	} else {
+		fmt.Printf("Expires in: %v\n", wall.TTL)
+	}
 
 	return nil
 }

--- a/fly/commands/set_wall.go
+++ b/fly/commands/set_wall.go
@@ -9,8 +9,8 @@ import (
 )
 
 type SetWallCommand struct {
-	Message string        `short:"m" long:"message" required:"true" description:"Message to broadcast"`
-	TTL     time.Duration `long:"ttl" required:"true" description:"Time-to-live for the message (e.g. 1h30m)"`
+	Message string        `short:"m" long:"message" required:"true" description:"Message to broadcast. Supports emojis and links."`
+	TTL     time.Duration `long:"ttl" required:"false" description:"Time-to-live for the message (e.g. 1h30m). Zero values will result in a message with no expiration."`
 }
 
 func (command *SetWallCommand) Execute([]string) error {
@@ -35,7 +35,11 @@ func (command *SetWallCommand) Execute([]string) error {
 	}
 
 	fmt.Println("Wall message set successfully")
-	fmt.Printf("Message will expire in %v\n", command.TTL)
+	if command.TTL == 0 {
+		fmt.Println("No expiration set")
+	} else {
+		fmt.Printf("Message will expire in %v\n", command.TTL)
+	}
 
 	return nil
 }

--- a/fly/commands/set_wall.go
+++ b/fly/commands/set_wall.go
@@ -1,0 +1,41 @@
+package commands
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/rc"
+)
+
+type SetWallCommand struct {
+	Message string        `short:"m" long:"message" required:"true" description:"Message to broadcast"`
+	TTL     time.Duration `long:"ttl" required:"true" description:"Time-to-live for the message (e.g. 1h30m)"`
+}
+
+func (command *SetWallCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	wall := atc.Wall{
+		Message: command.Message,
+		TTL:     command.TTL,
+	}
+
+	err = target.Client().SetWall(wall)
+	if err != nil {
+		return fmt.Errorf("failed to set wall message: %w", err)
+	}
+
+	fmt.Println("Wall message set successfully")
+	fmt.Printf("Message will expire in %v\n", command.TTL)
+
+	return nil
+}

--- a/fly/integration/clear_wall_test.go
+++ b/fly/integration/clear_wall_test.go
@@ -1,0 +1,33 @@
+package integration_test
+
+import (
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("FLY CLI", func() {
+	Describe("clear-wall", func() {
+		Context("when clearing succeeds", func() {
+			It("sends DELETE /api/v1/wall and prints success", func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("DELETE", "/api/v1/wall"),
+						ghttp.RespondWith(200, ""),
+					),
+				)
+
+				flyCmd := exec.Command(flyPath, "-t", targetName, "clear-wall")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+				Expect(sess.Out).To(gbytes.Say("Wall message cleared successfully"))
+			})
+		})
+	})
+})

--- a/fly/integration/clear_wall_test.go
+++ b/fly/integration/clear_wall_test.go
@@ -29,5 +29,22 @@ var _ = Describe("FLY CLI", func() {
 				Expect(sess.Out).To(gbytes.Say("Wall message cleared successfully"))
 			})
 		})
+
+		Context("when the API returns an error", func() {
+			It("exits non-zero and shows an error", func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("DELETE", "/api/v1/wall"),
+						ghttp.RespondWith(500, ""),
+					),
+				)
+				flyCmd := exec.Command(flyPath, "-t", targetName, "clear-wall")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+				Expect(sess.Err).To(gbytes.Say("failed to clear wall message"))
+			})
+		})
 	})
 })

--- a/fly/integration/get_wall_test.go
+++ b/fly/integration/get_wall_test.go
@@ -14,8 +14,8 @@ import (
 
 var _ = Describe("FLY CLI", func() {
 	Describe("get-wall", func() {
-		Context("when a wall message is set", func() {
-			It("shows the message and ttl", func() {
+		Context("when a wall message is set with ttl", func() {
+			It("shows the message", func() {
 				wall := atc.Wall{Message: "test message", TTL: time.Hour}
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -31,6 +31,26 @@ var _ = Describe("FLY CLI", func() {
 				Expect(sess.ExitCode()).To(Equal(0))
 				Expect(sess.Out).To(gbytes.Say("Wall Message: test message"))
 				Expect(sess.Out).To(gbytes.Say("Expires in:"))
+			})
+		})
+
+		Context("when a wall message is set without ttl", func() {
+			It("shows the message", func() {
+				wall := atc.Wall{Message: "test message"}
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/wall"),
+						ghttp.RespondWithJSONEncoded(200, wall),
+					),
+				)
+
+				flyCmd := exec.Command(flyPath, "-t", targetName, "get-wall")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+				Expect(sess.Out).To(gbytes.Say("Wall Message: test message"))
+				Expect(sess.Out).To(gbytes.Say("No expiration set"))
 			})
 		})
 

--- a/fly/integration/get_wall_test.go
+++ b/fly/integration/get_wall_test.go
@@ -1,0 +1,71 @@
+package integration_test
+
+import (
+	"os/exec"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("FLY CLI", func() {
+	Describe("get-wall", func() {
+		Context("when a wall message is set", func() {
+			It("shows the message and ttl", func() {
+				wall := atc.Wall{Message: "test message", TTL: time.Hour}
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/wall"),
+						ghttp.RespondWithJSONEncoded(200, wall),
+					),
+				)
+
+				flyCmd := exec.Command(flyPath, "-t", targetName, "get-wall")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+				Expect(sess.Out).To(gbytes.Say("Wall Message: test message"))
+				Expect(sess.Out).To(gbytes.Say("Expires in:"))
+			})
+		})
+
+		Context("when no wall message is set", func() {
+			It("prints a helpful message", func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/wall"),
+						ghttp.RespondWithJSONEncoded(200, atc.Wall{}),
+					),
+				)
+				flyCmd := exec.Command(flyPath, "-t", targetName, "get-wall")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+				Expect(sess.Out).To(gbytes.Say("No wall message is currently set"))
+			})
+		})
+
+		Context("when the API returns an error", func() {
+			It("exits non-zero and shows an error", func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/wall"),
+						ghttp.RespondWith(500, ""),
+					),
+				)
+				flyCmd := exec.Command(flyPath, "-t", targetName, "get-wall")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+				Expect(sess.Err).To(gbytes.Say("failed to get wall message"))
+			})
+		})
+	})
+})

--- a/fly/integration/set_wall_test.go
+++ b/fly/integration/set_wall_test.go
@@ -1,0 +1,54 @@
+package integration_test
+
+import (
+	"os/exec"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("FLY CLI", func() {
+	Describe("set-wall", func() {
+		Context("when setting a wall message succeeds", func() {
+			It("set wall and print success", func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", "/api/v1/wall"),
+						ghttp.RespondWithJSONEncoded(200, atc.Wall{Message: "test message", TTL: time.Hour}),
+					),
+				)
+
+				flyCmd := exec.Command(flyPath, "-t", targetName, "set-wall", "-m", "test message", "--ttl", "1h")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+				Expect(sess.Out).To(gbytes.Say("Wall message set successfully"))
+			})
+		})
+
+		Context("when the API returns an error", func() {
+			It("exits non-zero and shows an error", func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", "/api/v1/wall"),
+						ghttp.RespondWith(500, ""),
+					),
+				)
+				flyCmd := exec.Command(flyPath, "-t", targetName, "set-wall", "-m", "test message", "--ttl", "1h")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+				Expect(sess.Err).To(gbytes.Say("failed to set wall message"))
+			})
+		})
+	})
+})

--- a/fly/integration/set_wall_test.go
+++ b/fly/integration/set_wall_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("FLY CLI", func() {
 	Describe("set-wall", func() {
-		Context("when setting a wall message succeeds", func() {
+		Context("when setting a wall message succeeds with ttl", func() {
 			It("set wall and print success", func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -24,6 +24,25 @@ var _ = Describe("FLY CLI", func() {
 				)
 
 				flyCmd := exec.Command(flyPath, "-t", targetName, "set-wall", "-m", "test message", "--ttl", "1h")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+				Expect(sess.Out).To(gbytes.Say("Wall message set successfully"))
+			})
+		})
+
+		Context("when setting a wall message succeeds without ttl", func() {
+			It("set wall and print success", func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", "/api/v1/wall"),
+						ghttp.RespondWithJSONEncoded(200, atc.Wall{Message: "test message", TTL: time.Hour}),
+					),
+				)
+
+				flyCmd := exec.Command(flyPath, "-t", targetName, "set-wall", "-m", "test message")
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/go-concourse/concourse/client.go
+++ b/go-concourse/concourse/client.go
@@ -35,6 +35,9 @@ type Client interface {
 	Team(teamName string) Team
 	UserInfo() (atc.UserInfo, error)
 	ListActiveUsersSince(since time.Time) ([]atc.User, error)
+	GetWall() (atc.Wall, error)
+	SetWall(atc.Wall) error
+	ClearWall() error
 }
 
 type client struct {

--- a/go-concourse/concourse/concoursefakes/fake_client.go
+++ b/go-concourse/concourse/concoursefakes/fake_client.go
@@ -278,6 +278,39 @@ type FakeClient struct {
 	uRLReturnsOnCall map[int]struct {
 		result1 string
 	}
+	GetWallStub        func() (atc.Wall, error)
+	getWallMutex       sync.RWMutex
+	getWallArgsForCall []struct {
+	}
+	getWallReturns struct {
+		result1 atc.Wall
+		result2 error
+	}
+	getWallReturnsOnCall map[int]struct {
+		result1 atc.Wall
+		result2 error
+	}
+	SetWallStub        func(atc.Wall) error
+	setWallMutex       sync.RWMutex
+	setWallArgsForCall []struct {
+		arg1 atc.Wall
+	}
+	setWallReturns struct {
+		result1 error
+	}
+	setWallReturnsOnCall map[int]struct {
+		result1 error
+	}
+	ClearWallStub        func() error
+	clearWallMutex       sync.RWMutex
+	clearWallArgsForCall []struct {
+	}
+	clearWallReturns struct {
+		result1 error
+	}
+	clearWallReturnsOnCall map[int]struct {
+		result1 error
+	}
 	UserInfoStub        func() (atc.UserInfo, error)
 	userInfoMutex       sync.RWMutex
 	userInfoArgsForCall []struct {
@@ -1637,6 +1670,160 @@ func (fake *FakeClient) UserInfoReturnsOnCall(i int, result1 atc.UserInfo, resul
 	}{result1, result2}
 }
 
+func (fake *FakeClient) GetWall() (atc.Wall, error) {
+	fake.getWallMutex.Lock()
+	ret, specificReturn := fake.getWallReturnsOnCall[len(fake.getWallArgsForCall)]
+	fake.getWallArgsForCall = append(fake.getWallArgsForCall, struct{}{})
+	stub := fake.GetWallStub
+	fakeReturns := fake.getWallReturns
+	fake.recordInvocation("GetWall", []interface{}{})
+	fake.getWallMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetWallCallCount() int {
+	fake.getWallMutex.RLock()
+	defer fake.getWallMutex.RUnlock()
+	return len(fake.getWallArgsForCall)
+}
+
+func (fake *FakeClient) GetWallCalls(stub func() (atc.Wall, error)) {
+	fake.getWallMutex.Lock()
+	defer fake.getWallMutex.Unlock()
+	fake.GetWallStub = stub
+}
+
+func (fake *FakeClient) GetWallReturns(result1 atc.Wall, result2 error) {
+	fake.getWallMutex.Lock()
+	defer fake.getWallMutex.Unlock()
+	fake.GetWallStub = nil
+	fake.getWallReturns = struct {
+		result1 atc.Wall
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetWallReturnsOnCall(i int, result1 atc.Wall, result2 error) {
+	fake.getWallMutex.Lock()
+	defer fake.getWallMutex.Unlock()
+	fake.GetWallStub = nil
+	if fake.getWallReturnsOnCall == nil {
+		fake.getWallReturnsOnCall = make(map[int]struct {
+			result1 atc.Wall
+			result2 error
+		})
+	}
+	fake.getWallReturnsOnCall[i] = struct {
+		result1 atc.Wall
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) SetWall(arg1 atc.Wall) error {
+	fake.setWallMutex.Lock()
+	ret, specificReturn := fake.setWallReturnsOnCall[len(fake.setWallArgsForCall)]
+	fake.setWallArgsForCall = append(fake.setWallArgsForCall, struct{ arg1 atc.Wall }{arg1})
+	stub := fake.SetWallStub
+	fakeReturns := fake.setWallReturns
+	fake.recordInvocation("SetWall", []interface{}{arg1})
+	fake.setWallMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) SetWallCallCount() int {
+	fake.setWallMutex.RLock()
+	defer fake.setWallMutex.RUnlock()
+	return len(fake.setWallArgsForCall)
+}
+
+func (fake *FakeClient) SetWallCalls(stub func(atc.Wall) error) {
+	fake.setWallMutex.Lock()
+	defer fake.setWallMutex.Unlock()
+	fake.SetWallStub = stub
+}
+
+func (fake *FakeClient) SetWallArgsForCall(i int) atc.Wall {
+	fake.setWallMutex.RLock()
+	defer fake.setWallMutex.RUnlock()
+	argsForCall := fake.setWallArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) SetWallReturns(result1 error) {
+	fake.setWallMutex.Lock()
+	defer fake.setWallMutex.Unlock()
+	fake.SetWallStub = nil
+	fake.setWallReturns = struct{ result1 error }{result1}
+}
+
+func (fake *FakeClient) SetWallReturnsOnCall(i int, result1 error) {
+	fake.setWallMutex.Lock()
+	defer fake.setWallMutex.Unlock()
+	fake.SetWallStub = nil
+	if fake.setWallReturnsOnCall == nil {
+		fake.setWallReturnsOnCall = make(map[int]struct{ result1 error })
+	}
+	fake.setWallReturnsOnCall[i] = struct{ result1 error }{result1}
+}
+
+func (fake *FakeClient) ClearWall() error {
+	fake.clearWallMutex.Lock()
+	ret, specificReturn := fake.clearWallReturnsOnCall[len(fake.clearWallArgsForCall)]
+	fake.clearWallArgsForCall = append(fake.clearWallArgsForCall, struct{}{})
+	stub := fake.ClearWallStub
+	fakeReturns := fake.clearWallReturns
+	fake.recordInvocation("ClearWall", []interface{}{})
+	fake.clearWallMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) ClearWallCallCount() int {
+	fake.clearWallMutex.RLock()
+	defer fake.clearWallMutex.RUnlock()
+	return len(fake.clearWallArgsForCall)
+}
+
+func (fake *FakeClient) ClearWallCalls(stub func() error) {
+	fake.clearWallMutex.Lock()
+	defer fake.clearWallMutex.Unlock()
+	fake.ClearWallStub = stub
+}
+
+func (fake *FakeClient) ClearWallReturns(result1 error) {
+	fake.clearWallMutex.Lock()
+	defer fake.clearWallMutex.Unlock()
+	fake.ClearWallStub = nil
+	fake.clearWallReturns = struct{ result1 error }{result1}
+}
+
+func (fake *FakeClient) ClearWallReturnsOnCall(i int, result1 error) {
+	fake.clearWallMutex.Lock()
+	defer fake.clearWallMutex.Unlock()
+	fake.ClearWallStub = nil
+	if fake.clearWallReturnsOnCall == nil {
+		fake.clearWallReturnsOnCall = make(map[int]struct{ result1 error })
+	}
+	fake.clearWallReturnsOnCall[i] = struct{ result1 error }{result1}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1682,6 +1869,12 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.teamMutex.RUnlock()
 	fake.uRLMutex.RLock()
 	defer fake.uRLMutex.RUnlock()
+	fake.getWallMutex.RLock()
+	defer fake.getWallMutex.RUnlock()
+	fake.setWallMutex.RLock()
+	defer fake.setWallMutex.RUnlock()
+	fake.clearWallMutex.RLock()
+	defer fake.clearWallMutex.RUnlock()
 	fake.userInfoMutex.RLock()
 	defer fake.userInfoMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/go-concourse/concourse/wall.go
+++ b/go-concourse/concourse/wall.go
@@ -1,0 +1,48 @@
+package concourse
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/go-concourse/concourse/internal"
+)
+
+func (client *client) GetWall() (atc.Wall, error) {
+	var wall atc.Wall
+
+	err := client.connection.Send(internal.Request{
+		RequestName: atc.GetWall,
+	}, &internal.Response{
+		Result: &wall,
+	})
+
+	return wall, err
+}
+
+func (client *client) SetWall(wall atc.Wall) error {
+	buffer := &bytes.Buffer{}
+	err := json.NewEncoder(buffer).Encode(wall)
+	if err != nil {
+		return err
+	}
+
+	err = client.connection.Send(internal.Request{
+		RequestName: atc.SetWall,
+		Body:        buffer,
+		Header: http.Header{
+			"Content-Type": {"application/json"},
+		},
+	}, &internal.Response{})
+
+	return err
+}
+
+func (client *client) ClearWall() error {
+	err := client.connection.Send(internal.Request{
+		RequestName: atc.ClearWall,
+	}, &internal.Response{})
+
+	return err
+}

--- a/go-concourse/concourse/wall_test.go
+++ b/go-concourse/concourse/wall_test.go
@@ -1,0 +1,63 @@
+package concourse_test
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Wall functions", func() {
+	Describe("GetWall function", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/wall"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Wall{Message: "test message", TTL: time.Minute}),
+				),
+			)
+		})
+
+		It("returns the wall message", func() {
+			wall, err := client.GetWall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wall.Message).To(Equal("test message"))
+			Expect(wall.TTL).To(Equal(time.Minute))
+		})
+	})
+
+	Describe("SetWall function", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", "/api/v1/wall"),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("sends the message and ttl", func() {
+			err := client.SetWall(atc.Wall{Message: "test message", TTL: time.Hour})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("ClearWall function", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("DELETE", "/api/v1/wall"),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("clears the wall", func() {
+			err := client.ClearWall()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/web/assets/css/main.less
+++ b/web/assets/css/main.less
@@ -34,3 +34,5 @@
 @import "animation.less";
 
 @import "download-fly.less";
+
+@import "wall.less";

--- a/web/assets/css/wall.less
+++ b/web/assets/css/wall.less
@@ -1,7 +1,8 @@
 @import (reference) "_vars.less";
 
 #wall-banner {
-  position: fixed;
+  position: sticky;
+  padding-block: clamp(0.4rem, 1.2vw, 0.75rem);
   top: 55px;
   left: 0;
   right: 0;
@@ -9,10 +10,8 @@
   background-color: @grey70;
   color: #ffff;
   padding: 6px 16px;
-  font-size: 14px;
-  font-family: sans-serif;
+  font-size: 1.25em;
+  font-family: 'Inconsolata', monospace;
   text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
+

--- a/web/assets/css/wall.less
+++ b/web/assets/css/wall.less
@@ -16,8 +16,3 @@
   justify-content: center;
   align-items: center;
 }
-
-#wall-banner .wall-icon {
-  font-size: 16px;
-  margin-right: 4px;
-}

--- a/web/assets/css/wall.less
+++ b/web/assets/css/wall.less
@@ -1,0 +1,23 @@
+@import (reference) "_vars.less";
+
+#wall-banner {
+  position: fixed;
+  top: 55px;
+  left: 0;
+  right: 0;
+  z-index: 998;
+  background-color: @grey70;
+  color: #ffff;
+  padding: 6px 16px;
+  font-size: 14px;
+  font-family: sans-serif;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#wall-banner .wall-icon {
+  font-size: 16px;
+  margin-right: 4px;
+}

--- a/web/elm/src/Api/Endpoints.elm
+++ b/web/elm/src/Api/Endpoints.elm
@@ -28,6 +28,7 @@ type Endpoint
     | TeamsList
     | Team Concourse.TeamName TeamEndpoint
     | ClusterInfo
+    | Wall
     | Cli
     | UserInfo
     | Logout
@@ -175,6 +176,9 @@ builder endpoint =
 
         ClusterInfo ->
             base |> appendPath [ "info" ]
+
+        Wall ->
+            base |> appendPath [ "wall" ]
 
         Cli ->
             base |> appendPath [ "cli" ]

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -123,7 +123,7 @@ init flags url =
       , LoadFavoritedPipelines
       , LoadFavoritedInstanceGroups
       , FetchClusterInfo
-    , FetchWall
+      , FetchWall
       ]
         ++ handleTokenEffect
         ++ subEffects
@@ -482,12 +482,6 @@ view model =
                     Html.text ""
             , Html.div
                 ([ id "page-wrapper", style "height" "100%" ]
-                    ++ (case model.wallMessage of
-                            Just _ ->
-                                [ style "padding-top" "36px" ]
-                            Nothing ->
-                                []
-                       )
                     ++ (if model.session.draggingSideBar then
                             Styles.disableInteraction
                         else

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -474,14 +474,13 @@ view model =
             , SideBar.tooltip model.session
                 |> Maybe.map (Tooltip.view model.session)
                 |> Maybe.withDefault (Html.text "")
-            , (case model.wallMessage of
-                    Just msg ->
-                        Html.div [ id "wall-banner" ] (
-                            [ Html.span [ Html.Attributes.class "wall-icon" ] [ Html.text "⚠️" ] ]
-                                ++ wallLinks msg
-                        )
-                    Nothing -> Html.text ""
-              )
+            , case model.wallMessage of
+                Just msg ->
+                    Html.div [ id "wall-banner" ] <|
+                        Html.span [ Html.Attributes.class "wall-icon" ] [ Html.text "⚠️" ]
+                            :: wallLinks msg
+                Nothing ->
+                    Html.text ""
             , Html.div
                 ([ id "page-wrapper", style "height" "100%" ]
                     ++ (case model.wallMessage of

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -476,7 +476,7 @@ view model =
                 |> Maybe.withDefault (Html.text "")
             , case model.wallMessage of
                 Just msg ->
-                    Html.div [ id "wall-banner" ] <|
+                    Html.div [ id "wall-banner", style "white-space" "pre-wrap" ] <|
                         Html.span [ Html.Attributes.class "wall-icon" ] [ Html.text "⚠️" ]
                             :: wallLinks msg
                 Nothing ->
@@ -574,7 +574,7 @@ wallLinks msg =
             if String.startsWith "http://" t || String.startsWith "https://" t then
                 let
                     ( url, trailing ) = stripTrailingPunct t
-                    anchor = Html.a [ href url, target "_blank", rel "noopener noreferrer" ] [ Html.text url ]
+                    anchor = Html.a [ href url, target "_blank", rel "noopener noreferrer", style "text-decoration" "underline", style "margin-right" "0.25em" ] [ Html.text url ]
                 in
                 if trailing == "" then
                     [ anchor ]

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -247,7 +247,7 @@ handleCallback callback model =
                     let
                         trimmed = String.trim wall.message
                     in
-                    if trimmed == "" || wall.ttl == 0 then
+                    if trimmed == "" then
                         Nothing
                     else
                         Just trimmed
@@ -477,8 +477,7 @@ view model =
             , case model.wallMessage of
                 Just msg ->
                     Html.div [ id "wall-banner", style "white-space" "pre-wrap" ] <|
-                        Html.span [ Html.Attributes.class "wall-icon" ] [ Html.text "⚠️" ]
-                            :: wallLinks msg
+                        wallLinks msg
                 Nothing ->
                     Html.text ""
             , Html.div

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -22,6 +22,7 @@ module Concourse exposing
     , CausalityResource
     , CausalityResourceVersion
     , ClusterInfo
+    , Wall
     , DatabaseID
     , FeatureFlags
     , HookedPlan
@@ -61,6 +62,7 @@ module Concourse exposing
     , decodeBuildResources
     , decodeCausality
     , decodeInfo
+    , decodeWall
     , decodeInstanceGroupId
     , decodeInstanceVars
     , decodeJob
@@ -936,6 +938,22 @@ decodeInfo =
     Json.Decode.succeed ClusterInfo
         |> andMap (Json.Decode.field "version" Json.Decode.string)
         |> andMap (defaultTo "" <| Json.Decode.field "cluster_name" Json.Decode.string)
+
+
+-- Wall
+
+
+type alias Wall =
+    { message : String
+    , ttl : Int -- nanoseconds remaining; 0 when unset
+    }
+
+
+decodeWall : Json.Decode.Decoder Wall
+decodeWall =
+    Json.Decode.succeed Wall
+        |> andMap (defaultTo "" <| Json.Decode.field "message" Json.Decode.string)
+        |> andMap (defaultTo 0 <| Json.Decode.field "TTL" Json.Decode.int)
 
 
 

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -39,6 +39,7 @@ type Callback
     | VersionedResourcesFetched (Fetched ( Page, Paginated Concourse.VersionedResource ))
     | VersionedResourceIdFetched (Fetched (Maybe Concourse.VersionedResource))
     | ClusterInfoFetched (Fetched Concourse.ClusterInfo)
+    | WallFetched (Fetched Concourse.Wall)
     | PausedToggled (Fetched ())
     | InputToFetched (Fetched ( VersionId, List Concourse.Build ))
     | OutputOfFetched (Fetched ( VersionId, List Concourse.Build ))

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -136,6 +136,7 @@ type Effect
     | FetchPipeline Concourse.PipelineIdentifier
     | FetchPipelines String
     | FetchClusterInfo
+    | FetchWall
     | FetchInputTo Concourse.VersionedResourceIdentifier
     | FetchDownstreamCausality Concourse.VersionedResourceIdentifier
     | FetchOutputOf Concourse.VersionedResourceIdentifier
@@ -333,6 +334,12 @@ runEffect effect key csrfToken =
                 |> Api.expectJson Concourse.decodeInfo
                 |> Api.request
                 |> Task.attempt ClusterInfoFetched
+
+        FetchWall ->
+            Api.get Endpoints.Wall
+                |> Api.expectJson Concourse.decodeWall
+                |> Api.request
+                |> Task.attempt WallFetched
 
         FetchInputTo id ->
             Api.get

--- a/web/elm/tests/ApiEndpointsTests.elm
+++ b/web/elm/tests/ApiEndpointsTests.elm
@@ -276,6 +276,11 @@ testEndpoints =
                 ClusterInfo
                     |> toPath
                     |> Expect.equal "/api/v1/info"
+        , test "Wall" <|
+            \_ ->
+                Wall
+                    |> toPath
+                    |> Expect.equal "/api/v1/wall"
         , test "Cli" <|
             \_ ->
                 Cli

--- a/web/elm/tests/ApplicationTests.elm
+++ b/web/elm/tests/ApplicationTests.elm
@@ -258,4 +258,33 @@ all =
                         |> Routes.getGroups
                         |> Expect.equal []
             ]
+        , describe "wall banner"
+            [ test "wall banner is not displayed when there's no message" <|
+                \_ ->
+                    Common.init "/teams/t/pipelines/p/"
+                        |> Common.queryView
+                        |> Query.findAll [ id "wall-banner" ]
+                        |> Query.count (Expect.equal 0)
+            , test "wall banner is displayed when there is a message" <|
+                \_ ->
+                    Common.init "/teams/t/pipelines/p/"
+                        |> Application.handleCallback
+                            (Callback.WallFetched <|
+                                Ok { message = "Some test message", ttl = 0 }
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.has [ id "wall-banner" ]
+            , test "wall banner is not displayed on WallFetched error" <|
+                \_ ->
+                    Common.init "/teams/t/pipelines/p/"
+                        |> Application.handleCallback
+                            (Callback.WallFetched
+                                Data.httpInternalServerError
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.findAll [ id "wall-banner" ]
+                        |> Query.count (Expect.equal 0)
+            ]
         ]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #9241
closes #9239 

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] `fly set-wall` with required parameters `-m` as message and `--ttl` as time to live to set a broadcast message to appear on the top.
* [x] `fly get-wall` to get the already set broadcast message with it ttl.
* [x] `fly clear-wall` to clear the already set broadcast message.
* [x] Broadcast message appears at the top. After executing `fly set-wall` within few seconds the message will appear.
* [x] Executing `fly clear-wall` will remove the message of the top of the page within few seconds.
* [x] Working links if added to the broadcast message. If not it will appear as simple text at the top.
* [x] ~Added a warning icon before the message.~
* [x] Tests

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

- I've made the `--ttl` property for `fly set-wall` required, since I think it’s good to always specify it. If you feel it doesn’t need to be required, I can set a default value.
- I haven’t added tests yet—I’d like to get approval on the code before proceeding with them.
- I used a lighter gray as the container’s background color. I tried using orange, but it felt too distracting on the screen. That's why i added the warning icon.
- I am not sure how good is to have directly pasted icon in the elm code. I can remove it and replace it with an alternative if needed.



## Release Note
By using the `fly` commands `set-wall, get-wall, and clear-wall`, we can easily manage a broadcast message that appears at the top of the page.

<img width="1271" height="1195" alt="broadcast_message" src="https://github.com/user-attachments/assets/2a0c40a1-3c1d-43cb-bbad-34eee810a720" />
