### PR TITLE
Update MD5 hashing migration to handle empty versions

### DIFF
--- a/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.down.sql
+++ b/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.down.sql
@@ -50,9 +50,12 @@ WITH json_string_cte AS (
     SELECT 
         rcv.id,
         rcv.version_md5 AS old_version_md5,
-        '{' || string_agg('"' || kv.key || '":"' || kv.value || '"', ',' ORDER BY kv.key) || '}' AS json_string
+        COALESCE(
+            '{' || string_agg('"' || kv.key || '":"' || kv.value || '"', ',' ORDER BY kv.key) || '}',
+            '{}'
+        ) AS json_string
     FROM resource_config_versions rcv
-    JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true
+    LEFT JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true
     WHERE jsonb_typeof(rcv.version::jsonb) = 'object'
     GROUP BY rcv.id, rcv.version_md5
 ),

--- a/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.up.sql
+++ b/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.up.sql
@@ -53,9 +53,12 @@ WITH json_string_cte AS (
     SELECT 
         rcv.id,
         rcv.version_sha256 AS old_version_sha256,
-        '{' || string_agg('"' || kv.key || '":"' || kv.value || '"', ',' ORDER BY kv.key) || '}' AS json_string
+        COALESCE(
+            '{' || string_agg('"' || kv.key || '":"' || kv.value || '"', ',' ORDER BY kv.key) || '}',
+            '{}'
+        ) AS json_string
     FROM resource_config_versions rcv
-    JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true
+    LEFT JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true
     WHERE jsonb_typeof(rcv.version::jsonb) = 'object'
     GROUP BY rcv.id, rcv.version_sha256
 ),


### PR DESCRIPTION
## Changes proposed by this PR

This PR updates the MD5 hashing migration to correctly handle and migrate empty versions (`{}`). 

closes #9280
related #9165

## Notes to reviewer

I've used sample pipeline from https://github.com/concourse/concourse/pull/9165#issuecomment-3254740682 to validate it:
```yml
resource_types:
  - name: mock-empty
    type: registry-image
    source:
      repository: concourseteam/mock-resource
      tag: empty-version

resources:
  - name: mock
    type: mock-empty

jobs:
  - name: job
    plan:
      - get: mock
```