### PR TITLE
Fix [containerd]: make container attach idempotent and handle exited processes gracefully

### DIFF
--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -24,8 +24,8 @@ const (
 	SuperuserPath = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	Path          = "PATH=/usr/local/bin:/usr/bin:/bin"
 
-	GraceTimeKey            = "garden.grace-time"
-	ContainerProcessExitKey = "garden.process-exit-code"
+	GraceTimeKey         = "garden.grace-time"
+	ProcessExitStatusKey = "garden.process-exit-status"
 )
 
 var (
@@ -492,7 +492,7 @@ func isNoSuchExecutable(err error) bool {
 }
 
 func (c *Container) lookupStoredExit() (int, bool) {
-	val, err := c.Property(ContainerProcessExitKey)
+	val, err := c.Property(ProcessExitStatusKey)
 	if err != nil || val == "" {
 		return 0, false
 	}

--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,7 +24,8 @@ const (
 	SuperuserPath = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 	Path          = "PATH=/usr/local/bin:/usr/bin:/bin"
 
-	GraceTimeKey = "garden.grace-time"
+	GraceTimeKey            = "garden.grace-time"
+	ContainerProcessExitKey = "garden.process-exit-code"
 )
 
 var (
@@ -175,7 +177,7 @@ func (c *Container) Run(
 		}
 	}
 
-	return NewProcess(proc, exitStatusC), nil
+	return NewProcess(proc, exitStatusC, *c), nil
 }
 
 // Attach starts streaming the output back to the client from a specified process.
@@ -215,6 +217,11 @@ func (c *Container) Attach(pid string, processIO garden.ProcessIO) (process gard
 	}
 
 	if lastErr != nil {
+		if errdefs.IsNotFound(lastErr) {
+			if code, ok := c.lookupStoredExit(); ok {
+				return NewFinishedProcess(pid, code), nil
+			}
+		}
 		return nil, fmt.Errorf("load proc: %w", lastErr)
 	}
 
@@ -232,7 +239,7 @@ func (c *Container) Attach(pid string, processIO garden.ProcessIO) (process gard
 		return nil, fmt.Errorf("proc wait: %w", err)
 	}
 
-	return NewProcess(proc, exitStatusC), nil
+	return NewProcess(proc, exitStatusC, *c), nil
 }
 
 // Properties returns the current set of properties
@@ -482,4 +489,16 @@ func containerdCIO(gdnProcIO garden.ProcessIO, tty bool) []cio.Opt {
 
 func isNoSuchExecutable(err error) bool {
 	return noSuchFile.MatchString(err.Error()) || executableNotFound.MatchString(err.Error())
+}
+
+func (c *Container) lookupStoredExit() (int, bool) {
+	val, err := c.Property(ContainerProcessExitKey)
+	if err != nil || val == "" {
+		return 0, false
+	}
+	code, convErr := strconv.Atoi(val)
+	if convErr != nil {
+		return 0, false
+	}
+	return code, true
 }

--- a/worker/runtime/finished_process.go
+++ b/worker/runtime/finished_process.go
@@ -6,16 +6,16 @@ import (
 	"code.cloudfoundry.org/garden"
 )
 
-type finishedProcess struct {
+type FinishedProcess struct {
 	id         string
 	exitStatus int
 }
 
 func NewFinishedProcess(id string, exitStatus int) garden.Process {
-	return &finishedProcess{id: id, exitStatus: exitStatus}
+	return &FinishedProcess{id: id, exitStatus: exitStatus}
 }
 
-func (p *finishedProcess) ID() string                        { return p.id }
-func (p *finishedProcess) Wait() (int, error)                { return p.exitStatus, nil }
-func (p *finishedProcess) SetTTY(garden.TTYSpec) error       { return nil }
-func (p *finishedProcess) Signal(signal garden.Signal) error { return ErrNotImplemented }
+func (p *FinishedProcess) ID() string                        { return p.id }
+func (p *FinishedProcess) Wait() (int, error)                { return p.exitStatus, nil }
+func (p *FinishedProcess) SetTTY(garden.TTYSpec) error       { return nil }
+func (p *FinishedProcess) Signal(signal garden.Signal) error { return ErrNotImplemented }

--- a/worker/runtime/finished_process.go
+++ b/worker/runtime/finished_process.go
@@ -7,15 +7,15 @@ import (
 )
 
 type finishedProcess struct {
-	id       string
-	exitCode int
+	id         string
+	exitStatus int
 }
 
-func NewFinishedProcess(id string, exitCode int) garden.Process {
-	return &finishedProcess{id: id, exitCode: exitCode}
+func NewFinishedProcess(id string, exitStatus int) garden.Process {
+	return &finishedProcess{id: id, exitStatus: exitStatus}
 }
 
 func (p *finishedProcess) ID() string                        { return p.id }
-func (p *finishedProcess) Wait() (int, error)                { return p.exitCode, nil }
+func (p *finishedProcess) Wait() (int, error)                { return p.exitStatus, nil }
 func (p *finishedProcess) SetTTY(garden.TTYSpec) error       { return nil }
 func (p *finishedProcess) Signal(signal garden.Signal) error { return ErrNotImplemented }

--- a/worker/runtime/finished_process.go
+++ b/worker/runtime/finished_process.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package runtime
+
+import (
+	"code.cloudfoundry.org/garden"
+)
+
+type finishedProcess struct {
+	id       string
+	exitCode int
+}
+
+func NewFinishedProcess(id string, exitCode int) garden.Process {
+	return &finishedProcess{id: id, exitCode: exitCode}
+}
+
+func (p *finishedProcess) ID() string                        { return p.id }
+func (p *finishedProcess) Wait() (int, error)                { return p.exitCode, nil }
+func (p *finishedProcess) SetTTY(garden.TTYSpec) error       { return nil }
+func (p *finishedProcess) Signal(signal garden.Signal) error { return ErrNotImplemented }

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -775,10 +775,6 @@ func (s *IntegrationSuite) TestAttachToFinishedProcess() {
 	})
 	s.NoError(err)
 
-	defer func() {
-		s.NoError(s.gardenBackend.Destroy(handle))
-	}()
-
 	buf := new(buffer)
 	proc, err := container.Run(
 		garden.ProcessSpec{
@@ -813,6 +809,9 @@ func (s *IntegrationSuite) TestAttachToFinishedProcess() {
 	attachedExitCode, err := attachedProc.Wait()
 	s.NoError(err)
 	s.Equal(exitCode, attachedExitCode)
+	s.Contains(buf.String(), "")
+	err = s.gardenBackend.Destroy(container.Handle())
+	s.NoError(err)
 }
 
 // TestAttach tries to validate that we're able to start a process in a

--- a/worker/runtime/process.go
+++ b/worker/runtime/process.go
@@ -15,15 +15,18 @@ import (
 type Process struct {
 	process     containerd.Process
 	exitStatusC <-chan containerd.ExitStatus
+	c           Container
 }
 
 func NewProcess(
 	p containerd.Process,
 	ch <-chan containerd.ExitStatus,
+	c Container,
 ) *Process {
 	return &Process{
 		process:     p,
 		exitStatusC: ch,
+		c:           c,
 	}
 }
 
@@ -58,6 +61,7 @@ func (p *Process) Wait() (int, error) {
 		return 0, fmt.Errorf("delete process: %w", err)
 	}
 
+	p.c.SetProperty(ContainerProcessExitKey, fmt.Sprintf("%d", status.ExitCode()))
 	return int(status.ExitCode()), nil
 }
 

--- a/worker/runtime/process.go
+++ b/worker/runtime/process.go
@@ -15,18 +15,18 @@ import (
 type Process struct {
 	process     containerd.Process
 	exitStatusC <-chan containerd.ExitStatus
-	c           Container
+	container   Container
 }
 
 func NewProcess(
 	p containerd.Process,
 	ch <-chan containerd.ExitStatus,
-	c Container,
+	container Container,
 ) *Process {
 	return &Process{
 		process:     p,
 		exitStatusC: ch,
-		c:           c,
+		container:   container,
 	}
 }
 
@@ -61,7 +61,7 @@ func (p *Process) Wait() (int, error) {
 		return 0, fmt.Errorf("delete process: %w", err)
 	}
 
-	p.c.SetProperty(ProcessExitStatusKey, fmt.Sprintf("%d", status.ExitCode()))
+	p.container.SetProperty(ProcessExitStatusKey, fmt.Sprintf("%d", status.ExitCode()))
 	return int(status.ExitCode()), nil
 }
 

--- a/worker/runtime/process.go
+++ b/worker/runtime/process.go
@@ -61,7 +61,7 @@ func (p *Process) Wait() (int, error) {
 		return 0, fmt.Errorf("delete process: %w", err)
 	}
 
-	p.c.SetProperty(ContainerProcessExitKey, fmt.Sprintf("%d", status.ExitCode()))
+	p.c.SetProperty(ProcessExitStatusKey, fmt.Sprintf("%d", status.ExitCode()))
 	return int(status.ExitCode()), nil
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #9344

This change refactors process attach behavior to handle exited container processes gracefully.
Instead re-running task after web restart, the runtime now reuses the recorded exit status when a process no longer exists in containerd.

## Notes to reviewer
1. Create pipeline:
```yml
jobs:
- name: hello-world
  plan:
  - task: say-hello
    config:
      platform: linux
      image_resource:
        type: mock
        source: {mirror_self: true}
      run:
        path: bash
        args: 
        - -exc
        - |
          echo "pid: $$"
          for i in {1..15}; do
            echo "Welcome $i times" && sleep 1
          done
          exit 1
```
2. Trigger pipeline
3. Restart the Concourse web process a few seconds before the loop completes.
4. Expected result
    - The worker should not re-run the task after the web restart.
    - The task should complete normally and report the correct exit status (1).
    - The pipeline UI should show the task as finished.