### PR TITLE
Fix SVG styling inheritance on Chrome >= v141

### DIFF
--- a/web/assets/css/svg.less
+++ b/web/assets/css/svg.less
@@ -1,10 +1,5 @@
 @import (reference) "_vars.less";
 
-svg {
-  width: 100%;
-  height: 100%;
-}
-
 svg.causality-graph {
   position: absolute;
   .node text {

--- a/web/assets/css/svg.less
+++ b/web/assets/css/svg.less
@@ -7,6 +7,8 @@ svg:root {
 
 svg.causality-graph {
   position: absolute;
+  width: 100%;
+  height: 100%;
   .node text {
     font-family: 'Inconsolata';
     letter-spacing: 1pt;

--- a/web/assets/css/svg.less
+++ b/web/assets/css/svg.less
@@ -1,5 +1,10 @@
 @import (reference) "_vars.less";
 
+svg:root {
+  width: 100%;
+  height: 100%;
+}
+
 svg.causality-graph {
   position: absolute;
   .node text {
@@ -10,6 +15,8 @@ svg.causality-graph {
 
 svg.pipeline-graph {
   position: absolute;
+  width: 100%;
+  height: 100%;
   h1 {
     margin: 5px;
     width: 100%;


### PR DESCRIPTION
~~🚧 Untested!~~ Fixes #9307

I was looking into #9307, and am not sure if this is a Chrome bug introduced in 141, or if this is enforcing some niche webspec that makes Chromium an outlier.

In devtools, if I remove the svg css snippet below (`width: 100%; height: 100%`) then the icons render at their normal size.

I haven't testing this change, and am not sure what knock-on effects there could be, but from a quick glance around concourse it looks fine.

---

Edit from @taylorsilva 
See https://github.com/concourse/concourse/issues/9307#issuecomment-3368141042 for a few more details. Thanks go to the Chrome maintainers for helping nudge us towards this final fix.