### PR TITLE
Prevent resources from emitting empty versions

### DIFF
--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -261,7 +261,7 @@ func (r *resourceConfigScope) UpdateLastCheckEndTime(succeeded bool) (bool, erro
 
 func saveResourceVersion(tx Tx, rcsID int, version atc.Version, metadata ResourceConfigMetadataFields, spanContext SpanContext) (bool, error) {
 	if len(version) == 0 {
-		return false, errors.New("resource output version is missing")
+		return false, errors.New("resource output version is empty. Version must contain at least one key-value pair")
 	}
 
 	versionJSON, err := json.Marshal(version)

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -259,6 +260,10 @@ func (r *resourceConfigScope) UpdateLastCheckEndTime(succeeded bool) (bool, erro
 }
 
 func saveResourceVersion(tx Tx, rcsID int, version atc.Version, metadata ResourceConfigMetadataFields, spanContext SpanContext) (bool, error) {
+	if len(version) == 0 {
+		return false, errors.New("resource output version is missing")
+	}
+
 	versionJSON, err := json.Marshal(version)
 	if err != nil {
 		return false, err

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Resource Config Scope", func() {
 
 				err := resourceScope.SaveVersions(nil, emptyVersions)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("resource output version is missing"))
+				Expect(err.Error()).To(ContainSubstring("resource output version is empty. Version must contain at least one key-value pair"))
 			})
 		})
 	})

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -188,6 +188,17 @@ var _ = Describe("Resource Config Scope", func() {
 				})
 			})
 		})
+		Context("when a version is empty", func() {
+			It("returns an error", func() {
+				emptyVersions := []atc.Version{
+					{},
+				}
+
+				err := resourceScope.SaveVersions(nil, emptyVersions)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("resource output version is missing"))
+			})
+		})
 	})
 
 	Describe("LatestVersion", func() {


### PR DESCRIPTION

## Changes proposed by this PR

closes #9279

Resources should not be allowed to emit empty versions (`{}`). Currently, Concourse accepts them, which results in confusing behavior:

- They render in the UI as a blank/empty rectangle.
- They are stored in the database as {}, which has no semantic meaning.

This PR filters out empty versions before they are persisted and provide a clear error message in the UI, so users know their resource is misconfigured and can update its configuration.

## Notes to reviewer

To validate it:
1. Add it to a pipeline:
```yml
resource_types:
  - name: mock-empty
    type: registry-image
    source:
      repository: concourseteam/mock-resource
      tag: empty-version

resources:
  - name: mock
    type: mock-empty

jobs:
  - name: job
    plan:
      - get: mock
```
2. Output:
<img width="690" height="255" alt="image" src="https://github.com/user-attachments/assets/8a47c33e-a35c-47a1-8908-b6e36076088d" />

