### PR TITLE
fix: correct LockTypeBuildTracking to factoryBuildTracking mapping

### DIFF
--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -49,8 +49,8 @@ func mapLockTypeToFactory(lockType int) int {
 		return factoryResourceConfigChecking
 	case LockTypeInMemoryCheckBuildTracking:
 		return factoryInMemoryCheckBuildTracking
-	case factoryBuildTracking:
-		return LockTypeBuildTracking
+	case LockTypeBuildTracking:
+		return factoryBuildTracking
 	case LockTypeJobScheduling:
 		return factoryJobScheduling
 	default:


### PR DESCRIPTION
The mapLockTypeToFactory switch statement had the case condition and return value reversed for build tracking locks. It was checking for factoryBuildTracking (factory index) instead of LockTypeBuildTracking (lock type), and returning the wrong value.
