### PR TITLE
feat: display team name in set_pipeline step header

### DIFF
--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -102,7 +102,7 @@ init buildId hl resources plan =
         Concourse.BuildStepArtifactOutput _ ->
             step |> initBottom buildId hl resources plan ArtifactOutput
 
-        Concourse.BuildStepSetPipeline _ _ ->
+        Concourse.BuildStepSetPipeline _ _ _ ->
             step |> initBottom buildId hl resources plan SetPipeline
 
         Concourse.BuildStepLoadVar _ ->
@@ -1247,17 +1247,25 @@ viewStepHeader step =
         Concourse.BuildStepTask name ->
             simpleHeader "task:" Nothing name
 
-        Concourse.BuildStepSetPipeline name instanceVars ->
-            headerWithContent "set_pipeline:" (Just "pipeline config changed") <|
-                Html.span [] [ Html.text name ]
-                    :: (if Dict.isEmpty instanceVars then
-                            []
-
-                        else
-                            [ Html.span [ style "margin-left" "10px", style "margin-right" "4px" ] [ Html.text "/" ]
-                            , viewKeyValuePairHeaderLabels (Dict.toList instanceVars)
+        Concourse.BuildStepSetPipeline name team instanceVars ->
+            headerWithContent "set_pipeline:" (Just "pipeline config changed")
+                ([Html.span [] [ Html.text name ]]
+                 ++ (case team of
+                        Just teamName ->
+                            [ Html.span [ style "color" Colors.pending, style "margin-left" "10px", style "margin-right" "4px" ] [ Html.text "team:" ]
+                            , Html.text teamName
                             ]
-                       )
+
+                        Nothing ->
+                            []
+                    )
+                ++ (if Dict.isEmpty instanceVars then
+                    []
+                 else
+                    [ Html.span [ style "margin-left" "10px", style "margin-right" "4px" ] [ Html.text "/" ]
+                    , viewKeyValuePairHeaderLabels (Dict.toList instanceVars)
+                    ]
+                ))
 
         Concourse.BuildStepLoadVar name ->
             simpleHeader "load_var:" Nothing name
@@ -1323,7 +1331,7 @@ stepName header =
         Concourse.BuildStepTask name ->
             Just name
 
-        Concourse.BuildStepSetPipeline name _ ->
+        Concourse.BuildStepSetPipeline name _ _ ->
             Just name
 
         Concourse.BuildStepLoadVar name ->

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -1249,8 +1249,8 @@ viewStepHeader step =
 
         Concourse.BuildStepSetPipeline name team instanceVars ->
             headerWithContent "set_pipeline:" (Just "pipeline config changed")
-                ([Html.span [] [ Html.text name ]]
-                 ++ (case team of
+                (Html.span [] [ Html.text name ]
+                 :: (case team of
                         Just teamName ->
                             [ Html.span [ style "color" Colors.pending, style "margin-left" "10px", style "margin-right" "4px" ] [ Html.text "team:" ]
                             , Html.text teamName

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -393,7 +393,7 @@ mapBuildPlan fn plan =
                 BuildStepTask _ ->
                     []
 
-                BuildStepSetPipeline _ _ ->
+                BuildStepSetPipeline _ _ _ ->
                     []
 
                 BuildStepLoadVar _ ->
@@ -487,7 +487,7 @@ type alias ImageBuildPlans =
 
 type BuildStep
     = BuildStepTask StepName
-    | BuildStepSetPipeline StepName InstanceVars
+    | BuildStepSetPipeline StepName (Maybe TeamName) InstanceVars
     | BuildStepLoadVar StepName
     | BuildStepArtifactInput StepName
     | BuildStepCheck StepName (Maybe ImageBuildPlans)
@@ -852,6 +852,12 @@ decodeBuildSetPipeline : Json.Decode.Decoder BuildStep
 decodeBuildSetPipeline =
     Json.Decode.succeed BuildStepSetPipeline
         |> andMap (Json.Decode.field "name" Json.Decode.string)
+        |> andMap (Json.Decode.maybe (Json.Decode.field "team" Json.Decode.string)
+                    |> Json.Decode.map (\maybeTeam ->
+                        case maybeTeam of
+                            Just "" -> Nothing
+                            other -> other
+                       ))
         |> andMap (defaultTo Dict.empty <| Json.Decode.field "instance_vars" decodeInstanceVars)
 
 

--- a/web/elm/tests/BuildStepTests.elm
+++ b/web/elm/tests/BuildStepTests.elm
@@ -438,6 +438,11 @@ all =
                     >> given theSetPipelineStepIsExpanded
                     >> when iAmLookingAtTheStepBody
                     >> then_ iSeeThePipelineName
+            , test "should show team name when specified" <|
+                given iVisitABuildWithASetPipelineStepWithTeamName
+                    >> given theSetPipelineStepIsExpanded
+                    >> when iAmLookingAtTheStepBody
+                    >> then_ iSeeTheTeamName
             , test "should show instance vars when they exist" <|
                 given iVisitABuildWithASetPipelineStepWithInstanceVars
                     >> given theSetPipelineStepIsExpanded
@@ -621,6 +626,12 @@ iVisitABuildWithASetPipelineStep =
     iOpenTheBuildPage
         >> myBrowserFetchedTheBuild
         >> thePlanContainsASetPipelineStep
+
+
+iVisitABuildWithASetPipelineStepWithTeamName =
+    iOpenTheBuildPage
+        >> myBrowserFetchedTheBuild
+        >> thePlanContainsASetPipelineStepWithTeamName
 
 
 iVisitABuildWithASetPipelineStepWithInstanceVars =
@@ -938,7 +949,22 @@ thePlanContainsASetPipelineStep =
             (Callback.PlanAndResourcesFetched 1 <|
                 Ok
                     ( { id = setPipelineStepId
-                      , step = Concourse.BuildStepSetPipeline "pipeline-name" Dict.empty
+                      , step = Concourse.BuildStepSetPipeline "pipeline-name" Nothing Dict.empty
+                      }
+                    , { inputs = []
+                      , outputs = []
+                      }
+                    )
+            )
+
+
+thePlanContainsASetPipelineStepWithTeamName =
+    Tuple.first
+        >> Application.handleCallback
+            (Callback.PlanAndResourcesFetched 1 <|
+                Ok
+                    ( { id = setPipelineStepId
+                      , step = Concourse.BuildStepSetPipeline "pipeline-name" (Just "team-name") Dict.empty
                       }
                     , { inputs = []
                       , outputs = []
@@ -954,7 +980,7 @@ thePlanContainsASetPipelineStepWithInstanceVars =
                 Ok
                     ( { id = setPipelineStepId
                       , step =
-                            Concourse.BuildStepSetPipeline "pipeline-name" <|
+                            Concourse.BuildStepSetPipeline "pipeline-name" Nothing <|
                                 Dict.fromList
                                     [ ( "foo", JsonString "bar" ), ( "a", JsonObject [ ( "b", JsonNumber 1 ) ] ) ]
                       }
@@ -1362,6 +1388,10 @@ iSeeATimestamp =
 
 iSeeThePipelineName =
     Query.has [ text "pipeline-name" ]
+
+
+iSeeTheTeamName =
+    Query.has [ text "team-name" ]
 
 
 iSeeTheInstanceVars =

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -2746,6 +2746,7 @@ all =
                                           , step =
                                                 Concourse.BuildStepSetPipeline
                                                     "step"
+                                                    Nothing
                                                     Dict.empty
                                           }
                                         , { inputs = [], outputs = [] }

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -120,7 +120,7 @@ initSetPipeline : Test
 initSetPipeline =
     let
         step =
-            BuildStepSetPipeline "some-name" Dict.empty
+            BuildStepSetPipeline "some-name" Nothing Dict.empty
 
         { tree, steps } =
             StepTree.init Nothing


### PR DESCRIPTION
Add team field to BuildStepSetPipeline type and display it in the step header after the pipeline name when specified. Backend already sends the team field; frontend was ignoring it.

Fixes #9255