### PR TITLE
fix: only set scrolledToCurrentBuild flag when actually scrolling to current build

### DIFF
--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -525,7 +525,10 @@ handleDelivery delivery ( model, effects ) =
                 shouldScroll =
                     currentBuildInvisible && not model.scrolledToCurrentBuild
             in
-            ( { model | scrolledToCurrentBuild = True }
+            ( if shouldScroll then
+                  { model | scrolledToCurrentBuild = True }
+              else
+                  model
             , effects
                 ++ (if shouldScroll then
                         [ Scroll (ToId id) historyId ]


### PR DESCRIPTION
The flag was being set unconditionally whenever any element became invisible, preventing auto-scroll to the current build when directly navigating to old builds via URL.
