### PR TITLE
Add ptrace syscall to seccomp profile. Kernel requirement >= 4.8. 

### DIFF
--- a/worker/runtime/spec/seccomp.go
+++ b/worker/runtime/spec/seccomp.go
@@ -232,6 +232,7 @@ var seccomp = &specs.LinuxSeccomp{
 				"process_mrelease",
 				"pselect6",
 				"pselect6_time64",
+				"ptrace",
 				"pwrite64",
 				"pwritev",
 				"pwritev2",


### PR DESCRIPTION
Resolves #9174.
