### PR TITLE
Fix HTML injection vulnerability in build names (causality graph)

### DIFF
--- a/web/elm/src/Causality/Causality.elm
+++ b/web/elm/src/Causality/Causality.elm
@@ -510,7 +510,7 @@ graphvizDotNotation model =
                                     Routes.Build { id = build, highlight = Routes.HighlightNothing, groups = [] }
                                         |> Routes.toString
                             in
-                            row (attributes [ ( "HREF", link ), ( "BGCOLOR", buildStatusColor True b.status ) ]) ("#" ++ b.name)
+                            row (attributes [ ( "HREF", link ), ( "BGCOLOR", buildStatusColor True b.status ) ]) ("#" ++ escape b.name)
                         )
                         builds
 


### PR DESCRIPTION
Escape build names in causality graph job labels to prevent HTML/XSS injection. Build names containing <, >, &, ", or ' characters were being rendered unescaped, breaking the GraphViz HTML table structure.