### PR TITLE
add back the retrying sql driver

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -294,6 +294,12 @@ type Migration struct {
 }
 
 func (m *Migration) Execute(args []string) error {
+	db.SetupConnectionRetryingDriver(
+		defaultDriverName,
+		m.Postgres.ConnectionString(),
+		retryingDriverName,
+	)
+
 	lockConns, err := constructLockConns(retryingDriverName, m.Postgres.ConnectionString())
 	if err != nil {
 		return err

--- a/atc/db/connection_retrying_driver.go
+++ b/atc/db/connection_retrying_driver.go
@@ -1,0 +1,65 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"slices"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type connectionRetryingDriver struct {
+	driver.Driver
+	driverName string
+}
+
+func SetupConnectionRetryingDriver(
+	delegateDriverName string,
+	sqlDataSource string,
+	newDriverName string,
+) {
+	if slices.Contains(sql.Drivers(), newDriverName) {
+		return
+	}
+	delegateDBConn, err := sql.Open(delegateDriverName, sqlDataSource)
+	if err == nil {
+		// ignoring any connection errors since we only need this to access the driver struct
+		_ = delegateDBConn.Close()
+	}
+
+	connectionRetryingDriver := &connectionRetryingDriver{
+		delegateDBConn.Driver(),
+		delegateDriverName,
+	}
+	sql.Register(newDriverName, connectionRetryingDriver)
+}
+
+func (d *connectionRetryingDriver) Open(connStr string) (driver.Conn, error) {
+	conn, err := backoff.Retry(context.TODO(), func() (driver.Conn, error) {
+		conn, err := d.Driver.Open(connStr)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			var connErr *pgconn.ConnectError
+			if errors.As(err, &pgErr) || errors.As(err, &connErr) || pgconn.SafeToRetry(err) {
+				return nil, err
+			}
+
+			return nil, backoff.Permanent(err)
+		}
+
+		return conn, nil
+	},
+		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithMaxElapsedTime(30*time.Second),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}


### PR DESCRIPTION
This driver was accidently removed during the migration to pgx (#9066). In practice it has made Concourse less robust and required us to update tests to check if postgres was ready to accept connections. I've noticed even with these adjustments that some tests still flake with db connection errors. 

With this PR, Concourse will retry if there are basic connection issues for up to 30s.

## Reproducing

On `master`, if you locally apply this diff, which resets the compose file to what it was before we migrated to pgx:

```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index 7edb3caca..94fde79fa 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,19 +16,20 @@ services:
       POSTGRES_USER: dev
       POSTGRES_PASSWORD: dev
       POSTGRES_HOST_AUTH_METHOD: ${AUTH_METHOD:-trust}
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U dev -d concourse"]
-      interval: 3s
-      timeout: 3s
-      retries: 5
+    # healthcheck:
+    #   test: ["CMD-SHELL", "pg_isready -U dev -d concourse"]
+    #   interval: 3s
+    #   timeout: 3s
+    #   retries: 5

   web:
     build: .
     image: concourse/concourse:local
     command: web
     depends_on:
-      db:
-        condition: service_healthy
+      [db]
+      # db:
+      # condition: service_healthy
     ports: [8080:8080]
     networks:
       - default
```

In the root of the Concourse repo, put it in a file called `compose-diff` and run `git apply compose-diff`.
Then run:
```
docker compose build web
docker compose up -d
docker compose ps -a
```

It's a race between the db and web service, so you might need to `compose down` and `compose up -d` a few times, but eventually you should see the web service fail to start:
```
NAME                 IMAGE                       COMMAND                  SERVICE   CREATED         STATUS                     PORTS
concourse-db-1       postgres:latest             "docker-entrypoint.s…"   db        4 seconds ago   Up 3 seconds               0.0.0.0:6543->5432/tcp, [::]:6543->5432/tcp
concourse-web-1      concourse/concourse:local   "dumb-init concourse…"   web       3 seconds ago   Exited (1) 3 seconds ago
concourse-worker-1   concourse/concourse:local   "dumb-init concourse…"   worker    3 seconds ago   Up 3 seconds               0.0.0.0:7777->7777/tcp, [::]:7777->7777/tcp, 0.0.0.0:7788->7788/tcp, [::]:7788->7788/tcp
```

And in the logs `docker compose logs web`:
```
web-1  | {"timestamp":"2025-11-14T19:20:45.561273128Z","level":"info","source":"atc","message":"atc.cmd.start","data":{"session":"1"}}
web-1  | {"timestamp":"2025-11-14T19:20:45.561423794Z","level":"debug","source":"atc","message":"atc.metrics.metric-initialize","data":{"attributes":{},"buffer-size":1000,"host":"543510da52ee","session":"2"}}
web-1  | {"timestamp":"2025-11-14T19:20:45.565651628Z","level":"info","source":"atc","message":"atc.cmd.finish","data":{"duration":4378083,"session":"1"}}
web-1  | error: failed to connect to database: failed to connect to `user=dev database=concourse`:
web-1  |        172.19.0.2:5432 (db): dial error: dial tcp 172.19.0.2:5432: connect: connection refused
web-1  |        [fdf1:f4a2:d53::1]:5432 (db): dial error: dial tcp [fdf1:f4a2:d53::1]:5432: connect: connection refused
```

Switching to this branch and repeating the above, you'll never see this error.