### PR TITLE
chore: correct spelling of 'CLI' throughout the codebase

### DIFF
--- a/testflight/download_cli_test.go
+++ b/testflight/download_cli_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("Download Fly Cli", func() {
+var _ = Describe("Download Fly CLI", func() {
 	var beforeFly string
 
 	BeforeEach(func() {
@@ -27,7 +27,7 @@ var _ = Describe("Download Fly Cli", func() {
 		config.FlyBin = beforeFly
 	})
 
-	It("can download fly cli without issue", func() {
+	It("can download fly CLI without issue", func() {
 		watch := fly("sync", "--force")
 		Expect(watch).ToNot(gbytes.Say("warning: failed to parse Content-Length"))
 		Expect(watch).To(gbytes.Say("done"))

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1223,7 +1223,7 @@ welcomeCard session =
                         [ href "/download-fly"
                         , style "text-decoration" "underline"
                         ]
-                        [ Html.text "download the fly cli" ]
+                        [ Html.text "download the fly CLI" ]
                     ]
                 ]
             , Html.div

--- a/web/elm/src/Dashboard/Footer.elm
+++ b/web/elm/src/Dashboard/Footer.elm
@@ -207,7 +207,7 @@ concourseInfo { version } =
                 , style "display" "flex"
                 ]
                 [ Html.div Styles.consoleIcon []
-                , Html.text "Download fly cli"
+                , Html.text "Download fly CLI"
                 ]
             ]
         , Html.div

--- a/web/elm/src/DownloadFly/DownloadFly.elm
+++ b/web/elm/src/DownloadFly/DownloadFly.elm
@@ -64,7 +64,7 @@ init route =
 
 documentTitle : String
 documentTitle =
-    "Download fly cli"
+    "Download fly CLI"
 
 
 view : Session -> Model -> Html Message

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -634,7 +634,7 @@ viewSubPage session model =
                             , style "display" "flex"
                             ]
                             [ Html.div Styles.consoleIcon []
-                            , Html.text "Download fly cli"
+                            , Html.text "Download fly CLI"
                             ]
                         ]
                     ]

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -1684,7 +1684,7 @@ all =
                                 |> Query.index 1
                                 |> Query.has [ text "Docs" ]
                     ]
-                , describe "download fly cli footer link" <|
+                , describe "download fly CLI footer link" <|
                     let
                         downloadFlyLink =
                             info
@@ -1720,14 +1720,14 @@ all =
                                     , style "height" "20px"
                                     , style "margin-right" "5px"
                                     ]
-                    , test "has the text 'Download fly cli'" <|
+                    , test "has the text 'Download fly CLI'" <|
                         \_ ->
                             downloadFlyLink
                                 |> Query.children []
                                 |> Query.index 0
                                 |> Query.children []
                                 |> Query.index 1
-                                |> Query.has [ text "Download fly cli" ]
+                                |> Query.has [ text "Download fly CLI" ]
                     ]
                 , test "shows concourse version" <|
                     \_ ->

--- a/web/elm/tests/DownloadFlyTests.elm
+++ b/web/elm/tests/DownloadFlyTests.elm
@@ -21,7 +21,7 @@ all =
                 Common.initRoute Routes.DownloadFly
                     |> Application.view
                     |> .title
-                    |> Expect.equal "Download fly cli - Concourse"
+                    |> Expect.equal "Download fly CLI - Concourse"
         , test "does not show install steps on init" <|
             \_ ->
                 Common.initRoute Routes.DownloadFly

--- a/web/elm/tests/WelcomeCardTests.elm
+++ b/web/elm/tests/WelcomeCardTests.elm
@@ -196,10 +196,10 @@ hasWelcomeCard setup =
                     >> Query.children []
                     >> Query.index 0
                     >> Query.has [ text instruction ]
-            , test "has 'download fly cli' as a link to '/download-fly'" <|
+            , test "has 'download fly CLI' as a link to '/download-fly'" <|
                 let
                     instruction =
-                        "download the fly cli"
+                        "download the fly CLI"
 
                     link =
                         "/download-fly"


### PR DESCRIPTION
This PR standardizes the spelling and capitalization of "CLI" (Command Line Interface) across the entire codebase for consistency and maintainability.
