### PR TITLE
fix: use tolerance for scroll bottom detection to prevent auto-scrolling breaking

### DIFF
--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -478,7 +478,7 @@ update msg ( model, effects ) =
         Scrolled { scrollHeight, scrollTop, clientHeight } ->
             ( { model
                 | autoScroll =
-                    (scrollHeight == scrollTop + clientHeight)
+                    (scrollHeight - (scrollTop + clientHeight) <= 1)
                         && not model.isScrollToIdInProgress
               }
             , effects

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1050,9 +1050,9 @@ all =
                     |> Application.update
                         (Msgs.Update <|
                             Message.Message.Scrolled
-                                { scrollHeight = 2
+                                { scrollHeight = 10
                                 , scrollTop = 0
-                                , clientHeight = 1
+                                , clientHeight = 5
                                 }
                         )
                     |> Tuple.first


### PR DESCRIPTION
The exact equality check for detecting scroll position at bottom was failing due to sub-pixel rounding differences between scrollHeight, scrollTop, and clientHeight. This caused autoScroll to incorrectly disable during rapid content updates.

Added 1px tolerance to account for browser rounding behavior.
