### PR TITLE
web: behaviour: use async XHR for fly login to fix browser shield blocking

### DIFF
--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -341,13 +341,10 @@ app.ports.rawHttpRequest.subscribe(function(url) {
     app.ports.rawHttpResponse.send('success');
   });
 
-  xhr.open('GET', url, false);
+  xhr.open('GET', url, true);
 
   try {
     xhr.send();
-    if (xhr.readyState === 1) {
-      app.ports.rawHttpResponse.send('browserError');
-    }
   } catch (error) {
     app.ports.rawHttpResponse.send('networkError');
   }


### PR DESCRIPTION
Synchronous XMLHttpRequest is deprecated and blocked by privacy-focused
browsers like Brave when shields are enabled. This prevented fly login
from retrieving the authentication token via the localhost callback.

Switch to asynchronous XHR which is compatible with modern browser
security features and still properly handled by existing event listeners.

Signed-off-by: ramonskie <ramonmakkelie@gmail.com>