### PR TITLE
Organize the guardian and containerd flags for the worker command

### DIFF
--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -30,12 +30,12 @@ type GdnBinaryFlags struct {
 	Server struct {
 		Network struct {
 			Pool string `long:"network-pool" description:"Network range to use for dynamically allocated container subnets. (default:10.80.0.0/16)"`
-		} `group:"Container Networking"`
+		}
 
 		Limits struct {
 			MaxContainers string `long:"max-containers" description:"Maximum container capacity. 0 means no limit. (default:250)"`
-		} `group:"Limits"`
-	} `group:"server"`
+		}
+	}
 }
 
 // Defaults for GdnBinaryFlags

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -30,12 +30,12 @@ type GdnBinaryFlags struct {
 	Server struct {
 		Network struct {
 			Pool string `long:"network-pool" description:"Network range to use for dynamically allocated container subnets. (default:10.80.0.0/16)"`
-		}
+		} `group:"Guardian Networking"`
 
 		Limits struct {
 			MaxContainers string `long:"max-containers" description:"Maximum container capacity. 0 means no limit. (default:250)"`
-		}
-	}
+		} `group:"Guardian Limits"`
+	} `group:"server"`
 }
 
 // Defaults for GdnBinaryFlags

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -26,7 +26,7 @@ type Certs struct {
 
 type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden server executable (non-absolute names get resolved from $PATH)."`
-	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+	DNS            DNSConfig     `namespace:"dns-proxy"`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 
 	Config      flag.File `long:"config"     description:"Path to a config file to use for the Garden backend. e.g. 'foo-bar=a,b' for '--foo-bar a --foo-bar b'."`
@@ -48,7 +48,7 @@ type ContainerdRuntime struct {
 	Network struct {
 		ExternalIP flag.IP `long:"external-ip" description:"IP address to use to reach container's mapped ports. Autodetected if not specified."`
 		//TODO can DNSConfig be simplifed to just a bool rather than struct with a bool?
-		DNS                DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+		DNS                DNSConfig `group:"Containerd DNS Proxy Configuration" namespace:"dns-proxy"`
 		DNSServers         []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 		AdditionalHosts    []string  `long:"additional-hosts" description:"Additional entries to add to /etc/hosts in containers. Can be specified multiple times or as a comma separated list. IP and Hostname should be separated by a space."`
 		RestrictedNetworks []string  `long:"restricted-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
@@ -59,7 +59,7 @@ type ContainerdRuntime struct {
 			Enable        bool   `long:"enable" description:"Enable IPv6 networking"`
 			Pool          string `long:"pool" default:"fd9c:31a6:c759::/64" description:"IPv6 network range to use for dynamically allocated container addresses."`
 			DisableIPMasq bool   `long:"disable-masquerade" description:"Masquerade container traffic with worker address."`
-		} `group:"IPv6 Configuration" namespace:"v6"`
+		} `group:"Containerd IPv6 Configuration" namespace:"v6"`
 	} `group:"Containerd Networking"`
 }
 

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -26,7 +26,7 @@ type Certs struct {
 
 type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden server executable (non-absolute names get resolved from $PATH)."`
-	DNS            DNSConfig     `namespace:"dns-proxy"`
+	DNS            DNSConfig     `group:"Guardian DNS Proxy Configuration" namespace:"dns-proxy"`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 
 	Config      flag.File `long:"config"     description:"Path to a config file to use for the Garden backend. e.g. 'foo-bar=a,b' for '--foo-bar a --foo-bar b'."`


### PR DESCRIPTION
## Changes proposed by this PR

This doesn't change the resulting names of the flags, just the headings they'd appear under when printing them in the `--help` screen.

This has no functional impact on how the worker command operates.

Before
```
Runtime Configuration:
      --runtime=[guardian|containerd|houdini]                       Runtime to use with the worker. Please note that Houdini is insecure and doesn't run 'tasks' in containers. (default: containerd) [$CONCOURSE_RUNTIME]

Guardian Configuration:
      --garden-bin=                                        Path to a garden server executable (non-absolute names get resolved from $PATH). [$CONCOURSE_GARDEN_BIN]
      --garden-request-timeout=                            How long to wait for requests to the Garden server to complete. 0 means no timeout. (default: 5m) [$CONCOURSE_GARDEN_REQUEST_TIMEOUT]
      --garden-config=                                     Path to a config file to use for the Garden backend. e.g. 'foo-bar=a,b' for '--foo-bar a --foo-bar b'. [$CONCOURSE_GARDEN_CONFIG]

DNS Proxy Configuration:
      --garden-dns-proxy-enable                            Enable proxy DNS server. Note: this will enable containers to access the host network. [$CONCOURSE_GARDEN_DNS_PROXY_ENABLE]

Container Networking:
      --garden-network-pool=                               Network range to use for dynamically allocated container subnets. (default:10.80.0.0/16) [$CONCOURSE_GARDEN_NETWORK_POOL]

Limits:
      --garden-max-containers=                             Maximum container capacity. 0 means no limit. (default:250) [$CONCOURSE_GARDEN_MAX_CONTAINERS]

Containerd Configuration:
      --containerd-config=                                 Path to a config file to use for the Containerd daemon. [$CONCOURSE_CONTAINERD_CONFIG]
      --containerd-bin=                                    Path to a containerd executable (non-absolute names get resolved from $PATH). [$CONCOURSE_CONTAINERD_BIN]
      --containerd-init-bin=                               Path to an init executable. By default will search within the concourse/bin directory the concourse binary is in. [$CONCOURSE_CONTAINERD_INIT_BIN]
      --containerd-seccomp-profile=                        Path to a seccomp filter override. By default will use a restrictive default set. [$CONCOURSE_CONTAINERD_SECCOMP_PROFILE]
      --containerd-oci-hooks-dir=                          Path to the oci hooks dir. By default none is provided. [$CONCOURSE_CONTAINERD_OCI_HOOKS_DIR]
      --containerd-cni-plugins-dir=                        Path to CNI network plugins. By default will set to the concourse/bin directory the concourse binary is in. [$CONCOURSE_CONTAINERD_CNI_PLUGINS_DIR]
      --containerd-log-level=[trace|debug|info|warn|error|fatal|panic] Minimum level of logs to see. (default: info) [$CONCOURSE_CONTAINERD_LOG_LEVEL]
      --containerd-request-timeout=                        How long to wait for requests to Containerd to complete. 0 means no timeout. (default: 5m) [$CONCOURSE_CONTAINERD_REQUEST_TIMEOUT]
      --containerd-max-containers=                         Max container capacity. 0 means no limit. (default: 250) [$CONCOURSE_CONTAINERD_MAX_CONTAINERS]
      --containerd-privileged-mode=[full|fuse-only|ignore] How many privileges privileged containers get. full is equivalent to root on host. ignore means no extra privileges. fuse-only means enough to use fuse-overlayfs. (default: full) [$CONCOURSE_CONTAINERD_PRIVILEGED_MODE]

Containerd Networking:
      --containerd-external-ip=                            IP address to use to reach container's mapped ports. Autodetected if not specified. [$CONCOURSE_CONTAINERD_EXTERNAL_IP]
      --containerd-dns-server=                             DNS server IP address to use instead of automatically determined servers. Can be specified multiple times. [$CONCOURSE_CONTAINERD_DNS_SERVER]
      --containerd-additional-hosts=                       Additional entries to add to /etc/hosts in containers. Can be specified multiple times or as a comma separated list. IP and Hostname should be separated by a space. [$CONCOURSE_CONTAINERD_ADDITIONAL_HOSTS]
      --containerd-restricted-network=                     Network ranges to which traffic from containers will be restricted. Can be specified multiple times. [$CONCOURSE_CONTAINERD_RESTRICTED_NETWORK]
      --containerd-network-pool=                           Network range to use for dynamically allocated container subnets. (default: 10.80.0.0/16) [$CONCOURSE_CONTAINERD_NETWORK_POOL]
      --containerd-mtu=                                    MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host. [$CONCOURSE_CONTAINERD_MTU]
      --containerd-allow-host-access                       Allow containers to reach the host's network. This is turned off by default. [$CONCOURSE_CONTAINERD_ALLOW_HOST_ACCESS]

DNS Proxy Configuration:
      --containerd-dns-proxy-enable                        Enable proxy DNS server. Note: this will enable containers to access the host network. [$CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE]

IPv6 Configuration:
      --containerd-v6-enable                               Enable IPv6 networking [$CONCOURSE_CONTAINERD_V6_ENABLE]
      --containerd-v6-pool=                                IPv6 network range to use for dynamically allocated container addresses. (default: fd9c:31a6:c759::/64) [$CONCOURSE_CONTAINERD_V6_POOL]
      --containerd-v6-disable-masquerade                   Masquerade container traffic with worker address. [$CONCOURSE_CONTAINERD_V6_DISABLE_MASQUERADE]
```


After
```
Runtime Configuration:
      --runtime=[guardian|containerd|houdini]                       Runtime to use with the worker. Please note that Houdini is insecure and doesn't run 'tasks' in containers. (default: containerd) [$CONCOURSE_RUNTIME]

Guardian Configuration:
      --garden-bin=                                                    Path to a garden server executable (non-absolute names get resolved from $PATH). [$CONCOURSE_GARDEN_BIN]
      --garden-request-timeout=                                        How long to wait for requests to the Garden server to complete. 0 means no timeout. (default: 5m) [$CONCOURSE_GARDEN_REQUEST_TIMEOUT]
      --garden-config=                                                 Path to a config file to use for the Garden backend. e.g. 'foo-bar=a,b' for '--foo-bar a --foo-bar b'. [$CONCOURSE_GARDEN_CONFIG]

Guardian DNS Proxy Configuration:
      --garden-dns-proxy-enable                                        Enable proxy DNS server. Note: this will enable containers to access the host network. [$CONCOURSE_GARDEN_DNS_PROXY_ENABLE]

Guardian Networking:
      --garden-network-pool=                                           Network range to use for dynamically allocated container subnets. (default:10.80.0.0/16) [$CONCOURSE_GARDEN_NETWORK_POOL]

Guardian Limits:
      --garden-max-containers=                                         Maximum container capacity. 0 means no limit. (default:250) [$CONCOURSE_GARDEN_MAX_CONTAINERS]

Containerd Configuration:
      --containerd-config=                                             Path to a config file to use for the Containerd daemon. [$CONCOURSE_CONTAINERD_CONFIG]
      --containerd-bin=                                                Path to a containerd executable (non-absolute names get resolved from $PATH). [$CONCOURSE_CONTAINERD_BIN]
      --containerd-init-bin=                                           Path to an init executable. By default will search within the concourse/bin directory the concourse binary is in. [$CONCOURSE_CONTAINERD_INIT_BIN]
      --containerd-seccomp-profile=                                    Path to a seccomp filter override. By default will use a restrictive default set. [$CONCOURSE_CONTAINERD_SECCOMP_PROFILE]
      --containerd-oci-hooks-dir=                                      Path to the oci hooks dir. By default none is provided. [$CONCOURSE_CONTAINERD_OCI_HOOKS_DIR]
      --containerd-cni-plugins-dir=                                    Path to CNI network plugins. By default will set to the concourse/bin directory the concourse binary is in. [$CONCOURSE_CONTAINERD_CNI_PLUGINS_DIR]
      --containerd-log-level=[trace|debug|info|warn|error|fatal|panic] Minimum level of logs to see. (default: info) [$CONCOURSE_CONTAINERD_LOG_LEVEL]
      --containerd-request-timeout=                                    How long to wait for requests to Containerd to complete. 0 means no timeout. (default: 5m) [$CONCOURSE_CONTAINERD_REQUEST_TIMEOUT]
      --containerd-max-containers=                                     Max container capacity. 0 means no limit. (default: 250) [$CONCOURSE_CONTAINERD_MAX_CONTAINERS]
      --containerd-privileged-mode=[full|fuse-only|ignore]             How many privileges privileged containers get. full is equivalent to root on host. ignore means no extra privileges. fuse-only means enough to use fuse-overlayfs. (default: full) [$CONCOURSE_CONTAINERD_PRIVILEGED_MODE]

Containerd Networking:
      --containerd-external-ip=                                        IP address to use to reach container's mapped ports. Autodetected if not specified. [$CONCOURSE_CONTAINERD_EXTERNAL_IP]
      --containerd-dns-server=                                         DNS server IP address to use instead of automatically determined servers. Can be specified multiple times. [$CONCOURSE_CONTAINERD_DNS_SERVER]
      --containerd-additional-hosts=                                   Additional entries to add to /etc/hosts in containers. Can be specified multiple times or as a comma separated list. IP and Hostname should be separated by a space. [$CONCOURSE_CONTAINERD_ADDITIONAL_HOSTS]
      --containerd-restricted-network=                                 Network ranges to which traffic from containers will be restricted. Can be specified multiple times. [$CONCOURSE_CONTAINERD_RESTRICTED_NETWORK]
      --containerd-network-pool=                                       Network range to use for dynamically allocated container subnets. (default: 10.80.0.0/16) [$CONCOURSE_CONTAINERD_NETWORK_POOL]
      --containerd-mtu=                                                MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host. [$CONCOURSE_CONTAINERD_MTU]
      --containerd-allow-host-access                                   Allow containers to reach the host's network. This is turned off by default. [$CONCOURSE_CONTAINERD_ALLOW_HOST_ACCESS]

Containerd DNS Proxy Configuration:
      --containerd-dns-proxy-enable                                    Enable proxy DNS server. Note: this will enable containers to access the host network. [$CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE]

Containerd IPv6 Configuration:
      --containerd-v6-enable                                           Enable IPv6 networking [$CONCOURSE_CONTAINERD_V6_ENABLE]
      --containerd-v6-pool=                                            IPv6 network range to use for dynamically allocated container addresses. (default: fd9c:31a6:c759::/64) [$CONCOURSE_CONTAINERD_V6_POOL]
      --containerd-v6-disable-masquerade                               Masquerade container traffic with worker address. [$CONCOURSE_CONTAINERD_V6_DISABLE_MASQUERADE]
```