### PR TITLE
fix: prevent panic in teams cache when notification listener fails

### DIFF
--- a/atc/api/accessor/teams_cacher.go
+++ b/atc/api/accessor/teams_cacher.go
@@ -60,6 +60,7 @@ func (c *teamsCacher) waitForNotifications() {
 	notifier, err := c.notifications.Listen(atc.TeamCacheChannel, 1)
 	if err != nil {
 		c.logger.Error("failed-to-listen-for-team-cache", err)
+		return
 	}
 
 	defer c.notifications.Unlisten(atc.TeamCacheChannel, notifier)


### PR DESCRIPTION
Return early from waitForNotifications goroutine if Listen() returns an error, avoiding nil channel dereference panic in the receive loop.
