### PR TITLE
Add `--non-interactive` flag to `clear-versions` command

### DIFF
--- a/fly/commands/clear_versions.go
+++ b/fly/commands/clear_versions.go
@@ -13,7 +13,7 @@ import (
 type ClearVersionsCommand struct {
 	Resource        flaghelpers.ResourceFlag `long:"resource" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear versions"`
 	ResourceType    flaghelpers.ResourceFlag `long:"resource-type" value-name:"PIPELINE/RESOURCE-TYPE" description:"Name of a resource type to clear versions"`
-	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Clear resource versions or resource type versions without confirmation"`
+	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Clear versions versions without confirmation"`
 }
 
 func (command *ClearVersionsCommand) Execute(args []string) error {

--- a/fly/commands/clear_versions.go
+++ b/fly/commands/clear_versions.go
@@ -14,7 +14,7 @@ import (
 type ClearVersionsCommand struct {
 	Resource        flaghelpers.ResourceFlag `long:"resource" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear versions"`
 	ResourceType    flaghelpers.ResourceFlag `long:"resource-type" value-name:"PIPELINE/RESOURCE-TYPE" description:"Name of a resource type to clear versions"`
-	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Clear versions without confirmation"`
+	SkipInteractive bool                     `short:"n" long:"non-interactive" description:"Clear versions without confirmation"`
 	Team            flaghelpers.TeamFlag     `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 

--- a/fly/commands/clear_versions.go
+++ b/fly/commands/clear_versions.go
@@ -11,8 +11,9 @@ import (
 )
 
 type ClearVersionsCommand struct {
-	Resource     flaghelpers.ResourceFlag `long:"resource" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear versions"`
-	ResourceType flaghelpers.ResourceFlag `long:"resource-type" value-name:"PIPELINE/RESOURCE-TYPE" description:"Name of a resource type to clear versions"`
+	Resource        flaghelpers.ResourceFlag `long:"resource" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear versions"`
+	ResourceType    flaghelpers.ResourceFlag `long:"resource-type" value-name:"PIPELINE/RESOURCE-TYPE" description:"Name of a resource type to clear versions"`
+	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Clear resource versions or resource type versions without confirmation"`
 }
 
 func (command *ClearVersionsCommand) Execute(args []string) error {
@@ -50,13 +51,15 @@ func (command *ClearVersionsCommand) Execute(args []string) error {
 			return fmt.Errorf("resource '%s' is not found", command.Resource.ResourceName)
 		}
 
-		confirmed, err := command.warningMessage(shared)
-		if err != nil {
-			return err
-		}
+		if !command.SkipInteractive {
+			confirmed, err := command.warningMessage(shared)
+			if err != nil {
+				return err
+			}
 
-		if !confirmed {
-			return nil
+			if !confirmed {
+				return nil
+			}
 		}
 
 		numDeleted, err := team.ClearResourceVersions(command.Resource.PipelineRef, command.Resource.ResourceName)
@@ -77,13 +80,15 @@ func (command *ClearVersionsCommand) Execute(args []string) error {
 			return fmt.Errorf("resource type '%s' is not found", command.ResourceType.ResourceName)
 		}
 
-		confirmed, err := command.warningMessage(shared)
-		if err != nil {
-			return err
-		}
+		if !command.SkipInteractive {
+			confirmed, err := command.warningMessage(shared)
+			if err != nil {
+				return err
+			}
 
-		if !confirmed {
-			return nil
+			if !confirmed {
+				return nil
+			}
 		}
 
 		numDeleted, err := team.ClearResourceTypeVersions(command.ResourceType.PipelineRef, command.ResourceType.ResourceName)

--- a/fly/commands/clear_versions.go
+++ b/fly/commands/clear_versions.go
@@ -13,7 +13,7 @@ import (
 type ClearVersionsCommand struct {
 	Resource        flaghelpers.ResourceFlag `long:"resource" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear versions"`
 	ResourceType    flaghelpers.ResourceFlag `long:"resource-type" value-name:"PIPELINE/RESOURCE-TYPE" description:"Name of a resource type to clear versions"`
-	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Clear versions versions without confirmation"`
+	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Clear versions without confirmation"`
 }
 
 func (command *ClearVersionsCommand) Execute(args []string) error {

--- a/fly/integration/clear_versions_test.go
+++ b/fly/integration/clear_versions_test.go
@@ -171,6 +171,20 @@ and the following resource types:
 					Eventually(sess).Should(gexec.Exit(1))
 				})
 			})
+
+			Context("when running in non-interactive mode", func() {
+				BeforeEach(func() {
+					args = append(args, "--non-interactive")
+					sharedResourcesStatus = http.StatusOK
+					deleteVersionsStatus = http.StatusOK
+				})
+
+				It("does not prompt the user", func() {
+					Consistently(sess).ShouldNot(gbytes.Say(`are you sure\?`))
+					Eventually(sess).Should(gbytes.Say("1 versions removed"))
+					Eventually(sess).Should(gexec.Exit(0))
+				})
+			})
 		})
 
 		Context("when a resource type is specified", func() {
@@ -285,6 +299,20 @@ and the following resource types:
 				It("fails to delete versions", func() {
 					Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
 					Eventually(sess).Should(gexec.Exit(1))
+				})
+			})
+
+			Context("when running in non-interactive mode", func() {
+				BeforeEach(func() {
+					args = append(args, "--non-interactive")
+					sharedResourcesStatus = http.StatusOK
+					deleteVersionsStatus = http.StatusOK
+				})
+
+				It("does not prompt the user", func() {
+					Consistently(sess).ShouldNot(gbytes.Say(`are you sure\?`))
+					Eventually(sess).Should(gbytes.Say("2 versions removed"))
+					Eventually(sess).Should(gexec.Exit(0))
 				})
 			})
 		})


### PR DESCRIPTION
## Changes proposed by this PR
Allow users to clear versions for a pipeline resource or resource type without being prompted for confirmation

* [x]  add non-interactive flag to `clear-versions`
* [x]  integration tests

## Release Note
* Added non-interactive flag to fly command clear-versions. Use:
  `fly -t dev clear-versions --resource=pipeline/resource --non-interactive`