### PR TITLE
Remove unused minMaxIdQuery

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -109,9 +109,6 @@ var buildsQuery = psql.Select(`
 	JoinClause("LEFT OUTER JOIN builds rb ON rb.id = b.rerun_of").
 	JoinClause("LEFT OUTER JOIN build_comments bc ON b.id = bc.build_id")
 
-var minMaxIdQuery = psql.Select("COALESCE(MAX(b.id), 0)", "COALESCE(MIN(b.id), 0)").
-	From("builds as b")
-
 var latestCompletedBuildQuery = psql.Select("max(id)").
 	From("builds").
 	Where(sq.Expr(`status NOT IN ('pending', 'started')`))

--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -159,26 +159,22 @@ func (f *buildFactory) VisibleBuilds(teamNames []string, page Page) ([]BuildForA
 		})
 
 	if page.UseDate {
-		return getBuildsWithDates(newBuildsQuery, minMaxIdQuery, page, f.conn,
+		return getBuildsWithDates(newBuildsQuery, page, f.conn,
 			f.lockFactory)
 	}
-	return getBuildsWithPagination(newBuildsQuery, minMaxIdQuery, page, f.conn,
-		f.lockFactory, false)
+	return getBuildsWithPagination(newBuildsQuery, page, f.conn, f.lockFactory, false)
 }
 
 func (f *buildFactory) AllBuilds(page Page) ([]BuildForAPI, Pagination, error) {
 	if page.UseDate {
-		return getBuildsWithDates(buildsQuery, minMaxIdQuery, page, f.conn,
-			f.lockFactory)
+		return getBuildsWithDates(buildsQuery, page, f.conn, f.lockFactory)
 	}
-	return getBuildsWithPagination(buildsQuery, minMaxIdQuery,
-		page, f.conn, f.lockFactory, false)
+	return getBuildsWithPagination(buildsQuery, page, f.conn, f.lockFactory, false)
 }
 
 func (f *buildFactory) PublicBuilds(page Page) ([]BuildForAPI, Pagination, error) {
 	return getBuildsWithPagination(
-		buildsQuery.Where(sq.Eq{"p.public": true}), minMaxIdQuery,
-		page, f.conn, f.lockFactory, false)
+		buildsQuery.Where(sq.Eq{"p.public": true}), page, f.conn, f.lockFactory, false)
 }
 
 func (f *buildFactory) MarkNonInterceptibleBuilds() error {
@@ -273,7 +269,7 @@ func getBuilds(buildsQuery sq.SelectBuilder, conn DbConn, lockFactory lock.LockF
 	return bs, nil
 }
 
-func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, conn DbConn, lockFactory lock.LockFactory) ([]BuildForAPI, Pagination, error) {
+func getBuildsWithDates(buildsQuery sq.SelectBuilder, page Page, conn DbConn, lockFactory lock.LockFactory) ([]BuildForAPI, Pagination, error) {
 	if page.From != nil {
 		buildsQuery = buildsQuery.Where(sq.Expr("b.start_time >= to_timestamp(?)", *page.From))
 	}
@@ -304,7 +300,7 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 	return builds, Pagination{}, nil
 }
 
-func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, conn DbConn, lockFactory lock.LockFactory, chronological bool) ([]BuildForAPI, Pagination, error) {
+func getBuildsWithPagination(buildsQuery sq.SelectBuilder, page Page, conn DbConn, lockFactory lock.LockFactory, chronological bool) ([]BuildForAPI, Pagination, error) {
 	var (
 		rows    *sql.Rows
 		err     error

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -552,37 +552,17 @@ func (j *job) UpdateFirstLoggedBuildID(newFirstLoggedBuildID int) error {
 
 func (j *job) BuildsWithTime(page Page) ([]BuildForAPI, Pagination, error) {
 	newBuildsQuery := buildsQuery.Where(sq.Eq{"j.id": j.id})
-	newMinMaxIdQuery := minMaxIdQuery.
-		Join("jobs j ON b.job_id = j.id").
-		Where(sq.Eq{
-			"j.name":        j.name,
-			"j.pipeline_id": j.pipelineID,
-		})
-	return getBuildsWithDates(newBuildsQuery, newMinMaxIdQuery, page, j.conn, j.lockFactory)
+	return getBuildsWithDates(newBuildsQuery, page, j.conn, j.lockFactory)
 }
 
 func (j *job) Builds(page Page) ([]BuildForAPI, Pagination, error) {
 	newBuildsQuery := buildsQuery.Where(sq.Eq{"j.id": j.id})
-	newMinMaxIdQuery := minMaxIdQuery.
-		Join("jobs j ON b.job_id = j.id").
-		Where(sq.Eq{
-			"j.name":        j.name,
-			"j.pipeline_id": j.pipelineID,
-		})
-
-	return getBuildsWithPagination(newBuildsQuery, newMinMaxIdQuery, page, j.conn, j.lockFactory, false)
+	return getBuildsWithPagination(newBuildsQuery, page, j.conn, j.lockFactory, false)
 }
 
 func (j *job) ChronoBuilds(page Page) ([]BuildForAPI, Pagination, error) {
 	newBuildsQuery := buildsQuery.Where(sq.Eq{"j.id": j.id})
-	newMinMaxIdQuery := minMaxIdQuery.
-		Join("jobs j ON b.job_id = j.id").
-		Where(sq.Eq{
-			"j.name":        j.name,
-			"j.pipeline_id": j.pipelineID,
-		})
-
-	return getBuildsWithPagination(newBuildsQuery, newMinMaxIdQuery, page, j.conn, j.lockFactory, true)
+	return getBuildsWithPagination(newBuildsQuery, page, j.conn, j.lockFactory, true)
 }
 
 func (j *job) Build(name string) (Build, bool, error) {

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -1,9 +1,9 @@
 package db
 
 import (
-	"errors"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -478,12 +478,12 @@ func (p *pipeline) resource(where map[string]any) (Resource, bool, error) {
 
 func (p *pipeline) Builds(page Page) ([]BuildForAPI, Pagination, error) {
 	return getBuildsWithPagination(
-		buildsQuery.Where(sq.Eq{"b.pipeline_id": p.id}), minMaxIdQuery, page, p.conn, p.lockFactory, false)
+		buildsQuery.Where(sq.Eq{"b.pipeline_id": p.id}), page, p.conn, p.lockFactory, false)
 }
 
 func (p *pipeline) BuildsWithTime(page Page) ([]BuildForAPI, Pagination, error) {
 	return getBuildsWithDates(
-		buildsQuery.Where(sq.Eq{"b.pipeline_id": p.id}), minMaxIdQuery, page, p.conn, p.lockFactory)
+		buildsQuery.Where(sq.Eq{"b.pipeline_id": p.id}), page, p.conn, p.lockFactory)
 }
 
 func (p *pipeline) Resources() (Resources, error) {

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -920,15 +920,15 @@ func (t *team) PrivateAndPublicBuilds(page Page) ([]BuildForAPI, Pagination, err
 	newBuildsQuery := buildsQuery.
 		Where(sq.Or{sq.Eq{"p.public": true}, sq.Eq{"t.id": t.id}})
 
-	return getBuildsWithPagination(newBuildsQuery, minMaxIdQuery, page, t.conn, t.lockFactory, false)
+	return getBuildsWithPagination(newBuildsQuery, page, t.conn, t.lockFactory, false)
 }
 
 func (t *team) BuildsWithTime(page Page) ([]BuildForAPI, Pagination, error) {
-	return getBuildsWithDates(buildsQuery.Where(sq.Eq{"t.id": t.id}), minMaxIdQuery, page, t.conn, t.lockFactory)
+	return getBuildsWithDates(buildsQuery.Where(sq.Eq{"t.id": t.id}), page, t.conn, t.lockFactory)
 }
 
 func (t *team) Builds(page Page) ([]BuildForAPI, Pagination, error) {
-	return getBuildsWithPagination(buildsQuery.Where(sq.Eq{"t.id": t.id}), minMaxIdQuery, page, t.conn, t.lockFactory, false)
+	return getBuildsWithPagination(buildsQuery.Where(sq.Eq{"t.id": t.id}), page, t.conn, t.lockFactory, false)
 }
 
 func (t *team) SaveWorker(atcWorker atc.Worker, ttl time.Duration) (Worker, error) {


### PR DESCRIPTION
Follow-up to #9298 which started as removing an unused parameter in a function and cascaded into deleting all this code. At some point we stopped actually using `minMaxIdQuery` and just didn't remove all the places we were passing it around.