### PR TITLE
Fix inconsistent time handling: standardize on PostgreSQL now()

### DIFF
--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -444,7 +444,7 @@ func (j *job) Pause(pausedBy string) error {
 
 	_, err := psql.Update("jobs").
 		Set("paused", true).
-		Set("paused_at", time.Now()).
+		Set("paused_at", sq.Expr("now()")).
 		Set("paused_by", pausedBy).
 		Where(sq.Eq{"id": j.id, "paused": false}).
 		RunWith(j.conn).

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -1,9 +1,9 @@
 package db
 
 import (
-	"errors"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -660,7 +660,7 @@ func (p *pipeline) Dashboard() ([]atc.JobSummary, error) {
 func (p *pipeline) Pause(pausedBy string) error {
 	_, err := psql.Update("pipelines").
 		Set("paused", true).
-		Set("paused_at", time.Now()).
+		Set("paused_at", sq.Expr("now()")).
 		Set("paused_by", pausedBy).
 		Where(sq.Eq{"id": p.id, "paused": false}).
 		RunWith(p.conn).
@@ -722,7 +722,7 @@ func (p *pipeline) archive(tx Tx) error {
 		Set("last_updated", sq.Expr("now()")).
 		Set("paused", true).
 		Set("paused_by", "automatic-pipeline-archiver").
-		Set("paused_at", time.Now()).
+		Set("paused_at", sq.Expr("now()")).
 		Set("version", 0).
 		Where(sq.Eq{"id": p.id}).
 		RunWith(tx).


### PR DESCRIPTION
Replace application-side time.Now() calls with database-side now() for all timestamp columns to ensure consistency within transactions and eliminate clock skew issues.