### PR TITLE
Fix overlay driver metacopy detection for kernels without support

### DIFF
--- a/worker/baggageclaim/volume/driver/overlay_linux.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux.go
@@ -25,11 +25,8 @@ func init() {
 // file then it will not create a copy of the file. Files will only be copied
 // when they are written to.
 func metacopySupported() bool {
-	_, err := os.Stat("/sys/module/overlay/parameters/metacopy")
-	if err != nil {
-		return !errors.Is(err, os.ErrNotExist)
-	}
-	return true
+	data, err := os.ReadFile("/sys/module/overlay/parameters/metacopy")
+	return err == nil && len(data) > 0 && data[0] == 'Y'
 }
 
 type OverlayDriver struct {


### PR DESCRIPTION
Previously checked only for file existence, not actual enablement. Now reads /sys/module/overlay/parameters/metacopy and verifies it contains 'Y' before using metacopy=on mount option.

Fixes mount failures on systems with CONFIG_OVERLAY_FS_METACOPY unset.
