### PR TITLE
allow CDN caching for hashed static assets

### DIFF
--- a/web/cache_handler.go
+++ b/web/cache_handler.go
@@ -11,7 +11,7 @@ const yearInSeconds = 31536000
 
 func CacheNearlyForever(handler http.Handler) http.Handler {
 	withoutGz := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, private", yearInSeconds))
+		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public, immutable", yearInSeconds))
 		handler.ServeHTTP(w, r)
 	})
 	return gzhttp.GzipHandler(withoutGz)

--- a/web/cache_handler_test.go
+++ b/web/cache_handler_test.go
@@ -28,7 +28,7 @@ var _ = Describe("CacheNearlyForever", func() {
 		wrappedHandler.ServeHTTP(recorder, request) // request is never used
 
 		Expect(recorder.Body.String()).To(Equal("The wrapped handler was called!"))
-		Expect(recorder.Header().Get("Cache-Control")).To(Equal("max-age=31536000, private"))
+		Expect(recorder.Header().Get("Cache-Control")).To(Equal("max-age=31536000, public, immutable"))
 		Expect(recorder.Header().Get("Content-Encoding")).ToNot(Equal("gzip"))
 	})
 


### PR DESCRIPTION
Replace "private" with "public, immutable" in Cache-Control header. Assets use content hashing, safe for aggressive caching.