### PR TITLE
fix: use case-insensitive comparison for cloudfoundry connector normalization

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -95,7 +95,7 @@ func contains(arr []string, val string) bool {
 func (a *access) rolesForTeam(auth atc.TeamAuth) []string {
 	connectorID := a.connectorID()
 
-	if connectorID == "cloudfoundry" {
+	if strings.EqualFold(connectorID, "cloudfoundry") {
 		connectorID = "cf"
 	}
 


### PR DESCRIPTION
Use strings.EqualFold instead of == when checking if connector is "cloudfoundry" to ensure consistent case-insensitive behavior with the rest of the auth matching logic in roleOnTeam.
