### PR TITLE
Windows/baggageclaim: Retry initializing volumes on "Access is denied" errors

### DIFF
--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -98,6 +98,7 @@ func ExtractEntry(header *tar.Header, dest string, input io.Reader, chown bool) 
 
 		_, err = io.Copy(file, input)
 		if err != nil {
+			file.Close()
 			return err
 		}
 

--- a/go-archive/tgzfs/extract.go
+++ b/go-archive/tgzfs/extract.go
@@ -23,6 +23,7 @@ func Extract(src io.Reader, dest string) error {
 	if err != nil {
 		return err
 	}
+	defer gr.Close()
 
 	tarReader := tar.NewReader(gr)
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #9352 (I hope)

Also looked at adjacent code to the main change made in this PR for anything we could be forgetting to close and found two cases where we fail to close our file handles.

I don't have a Windows worker setup to reproduce this issue myself, so this is mostly hoping it's fixed based on this comment: https://github.com/concourse/concourse/issues/9352#issuecomment-3512728939