### PR TITLE
Show pipeline last updated tooltip on pipeline name hover

### DIFF
--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -1143,6 +1143,7 @@ type alias Pipeline =
     , public : Bool
     , teamName : TeamName
     , groups : List PipelineGroup
+    , lastUpdatedAt : Time.Posix
     , backgroundImage : Maybe String
     , backgroundFilter : Maybe String
     }
@@ -1166,6 +1167,7 @@ encodePipeline pipeline =
         , ( "public", pipeline.public |> Json.Encode.bool )
         , ( "team_name", pipeline.teamName |> Json.Encode.string )
         , ( "groups", pipeline.groups |> Json.Encode.list encodePipelineGroup )
+        , ( "last_updated", (secondsFromDate >> Json.Encode.int) pipeline.lastUpdatedAt )
         , ( "display"
           , Json.Encode.object
                 [ ( "background_image", pipeline.backgroundImage |> Json.Encode.Extra.maybe Json.Encode.string )
@@ -1188,6 +1190,7 @@ decodePipeline =
         |> andMap (Json.Decode.field "public" Json.Decode.bool)
         |> andMap (Json.Decode.field "team_name" Json.Decode.string)
         |> andMap (defaultTo [] <| Json.Decode.field "groups" (Json.Decode.list decodePipelineGroup))
+        |> andMap (Json.Decode.field "last_updated" (Json.Decode.map dateFromSeconds Json.Decode.int))
         |> andMap (Json.Decode.maybe (Json.Decode.at [ "display", "background_image" ] Json.Decode.string))
         |> andMap (Json.Decode.maybe (Json.Decode.at [ "display", "background_filter" ] Json.Decode.string))
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -85,6 +85,7 @@ import ScreenSize exposing (ScreenSize(..))
 import Set
 import SideBar.SideBar as SideBar exposing (byDatabaseId, lookupPipeline)
 import StrictEvents exposing (onScroll)
+import Time
 import Tooltip
 import UserState
 import Views.Spinner as Spinner
@@ -614,6 +615,7 @@ toConcoursePipeline p =
     , pausedAt = Maybe.Nothing
     , archived = p.archived
     , groups = []
+    , lastUpdatedAt = Time.millisToPosix 0
     , backgroundImage = Maybe.Nothing
     , backgroundFilter = Maybe.Nothing
     }

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -897,6 +897,9 @@ toHtmlID domId =
         ResourceCommentTextarea ->
             "resource_comment"
 
+        TopBarPipelineName _ ->
+            "top-bar-pipeline-name"
+
         TopBarFavoritedIcon _ ->
             "top-bar-favorited-icon"
 

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -84,6 +84,7 @@ type DomID
     | PipelineCardFavoritedIcon PipelinesSection Concourse.DatabaseID
     | InstanceGroupCardFavoritedIcon PipelinesSection Concourse.InstanceGroupIdentifier
     | PipelineCardPauseToggle PipelinesSection Concourse.DatabaseID
+    | TopBarPipelineName Concourse.DatabaseID
     | TopBarPinIcon
     | TopBarFavoritedIcon Concourse.DatabaseID
     | TopBarPauseToggle Concourse.PipelineIdentifier

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -516,7 +516,7 @@ handleCallback callback session ( model, effects ) =
                         commentText =
                             "pinned by "
                                 ++ Login.userDisplayName user
-                                ++ " at "
+                                ++ " on "
                                 ++ formatDate session.timeZone time
                     in
                     ( { model
@@ -2097,7 +2097,7 @@ formatDate =
         , DateFormat.dayOfMonthNumber
         , DateFormat.text " "
         , DateFormat.yearNumber
-        , DateFormat.text " "
+        , DateFormat.text " at "
         , DateFormat.hourFixed
         , DateFormat.text ":"
         , DateFormat.minuteFixed

--- a/web/elm/src/Views/TopBar.elm
+++ b/web/elm/src/Views/TopBar.elm
@@ -23,6 +23,7 @@ import RemoteData
 import Routes
 import SideBar.SideBar exposing (byPipelineId, isPipelineVisible, lookupPipeline)
 import Time
+import Tooltip
 import Url
 import Views.InstanceGroupBadge as InstanceGroupBadge
 import Views.Styles as Styles
@@ -267,6 +268,17 @@ pipelineBreadcrumb inInstanceGroup pipeline groups isLastBreadcrumb =
 
             else
                 pipelineNameView pipeline.name pipeline.archived
+
+        nameHtml =
+            if isLastBreadcrumb then
+                Html.div
+                    (Styles.ellipsedText ++ Tooltip.hoverAttrs (TopBarPipelineName pipeline.id))
+                    [ Html.text <| decodeName text ]
+
+            else
+                Html.span
+                    (Tooltip.hoverAttrs (TopBarPipelineName pipeline.id))
+                    [ Html.text <| decodeName text ]
     in
     Html.a
         ([ id "breadcrumb-pipeline"
@@ -276,16 +288,16 @@ pipelineBreadcrumb inInstanceGroup pipeline groups isLastBreadcrumb =
          ]
             ++ Styles.breadcrumbItem True isLastBreadcrumb
         )
-        (breadcrumbComponent
-            isLastBreadcrumb
-            { icon =
+        [ Html.div
+            (Styles.breadcrumbComponent
                 { component = Assets.PipelineComponent
                 , widthPx = 28
                 , heightPx = 16
                 }
-            , name = text
-            }
-        )
+            )
+            []
+        , nameHtml
+        ]
 
 
 jobBreadcrumb : String -> Bool -> Html Message
@@ -373,7 +385,7 @@ formatDate =
         , DateFormat.dayOfMonthNumber
         , DateFormat.text " "
         , DateFormat.yearNumber
-        , DateFormat.text " "
+        , DateFormat.text " at "
         , DateFormat.hourFixed
         , DateFormat.text ":"
         , DateFormat.minuteFixed

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -47,6 +47,7 @@ module Data exposing
     , withJob
     , withJobName
     , withLastChecked
+    , withLastUpdatedAt
     , withName
     , withNextBuild
     , withPaused
@@ -188,6 +189,7 @@ pipeline team id =
     , public = True
     , teamName = team
     , groups = []
+    , lastUpdatedAt = Time.millisToPosix 0
     , backgroundImage = Maybe.Nothing
     , backgroundFilter = Maybe.Nothing
     }
@@ -232,6 +234,11 @@ withName name p =
 withGroups : List Concourse.PipelineGroup -> { r | groups : List Concourse.PipelineGroup } -> { r | groups : List Concourse.PipelineGroup }
 withGroups groups p =
     { p | groups = groups }
+
+
+withLastUpdatedAt : Time.Posix -> { r | lastUpdatedAt : Time.Posix } -> { r | lastUpdatedAt : Time.Posix }
+withLastUpdatedAt time p =
+    { p | lastUpdatedAt = time }
 
 
 withBackgroundImage : String -> { r | backgroundImage : Maybe String } -> { r | backgroundImage : Maybe String }

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -698,6 +698,27 @@ all =
                             |> Common.queryView
                             |> iSeeStarUnfilled
                 ]
+            , describe "pipeline name tooltip" <|
+                let
+                    setupPipeline time =
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> pipelineFetched
+                                (Data.pipeline "team" 0
+                                    |> Data.withName "pipeline"
+                                    |> Data.withLastUpdatedAt time
+                                )
+                in
+                [ test "hovering pipeline name shows last updated tooltip" <|
+                    \_ ->
+                        setupPipeline (Time.millisToPosix 0)
+                            |> Common.expectTooltipWith
+                                (Message.Message.TopBarPipelineName 0)
+                                (Expect.all
+                                    [ Query.has [ text "pipeline last updated on" ]
+                                    , Query.has [ text "1970" ]
+                                    ]
+                                )
+                ]
             ]
         ]
 

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -2515,14 +2515,14 @@ all =
                                 >> Query.has
                                     [ attribute <|
                                         Attr.value
-                                            "pinned by some-user at Jan 1 1970 12:00:00 AM"
+                                            "pinned by some-user on Jan 1 1970 at 12:00:00 AM"
                                     ]
                         , test "automatically tries to set comment" <|
                             onSuccess
                                 >> Tuple.second
                                 >> Expect.equal
                                     [ Effects.SetPinComment Data.resourceId
-                                        "pinned by some-user at Jan 1 1970 12:00:00 AM"
+                                        "pinned by some-user on Jan 1 1970 at 12:00:00 AM"
                                     ]
                         ]
                     , test "clicked button shows unpinned state when pinning fails" <|
@@ -3007,7 +3007,7 @@ all =
                             |> Query.find [ id "last-checked" ]
                             |> Query.has
                                 [ attribute <|
-                                    Attr.title "Jan 1 1970 05:00:00 AM"
+                                    Attr.title "Jan 1 1970 at 05:00:00 AM"
                                 ]
                 ]
             ]

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -339,6 +339,22 @@ all =
                         >> Query.has
                             [ style "border-left" <| "1px solid " ++ borderGrey ]
                 ]
+            , context "when hovering over the pipeline name"
+                (hoverOver (Msgs.TopBarPipelineName 0) >> Tuple.first)
+              <|
+                [ it "shows tooltip with last updated time" <|
+                    Application.handleCallback
+                        (Callback.PipelineFetched <|
+                            Ok
+                                (Data.pipeline "t" 0
+                                    |> Data.withName "p"
+                                )
+                        )
+                        >> Tuple.first
+                        >> queryView
+                        >> Query.find [ id "tooltips" ]
+                        >> Query.has [ text "pipeline last updated on Jan 1 1970 at 12:00:00 AM" ]
+                ]
             , context "when hovering over the pinned icon"
                 (hoverOver Msgs.TopBarPinIcon >> Tuple.first)
               <|


### PR DESCRIPTION
Add tooltip to pipeline breadcrumb name showing "pipeline last updated at <datetime>" when user hovers over the pipeline name in the top bar.
