### PR TITLE
fix: vault userpass auth cannot be used

### DIFF
--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -139,7 +139,7 @@ func (ac *APIClient) Login() (time.Duration, error) {
 	client := ac.client()
 	loginPath := path.Join("auth", ac.authConfig.Backend, "login")
 
-	if ac.authConfig.Backend == "ldap" || ac.authConfig.Backend == "okta" {
+	if ac.authConfig.Backend == "ldap" || ac.authConfig.Backend == "okta" || ac.authConfig.Backend == "userpass" {
 		username, ok := ac.loginParams()["username"].(string)
 		if !ok {
 			err := fmt.Errorf("failed to assert username as string")


### PR DESCRIPTION
when trying to exchange the user / pass combination for a token, the userpass auth expects the PUT to be done against a path that has the desired username as its last element.
e.g.:

```
vault login -output-curl-string -method=userpass username="HEREIAM" password="notinpath"
curl -X PUT -H "X-Vault-Request: true" -d '{"password":"notinpath"}' https://my-vault-host.com/v1/auth/userpass/login/HEREIAM
```

this is already done for okta and ldap, this commit enables the appending logic that exists for okta and ldap to also be executed for the userpass engine.

