### PR TITLE
Fix error logging level for missing resource in ListJobInputs

### DIFF
--- a/atc/api/jobserver/list_inputs.go
+++ b/atc/api/jobserver/list_inputs.go
@@ -2,8 +2,10 @@ package jobserver
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
+	"code.cloudfoundry.org/lager/v3"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/present"
 	"github.com/concourse/concourse/atc/db"
@@ -68,7 +70,7 @@ func (s *Server) ListJobInputs(pipeline db.Pipeline) http.Handler {
 
 			resource, found := resources.Lookup(config.Resource)
 			if !found {
-				logger.Debug("resource-is-not-found")
+				logger.Error("resource-not-found", errors.New("resource-not-found"), lager.Data{"resource": config.Resource})
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}


### PR DESCRIPTION
Change log level from Debug to Error when a required resource cannot be found during job input listing. This is a legitimate error condition that should be visible in production logs for debugging failed requests.

A missing resource causes the endpoint to return 500 Internal Server Error, which warrants error-level logging rather than debug-level.