### PR TITLE
set containerd as the default runtime for linux workers

### DIFF
--- a/worker/workercmd/worker_linux_amd64.go
+++ b/worker/workercmd/worker_linux_amd64.go
@@ -1,5 +1,5 @@
 package workercmd
 
 type RuntimeConfiguration struct {
-	Runtime string `long:"runtime" default:"guardian" choice:"guardian" choice:"containerd" choice:"houdini" description:"Runtime to use with the worker. Please note that Houdini is insecure and doesn't run 'tasks' in containers."`
+	Runtime string `long:"runtime" default:"containerd" choice:"guardian" choice:"containerd" choice:"houdini" description:"Runtime to use with the worker. Please note that Houdini is insecure and doesn't run 'tasks' in containers."`
 }


### PR DESCRIPTION
## Changes proposed by this PR

closes #9266 

Makes containerd the default runtime for linux workers. See related issue for rationale.

Did a quick look over the codebase to see if this would break any tests; nothing obvious popped out to me. We'll see how the PR checks do. I expect no issues.


