### PR TITLE
Nit: Remove sha1 usage and make task pwd less predictable

### DIFF
--- a/atc/engine/log_event_writer.go
+++ b/atc/engine/log_event_writer.go
@@ -90,7 +90,7 @@ func (writer *dbEventWriterWithSecretRedaction) Write(data []byte) (int, error) 
 			return len(data), nil
 		}
 	} else {
-		if writer.dangling == nil || len(writer.dangling) == 0 {
+		if len(writer.dangling) == 0 {
 			return 0, nil
 		}
 		text = writer.dangling

--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -1,7 +1,7 @@
 package engine
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -25,7 +25,7 @@ type coreStepFactory struct {
 	defaultLimits         atc.ContainerLimits
 	strategy              worker.PlacementStrategy
 	noInputStrategy       worker.PlacementStrategy
-	checkStrategy worker.PlacementStrategy
+	checkStrategy         worker.PlacementStrategy
 	defaultCheckTimeout   time.Duration
 	defaultGetTimeout     time.Duration
 	defaultPutTimeout     time.Duration
@@ -60,7 +60,7 @@ func NewCoreStepFactory(
 		defaultLimits:         defaultLimits,
 		strategy:              strategy,
 		noInputStrategy:       noInputStrategy,
-		checkStrategy: checkStrategy,
+		checkStrategy:         checkStrategy,
 		defaultCheckTimeout:   defaultCheckTimeout,
 		defaultGetTimeout:     defaultGetTimeout,
 		defaultPutTimeout:     defaultPutTimeout,
@@ -177,7 +177,7 @@ func (factory *coreStepFactory) TaskStep(
 	containerMetadata db.ContainerMetadata,
 	delegateFactory DelegateFactory,
 ) exec.Step {
-	sum := sha1.Sum([]byte(plan.Task.Name))
+	sum := sha256.Sum256(fmt.Appendf([]byte{}, "%d", time.Now().Unix()))
 	containerMetadata.WorkingDirectory = filepath.Join("/tmp", "build", fmt.Sprintf("%x", sum[:4]))
 
 	taskStep := exec.NewTaskStep(


### PR DESCRIPTION
## Changes proposed by this PR

users could determine the working dir of the task because it was based
on the sha1 of the task name. The intention has always been to encourage
users to not rely knowing the working dir of their tasks and write portable scripts.

This also removes usage of sha1 within the Go codebase of Concourse, though its usage here was fine.