### PR TITLE
skip container limits test when using guardian runtime

### DIFF
--- a/testflight/container_limits_test.go
+++ b/testflight/container_limits_test.go
@@ -29,6 +29,10 @@ var _ = Describe("A job with a task that has container limits", func() {
 	})
 
 	It("sets the correct CPU and memory limits on the container", func() {
+		if config.Runtime == "guardian" && cgroupsV2Only() {
+			Skip("guardian runtime doesn't mount /sys/fs/cgroup on systems only using cgroup V2. See https://github.com/cloudfoundry/garden-runc-release/issues/384")
+		}
+
 		setAndUnpausePipeline("fixtures/container_limits_failing.yml")
 
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-limits-failing-job"), "-w")

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -383,6 +383,11 @@ func withFlyTarget(target string, f func()) {
 
 // Returns true if only cgroups V2 is enabled and cgroups V1 is disabled
 func cgroupsV2Only() bool {
+	if runtime.GOOS != "linux" {
+		// likely running testflight on a Docker VM on Windows/macOS where only
+		// cgroups V2 is enabled
+		return true
+	}
 	_, err := os.Stat("/sys/fs/cgroup/cgroup.controllers")
 	return err == nil
 }

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -380,3 +380,9 @@ func withFlyTarget(target string, f func()) {
 	f()
 	flyTarget = before
 }
+
+// Returns true if only cgroups V2 is enabled and cgroups V1 is disabled
+func cgroupsV2Only() bool {
+	_, err := os.Stat("/sys/fs/cgroup/cgroup.controllers")
+	return err == nil
+}


### PR DESCRIPTION
on systems with only cgroup v2 enabled.

See upstream issue https://github.com/cloudfoundry/garden-runc-release/issues/384