### PR TITLE
Fix active_tasks going negative when MaxTasks == 0

### DIFF
--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -339,7 +339,7 @@ func (strategy limitActiveTasksStrategy) Approve(logger lager.Logger, worker db.
 }
 
 func (strategy limitActiveTasksStrategy) Release(logger lager.Logger, worker db.Worker, spec runtime.ContainerSpec) {
-	if spec.Type != db.ContainerTypeTask {
+	if spec.Type != db.ContainerTypeTask || strategy.MaxTasks == 0 {
 		return
 	}
 


### PR DESCRIPTION
Release() decremented without matching increment when MaxTasks == 0. Add same guard to Release() that exists in Approve().

Fixes logs like:
ERROR: new row for relation \"workers\" violates check constraint \"workers_active_tasks_check\"

