### PR TITLE
Bump elm-ansi to 11.0.1 that fixes CursorColumn (CSI G) to use 1-based indexing as per ANSI spec.

### DIFF
--- a/web/elm/elm.json
+++ b/web/elm/elm.json
@@ -26,7 +26,7 @@
             "matthewsj/elm-ordering": "2.0.0",
             "ryan-haskell/date-format": "1.0.0",
             "truqu/elm-base64": "2.0.4",
-            "vito/elm-ansi": "11.0.0"
+            "vito/elm-ansi": "11.0.1"
         },
         "indirect": {
             "BrianHicks/elm-trend": "2.1.3",


### PR DESCRIPTION
Other fixes:
- Fix hyperlink URL parsing to preserve semicolons in URLs by only splitting on first two semicolons
- Fix non-ASCII character encoding in URLs to encode individual characters rather than entire string
