### PR TITLE
fix(set_pipeline): evaluate InstanceVars ahead of other variables

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -266,6 +266,12 @@ func (s setPipelineSource) FetchPipelineConfig() (atc.Config, error) {
 	}
 
 	staticVars := []vars.Variables{}
+
+	// add instance vars first so that they take precedence during evaluation later
+	if len(s.step.plan.InstanceVars) > 0 {
+		staticVars = append(staticVars, vars.StaticVariables(maps.Clone(s.step.plan.InstanceVars)))
+	}
+
 	if len(s.step.plan.Vars) > 0 {
 		staticVars = append(staticVars, vars.StaticVariables(s.step.plan.Vars))
 	}
@@ -281,10 +287,6 @@ func (s setPipelineSource) FetchPipelineConfig() (atc.Config, error) {
 		}
 
 		staticVars = append(staticVars, sv)
-	}
-
-	if len(s.step.plan.InstanceVars) > 0 {
-		staticVars = append(staticVars, vars.StaticVariables(maps.Clone(s.step.plan.InstanceVars)))
 	}
 
 	if len(staticVars) > 0 {

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -50,7 +50,7 @@ jobs:
       run:
         path: echo
         args:
-         - hello
+         - ((branch))
 `
 
 	var pipelineObject = atc.Config{
@@ -69,7 +69,7 @@ jobs:
 								},
 								Run: atc.TaskRunConfig{
 									Path: "echo",
-									Args: []string{"hello"},
+									Args: []string{"feature/foo"},
 								},
 							},
 						},
@@ -182,6 +182,7 @@ jobs:
 		spPlan = &atc.SetPipelinePlan{
 			Name:         "some-pipeline",
 			File:         "some-resource/pipeline.yml",
+			Vars:         map[string]any{"branch": "feature/this-should-be-overridden-by-instance-var-with-same-name"},
 			InstanceVars: atc.InstanceVars{"branch": "feature/foo"},
 		}
 	})


### PR DESCRIPTION
## Changes proposed by this PR

closes #9356 

* [x] adds test to demonstrate broken behaviour
* [x] fix code make test pass

## Notes to reviewer

It's a shame the code used for `fly set-pipeline` and the `set_pipeline` step seem quite divergent - but that feels like a much bigger PR to look at, so this makes a smaller change to address the reported issue.

## Release Note

* `set_pipeline` step now allows `instance_vars` to override vars set via `vars`/`var_file`. This matches the behaviour of `fly set-pipeline`
