### PR TITLE
fix: close SQL result sets immediately in JobsToSchedule loop

### DIFF
--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -102,6 +102,8 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 		return nil, err
 	}
 
+	es := j.conn.EncryptionStrategy()
+
 	var schedulerJobs SchedulerJobs
 	pipelineResourceTypes := make(map[int]ResourceTypes)
 	pipelinePrototypes := make(map[int]Prototypes)
@@ -130,8 +132,6 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 				return nil, err
 			}
 
-			es := j.conn.EncryptionStrategy()
-
 			var noncense *string
 			if nonce.Valid {
 				noncense = &nonce.String
@@ -155,6 +155,11 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 				ExposeBuildCreatedBy: config.ExposeBuildCreatedBy,
 			})
 		}
+		if err = resourceRows.Err(); err != nil {
+			resourceRows.Close()
+			return nil, err
+		}
+		resourceRows.Close()
 
 		resourceTypes, found := pipelineResourceTypes[job.PipelineID()]
 		if !found {
@@ -177,6 +182,11 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 
 				resourceTypes = append(resourceTypes, resourceType)
 			}
+			if err = resourceTypeRows.Err(); err != nil {
+				resourceTypeRows.Close()
+				return nil, err
+			}
+			resourceTypeRows.Close()
 
 			pipelineResourceTypes[job.PipelineID()] = resourceTypes
 		}
@@ -202,6 +212,11 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 
 				prototypes = append(prototypes, prototype)
 			}
+			if err = prototypeRows.Err(); err != nil {
+				prototypeRows.Close()
+				return nil, err
+			}
+			prototypeRows.Close()
 
 			pipelinePrototypes[job.PipelineID()] = prototypes
 		}


### PR DESCRIPTION
The JobsToSchedule method was using defer Close() inside the job iteration loop, causing all result sets to remain open until function completion. With many jobs to schedule, this exhausts database connections and memory.

Changed to close resourceRows, resourceTypeRows, and prototypeRows immediately after processing each job instead of deferring closure until function return. Added rows.Err() checks after each iteration loop for defensive error handling.
