### PR TITLE
change put.inputs to default to detect inputs

### DIFF
--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -124,8 +124,8 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 
 	var putInputs PutInputs
 	if step.plan.Inputs == nil {
-		// Put step defaults to all inputs if not specified
-		putInputs = NewAllInputs()
+		// Put step defaults to detect inputs if not specified
+		putInputs = NewDetectInputs(step.plan.Params)
 	} else if step.plan.Inputs.All {
 		putInputs = NewAllInputs()
 	} else if step.plan.Inputs.Detect {

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -256,21 +256,17 @@ var _ = Describe("PutStep", func() {
 		})
 
 		Context("when inputs are left blank", func() {
-			It("runs with all inputs", func() {
+			BeforeEach(func() {
+				putPlan.Params = atc.Params{
+					"some-param": "input1/source",
+				}
+			})
+
+			It("runs with detected inputs", func() {
 				Expect(chosenContainer.Spec.Inputs).To(ConsistOf([]runtime.Input{
 					{
 						Artifact:        volume1,
 						DestinationPath: "/tmp/build/put/input1",
-						FromCache:       false,
-					},
-					{
-						Artifact:        volume2,
-						DestinationPath: "/tmp/build/put/input2",
-						FromCache:       true,
-					},
-					{
-						Artifact:        volume3,
-						DestinationPath: "/tmp/build/put/input3",
 						FromCache:       false,
 					},
 				}))

--- a/testflight/fixtures/put-inputs.yml
+++ b/testflight/fixtures/put-inputs.yml
@@ -74,6 +74,9 @@ jobs:
   - get: specified-input
   - get: all-input
   - put: some-resource
+    params:
+      specified: specified-input/something
+      not_there: does-not-exist
   - task: failing-task
     config:
       platform: linux

--- a/testflight/put_inputs_test.go
+++ b/testflight/put_inputs_test.go
@@ -45,13 +45,14 @@ var _ = Describe("A put step with inputs", func() {
 	})
 
 	Context("when no inputs are specified", func() {
-		It("attached all inputs to the put container", func() {
+		It("attaches only the detected inputs to the put container", func() {
 			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-no-inputs"), "-w")
 			<-watch.Exited
 
 			interceptS := fly("intercept", "-j", inPipeline("job-using-no-inputs"), "-s", "some-resource", "--step-type", "put", "--", "ls")
-			Expect(string(interceptS.Out.Contents())).To(ContainSubstring("all-input"))
-			Expect(string(interceptS.Out.Contents())).To(ContainSubstring("specified-input"))
+			logs := string(interceptS.Out.Contents())
+			Expect(logs).To(ContainSubstring("specified-input"))
+			Expect(logs).ToNot(ContainSubstring("all-input"))
 		})
 	})
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #9267

This should not be a breaking change for any known resource type. The only case where I can see this breaking for someone is where a resource type has been designed to expect volumes with specific names to be mounted into the put step. None of the core resource-types do this and I haven't seen any resource types in the wild do this either.