### PR TITLE
fix(skymarshal): use HMAC-signed stateless OAuth state tokens

### DIFF
--- a/skymarshal/skyserver/skyserver_test.go
+++ b/skymarshal/skyserver/skyserver_test.go
@@ -1,6 +1,8 @@
 package skyserver_test
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -14,6 +16,32 @@ import (
 
 	"github.com/onsi/gomega/ghttp"
 )
+
+// stateToken mirrors the struct in skyserver.go for test signing
+type stateToken struct {
+	RedirectURI string `json:"redirect_uri"`
+	Entropy     string `json:"entropy"`
+	Timestamp   int64  `json:"ts"`
+	Signature   string `json:"sig,omitempty"`
+}
+
+// signStateToken creates a signed state token for testing
+func signStateToken(redirectURI string, ts int64) string {
+	st := stateToken{
+		RedirectURI: redirectURI,
+		Entropy:     "test-entropy",
+		Timestamp:   ts,
+	}
+
+	payload, _ := json.Marshal(st)
+
+	mac := hmac.New(sha256.New, stateSigningKey)
+	mac.Write(payload)
+	st.Signature = base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	signed, _ := json.Marshal(st)
+	return base64.RawURLEncoding.EncodeToString(signed)
+}
 
 var _ = Describe("Sky Server API", func() {
 
@@ -42,15 +70,7 @@ var _ = Describe("Sky Server API", func() {
 
 			ExpectNewLogin := func() {
 
-				It("stores a state cookie", func() {
-					Expect(fakeTokenMiddleware.SetStateTokenCallCount()).To(Equal(1))
-					_, state, _ := fakeTokenMiddleware.SetStateTokenArgsForCall(0)
-					Expect(state).NotTo(BeEmpty())
-				})
-
 				It("redirects the initial request to the oauthConfig.AuthURL", func() {
-					_, state, _ := fakeTokenMiddleware.SetStateTokenArgsForCall(0)
-
 					redirectURL, err := response.Location()
 					Expect(err).NotTo(HaveOccurred())
 					Expect(redirectURL.Path).To(Equal("/auth"))
@@ -58,7 +78,7 @@ var _ = Describe("Sky Server API", func() {
 					redirectValues := redirectURL.Query()
 					Expect(redirectValues.Get("access_type")).To(Equal("offline"))
 					Expect(redirectValues.Get("response_type")).To(Equal("code"))
-					Expect(redirectValues.Get("state")).To(Equal(state))
+					Expect(redirectValues.Get("state")).NotTo(BeEmpty())
 					Expect(redirectValues.Get("scope")).To(Equal("some-scope"))
 				})
 
@@ -67,15 +87,19 @@ var _ = Describe("Sky Server API", func() {
 						request.URL.RawQuery = "redirect_uri=/redirect"
 					})
 
-					It("stores redirect_uri in the state token cookie", func() {
-						_, raw, _ := fakeTokenMiddleware.SetStateTokenArgsForCall(0)
-
-						data, err := base64.StdEncoding.DecodeString(raw)
+					It("stores redirect_uri in the signed state token", func() {
+						redirectURL, err := response.Location()
 						Expect(err).NotTo(HaveOccurred())
 
-						var state map[string]string
+						stateParam := redirectURL.Query().Get("state")
+						data, err := base64.RawURLEncoding.DecodeString(stateParam)
+						Expect(err).NotTo(HaveOccurred())
+
+						var state map[string]interface{}
 						json.Unmarshal(data, &state)
 						Expect(state["redirect_uri"]).To(Equal("/redirect"))
+						Expect(state["sig"]).NotTo(BeEmpty())
+						Expect(state["ts"]).NotTo(BeZero())
 					})
 				})
 
@@ -84,13 +108,15 @@ var _ = Describe("Sky Server API", func() {
 						request.URL.RawQuery = ""
 					})
 
-					It("stores / as the default redirect_uri in the state token cookie", func() {
-						_, raw, _ := fakeTokenMiddleware.SetStateTokenArgsForCall(0)
-
-						data, err := base64.StdEncoding.DecodeString(raw)
+					It("stores / as the default redirect_uri in the signed state token", func() {
+						redirectURL, err := response.Location()
 						Expect(err).NotTo(HaveOccurred())
 
-						var state map[string]string
+						stateParam := redirectURL.Query().Get("state")
+						data, err := base64.RawURLEncoding.DecodeString(stateParam)
+						Expect(err).NotTo(HaveOccurred())
+
+						var state map[string]interface{}
 						json.Unmarshal(data, &state)
 						Expect(state["redirect_uri"]).To(Equal("/"))
 					})
@@ -292,44 +318,70 @@ var _ = Describe("Sky Server API", func() {
 				})
 			})
 
-			Context("when the state cookie doesn't exist", func() {
+			Context("when the state token is missing", func() {
 				BeforeEach(func() {
-					fakeTokenMiddleware.GetStateTokenReturns("")
+					request.URL.RawQuery = ""
 				})
 
 				It("errors", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
 				})
 
-				It("shows state cookie invalid message", func() {
+				It("shows invalid state message", func() {
 					Expect(string(body)).To(Equal("invalid state token\n"))
 				})
 			})
 
-			Context("when the cookie state doesn't match the form state", func() {
+			Context("when the state token has invalid signature", func() {
 				BeforeEach(func() {
-					fakeTokenMiddleware.GetStateTokenReturns("not-state")
-					request.URL.RawQuery = "state=some-state"
+					// Create unsigned state token
+					st := stateToken{
+						RedirectURI: "/redirect",
+						Entropy:     "test",
+						Timestamp:   time.Now().Unix(),
+						Signature:   "invalid-signature",
+					}
+					data, _ := json.Marshal(st)
+					invalidState := base64.RawURLEncoding.EncodeToString(data)
+					request.URL.RawQuery = "state=" + invalidState
 				})
 
 				It("errors", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
 				})
 
-				It("shows state cookie unexpected message", func() {
-					Expect(string(body)).To(Equal("unexpected state token\n"))
+				It("shows invalid state message", func() {
+					Expect(string(body)).To(Equal("invalid state token\n"))
 				})
 			})
 
-			Context("when the cookie state matches the form state", func() {
+			Context("when the state token is expired", func() {
 				BeforeEach(func() {
-					fakeTokenMiddleware.GetStateTokenReturns("some-state")
-					request.URL.RawQuery = "state=some-state"
+					// Create state token with old timestamp (2 hours ago)
+					expiredState := signStateToken("/redirect", time.Now().Add(-2*time.Hour).Unix())
+					request.URL.RawQuery = "state=" + expiredState
+				})
+
+				It("errors", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+				})
+
+				It("shows invalid state message", func() {
+					Expect(string(body)).To(Equal("invalid state token\n"))
+				})
+			})
+
+			Context("when the state token is valid", func() {
+				var validState string
+
+				BeforeEach(func() {
+					validState = signStateToken("/some-redirect", time.Now().Unix())
+					request.URL.RawQuery = "state=" + validState
 				})
 
 				Context("when there is an authorization code", func() {
 					BeforeEach(func() {
-						request.URL.RawQuery = "code=some-code&state=some-state"
+						request.URL.RawQuery = "code=some-code&state=" + validState
 					})
 
 					Context("when requesting a token fails", func() {
@@ -396,13 +448,7 @@ var _ = Describe("Sky Server API", func() {
 
 						Context("when redirect URI is http://example.com", func() {
 							BeforeEach(func() {
-								state, _ := json.Marshal(map[string]string{
-									"redirect_uri": "http://example.com",
-								})
-
-								stateToken := base64.StdEncoding.EncodeToString(state)
-								fakeTokenMiddleware.GetStateTokenReturns(stateToken)
-
+								stateToken := signStateToken("http://example.com", time.Now().Unix())
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
@@ -413,13 +459,7 @@ var _ = Describe("Sky Server API", func() {
 
 						Context("when redirect URI is //example.com", func() {
 							BeforeEach(func() {
-								state, _ := json.Marshal(map[string]string{
-									"redirect_uri": "//example.com",
-								})
-
-								stateToken := base64.StdEncoding.EncodeToString(state)
-								fakeTokenMiddleware.GetStateTokenReturns(stateToken)
-
+								stateToken := signStateToken("//example.com", time.Now().Unix())
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
@@ -430,13 +470,7 @@ var _ = Describe("Sky Server API", func() {
 
 						Context("when redirect URI is http:///example.com/path", func() {
 							BeforeEach(func() {
-								state, _ := json.Marshal(map[string]string{
-									"redirect_uri": "http:///example.com/path",
-								})
-
-								stateToken := base64.StdEncoding.EncodeToString(state)
-								fakeTokenMiddleware.GetStateTokenReturns(stateToken)
-
+								stateToken := signStateToken("http:///example.com/path", time.Now().Unix())
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
@@ -447,13 +481,7 @@ var _ = Describe("Sky Server API", func() {
 
 						Context("when redirect URI is https:example.com", func() {
 							BeforeEach(func() {
-								state, _ := json.Marshal(map[string]string{
-									"redirect_uri": "https:example.com",
-								})
-
-								stateToken := base64.StdEncoding.EncodeToString(state)
-								fakeTokenMiddleware.GetStateTokenReturns(stateToken)
-
+								stateToken := signStateToken("https:example.com", time.Now().Unix())
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
@@ -464,13 +492,7 @@ var _ = Describe("Sky Server API", func() {
 
 						Context("when redirect URI is example.com", func() {
 							BeforeEach(func() {
-								state, _ := json.Marshal(map[string]string{
-									"redirect_uri": "example.com",
-								})
-
-								stateToken := base64.StdEncoding.EncodeToString(state)
-								fakeTokenMiddleware.GetStateTokenReturns(stateToken)
-
+								stateToken := signStateToken("example.com", time.Now().Unix())
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
@@ -481,13 +503,7 @@ var _ = Describe("Sky Server API", func() {
 
 						Context("when redirecting to the ATC", func() {
 							BeforeEach(func() {
-								state, _ := json.Marshal(map[string]string{
-									"redirect_uri": "/valid-redirect",
-								})
-
-								stateToken := base64.StdEncoding.EncodeToString(state)
-								fakeTokenMiddleware.GetStateTokenReturns(stateToken)
-
+								stateToken := signStateToken("/valid-redirect", time.Now().Unix())
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
@@ -517,10 +533,6 @@ var _ = Describe("Sky Server API", func() {
 								Context("when setting the csrf token succeeds", func() {
 									BeforeEach(func() {
 										fakeTokenMiddleware.SetCSRFTokenReturns(nil)
-									})
-
-									It("unsets the cookie state", func() {
-										Expect(fakeTokenMiddleware.UnsetStateTokenCallCount()).To(Equal(1))
 									})
 
 									It("saves the access token from the response", func() {

--- a/skymarshal/token/middleware.go
+++ b/skymarshal/token/middleware.go
@@ -14,10 +14,6 @@ type Middleware interface {
 	SetCSRFToken(http.ResponseWriter, string, time.Time) error
 	UnsetCSRFToken(http.ResponseWriter)
 	GetCSRFToken(*http.Request) string
-
-	SetStateToken(http.ResponseWriter, string, time.Time) error
-	UnsetStateToken(http.ResponseWriter)
-	GetStateToken(*http.Request) string
 }
 
 type middleware struct {
@@ -28,7 +24,6 @@ func NewMiddleware(secureCookies bool) Middleware {
 	return &middleware{secureCookies: secureCookies}
 }
 
-const stateCookieName = "skymarshal_state"
 const authCookieName = "skymarshal_auth"
 const csrfCookieName = "skymarshal_csrf"
 
@@ -92,39 +87,6 @@ func (m *middleware) SetCSRFToken(w http.ResponseWriter, csrfToken string, expir
 
 func (m *middleware) GetCSRFToken(r *http.Request) string {
 	cookie, err := r.Cookie(csrfCookieName)
-	if err != nil {
-		return ""
-	}
-	return cookie.Value
-}
-
-func (m *middleware) UnsetStateToken(w http.ResponseWriter) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     stateCookieName,
-		Path:     "/",
-		MaxAge:   -1,
-		Secure:   m.secureCookies,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
-}
-
-func (m *middleware) SetStateToken(w http.ResponseWriter, stateToken string, expiry time.Time) error {
-	http.SetCookie(w, &http.Cookie{
-		Name:     stateCookieName,
-		Value:    stateToken,
-		Path:     "/",
-		Expires:  expiry,
-		Secure:   m.secureCookies,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
-
-	return nil
-}
-
-func (m *middleware) GetStateToken(r *http.Request) string {
-	cookie, err := r.Cookie(stateCookieName)
 	if err != nil {
 		return ""
 	}

--- a/skymarshal/token/middleware_test.go
+++ b/skymarshal/token/middleware_test.go
@@ -1,10 +1,9 @@
 package token_test
 
 import (
-	"time"
-
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	"github.com/concourse/concourse/skymarshal/token"
 	. "github.com/onsi/ginkgo/v2"
@@ -122,54 +121,6 @@ var _ = Describe("Token Middleware", func() {
 				cookies := w.Result().Cookies()
 				Expect(cookies).To(HaveLen(1))
 				Expect(cookies[0].Name).To(Equal("skymarshal_csrf"))
-				Expect(cookies[0].Value).To(Equal(""))
-				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
-			})
-		})
-	})
-
-	Describe("State Tokens", func() {
-
-		Describe("GetStateToken", func() {
-			var result string
-
-			BeforeEach(func() {
-				r.AddCookie(&http.Cookie{Name: "skymarshal_state", Value: "blah"})
-			})
-
-			JustBeforeEach(func() {
-				result = middleware.GetStateToken(r)
-			})
-
-			It("gets the token from the request", func() {
-				Expect(result).To(Equal("blah"))
-			})
-		})
-
-		Describe("SetStateToken", func() {
-			JustBeforeEach(func() {
-				err = middleware.SetStateToken(w, "blah", expiry)
-			})
-
-			It("writes the token to a cookie", func() {
-				cookies := w.Result().Cookies()
-				Expect(cookies).To(HaveLen(1))
-				Expect(cookies[0].Name).To(Equal("skymarshal_state"))
-				Expect(cookies[0].Expires.Unix()).To(Equal(expiry.Unix()))
-				Expect(cookies[0].Value).To(Equal("blah"))
-				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
-			})
-		})
-
-		Describe("UnsetStateToken", func() {
-			JustBeforeEach(func() {
-				middleware.UnsetStateToken(w)
-			})
-
-			It("clears the token from the cookie", func() {
-				cookies := w.Result().Cookies()
-				Expect(cookies).To(HaveLen(1))
-				Expect(cookies[0].Name).To(Equal("skymarshal_state"))
 				Expect(cookies[0].Value).To(Equal(""))
 				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
 			})

--- a/skymarshal/token/tokenfakes/fake_middleware.go
+++ b/skymarshal/token/tokenfakes/fake_middleware.go
@@ -32,17 +32,6 @@ type FakeMiddleware struct {
 	getCSRFTokenReturnsOnCall map[int]struct {
 		result1 string
 	}
-	GetStateTokenStub        func(*http.Request) string
-	getStateTokenMutex       sync.RWMutex
-	getStateTokenArgsForCall []struct {
-		arg1 *http.Request
-	}
-	getStateTokenReturns struct {
-		result1 string
-	}
-	getStateTokenReturnsOnCall map[int]struct {
-		result1 string
-	}
 	SetAuthTokenStub        func(http.ResponseWriter, string, time.Time) error
 	setAuthTokenMutex       sync.RWMutex
 	setAuthTokenArgsForCall []struct {
@@ -69,19 +58,6 @@ type FakeMiddleware struct {
 	setCSRFTokenReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetStateTokenStub        func(http.ResponseWriter, string, time.Time) error
-	setStateTokenMutex       sync.RWMutex
-	setStateTokenArgsForCall []struct {
-		arg1 http.ResponseWriter
-		arg2 string
-		arg3 time.Time
-	}
-	setStateTokenReturns struct {
-		result1 error
-	}
-	setStateTokenReturnsOnCall map[int]struct {
-		result1 error
-	}
 	UnsetAuthTokenStub        func(http.ResponseWriter)
 	unsetAuthTokenMutex       sync.RWMutex
 	unsetAuthTokenArgsForCall []struct {
@@ -90,11 +66,6 @@ type FakeMiddleware struct {
 	UnsetCSRFTokenStub        func(http.ResponseWriter)
 	unsetCSRFTokenMutex       sync.RWMutex
 	unsetCSRFTokenArgsForCall []struct {
-		arg1 http.ResponseWriter
-	}
-	UnsetStateTokenStub        func(http.ResponseWriter)
-	unsetStateTokenMutex       sync.RWMutex
-	unsetStateTokenArgsForCall []struct {
 		arg1 http.ResponseWriter
 	}
 	invocations      map[string][][]interface{}
@@ -219,67 +190,6 @@ func (fake *FakeMiddleware) GetCSRFTokenReturnsOnCall(i int, result1 string) {
 		})
 	}
 	fake.getCSRFTokenReturnsOnCall[i] = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeMiddleware) GetStateToken(arg1 *http.Request) string {
-	fake.getStateTokenMutex.Lock()
-	ret, specificReturn := fake.getStateTokenReturnsOnCall[len(fake.getStateTokenArgsForCall)]
-	fake.getStateTokenArgsForCall = append(fake.getStateTokenArgsForCall, struct {
-		arg1 *http.Request
-	}{arg1})
-	stub := fake.GetStateTokenStub
-	fakeReturns := fake.getStateTokenReturns
-	fake.recordInvocation("GetStateToken", []interface{}{arg1})
-	fake.getStateTokenMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeMiddleware) GetStateTokenCallCount() int {
-	fake.getStateTokenMutex.RLock()
-	defer fake.getStateTokenMutex.RUnlock()
-	return len(fake.getStateTokenArgsForCall)
-}
-
-func (fake *FakeMiddleware) GetStateTokenCalls(stub func(*http.Request) string) {
-	fake.getStateTokenMutex.Lock()
-	defer fake.getStateTokenMutex.Unlock()
-	fake.GetStateTokenStub = stub
-}
-
-func (fake *FakeMiddleware) GetStateTokenArgsForCall(i int) *http.Request {
-	fake.getStateTokenMutex.RLock()
-	defer fake.getStateTokenMutex.RUnlock()
-	argsForCall := fake.getStateTokenArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeMiddleware) GetStateTokenReturns(result1 string) {
-	fake.getStateTokenMutex.Lock()
-	defer fake.getStateTokenMutex.Unlock()
-	fake.GetStateTokenStub = nil
-	fake.getStateTokenReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeMiddleware) GetStateTokenReturnsOnCall(i int, result1 string) {
-	fake.getStateTokenMutex.Lock()
-	defer fake.getStateTokenMutex.Unlock()
-	fake.GetStateTokenStub = nil
-	if fake.getStateTokenReturnsOnCall == nil {
-		fake.getStateTokenReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.getStateTokenReturnsOnCall[i] = struct {
 		result1 string
 	}{result1}
 }
@@ -410,69 +320,6 @@ func (fake *FakeMiddleware) SetCSRFTokenReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeMiddleware) SetStateToken(arg1 http.ResponseWriter, arg2 string, arg3 time.Time) error {
-	fake.setStateTokenMutex.Lock()
-	ret, specificReturn := fake.setStateTokenReturnsOnCall[len(fake.setStateTokenArgsForCall)]
-	fake.setStateTokenArgsForCall = append(fake.setStateTokenArgsForCall, struct {
-		arg1 http.ResponseWriter
-		arg2 string
-		arg3 time.Time
-	}{arg1, arg2, arg3})
-	stub := fake.SetStateTokenStub
-	fakeReturns := fake.setStateTokenReturns
-	fake.recordInvocation("SetStateToken", []interface{}{arg1, arg2, arg3})
-	fake.setStateTokenMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeMiddleware) SetStateTokenCallCount() int {
-	fake.setStateTokenMutex.RLock()
-	defer fake.setStateTokenMutex.RUnlock()
-	return len(fake.setStateTokenArgsForCall)
-}
-
-func (fake *FakeMiddleware) SetStateTokenCalls(stub func(http.ResponseWriter, string, time.Time) error) {
-	fake.setStateTokenMutex.Lock()
-	defer fake.setStateTokenMutex.Unlock()
-	fake.SetStateTokenStub = stub
-}
-
-func (fake *FakeMiddleware) SetStateTokenArgsForCall(i int) (http.ResponseWriter, string, time.Time) {
-	fake.setStateTokenMutex.RLock()
-	defer fake.setStateTokenMutex.RUnlock()
-	argsForCall := fake.setStateTokenArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *FakeMiddleware) SetStateTokenReturns(result1 error) {
-	fake.setStateTokenMutex.Lock()
-	defer fake.setStateTokenMutex.Unlock()
-	fake.SetStateTokenStub = nil
-	fake.setStateTokenReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeMiddleware) SetStateTokenReturnsOnCall(i int, result1 error) {
-	fake.setStateTokenMutex.Lock()
-	defer fake.setStateTokenMutex.Unlock()
-	fake.SetStateTokenStub = nil
-	if fake.setStateTokenReturnsOnCall == nil {
-		fake.setStateTokenReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.setStateTokenReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeMiddleware) UnsetAuthToken(arg1 http.ResponseWriter) {
 	fake.unsetAuthTokenMutex.Lock()
 	fake.unsetAuthTokenArgsForCall = append(fake.unsetAuthTokenArgsForCall, struct {
@@ -537,38 +384,6 @@ func (fake *FakeMiddleware) UnsetCSRFTokenArgsForCall(i int) http.ResponseWriter
 	return argsForCall.arg1
 }
 
-func (fake *FakeMiddleware) UnsetStateToken(arg1 http.ResponseWriter) {
-	fake.unsetStateTokenMutex.Lock()
-	fake.unsetStateTokenArgsForCall = append(fake.unsetStateTokenArgsForCall, struct {
-		arg1 http.ResponseWriter
-	}{arg1})
-	stub := fake.UnsetStateTokenStub
-	fake.recordInvocation("UnsetStateToken", []interface{}{arg1})
-	fake.unsetStateTokenMutex.Unlock()
-	if stub != nil {
-		fake.UnsetStateTokenStub(arg1)
-	}
-}
-
-func (fake *FakeMiddleware) UnsetStateTokenCallCount() int {
-	fake.unsetStateTokenMutex.RLock()
-	defer fake.unsetStateTokenMutex.RUnlock()
-	return len(fake.unsetStateTokenArgsForCall)
-}
-
-func (fake *FakeMiddleware) UnsetStateTokenCalls(stub func(http.ResponseWriter)) {
-	fake.unsetStateTokenMutex.Lock()
-	defer fake.unsetStateTokenMutex.Unlock()
-	fake.UnsetStateTokenStub = stub
-}
-
-func (fake *FakeMiddleware) UnsetStateTokenArgsForCall(i int) http.ResponseWriter {
-	fake.unsetStateTokenMutex.RLock()
-	defer fake.unsetStateTokenMutex.RUnlock()
-	argsForCall := fake.unsetStateTokenArgsForCall[i]
-	return argsForCall.arg1
-}
-
 func (fake *FakeMiddleware) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -576,20 +391,14 @@ func (fake *FakeMiddleware) Invocations() map[string][][]interface{} {
 	defer fake.getAuthTokenMutex.RUnlock()
 	fake.getCSRFTokenMutex.RLock()
 	defer fake.getCSRFTokenMutex.RUnlock()
-	fake.getStateTokenMutex.RLock()
-	defer fake.getStateTokenMutex.RUnlock()
 	fake.setAuthTokenMutex.RLock()
 	defer fake.setAuthTokenMutex.RUnlock()
 	fake.setCSRFTokenMutex.RLock()
 	defer fake.setCSRFTokenMutex.RUnlock()
-	fake.setStateTokenMutex.RLock()
-	defer fake.setStateTokenMutex.RUnlock()
 	fake.unsetAuthTokenMutex.RLock()
 	defer fake.unsetAuthTokenMutex.RUnlock()
 	fake.unsetCSRFTokenMutex.RLock()
 	defer fake.unsetCSRFTokenMutex.RUnlock()
-	fake.unsetStateTokenMutex.RLock()
-	defer fake.unsetStateTokenMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
Two bugs caused intermittent "unexpected state token" errors:

1. base64.StdEncoding uses +, /, = which get mangled in URLs
2. Multiple browser tabs race to overwrite the single state cookie

Replace cookie-based state validation with self-validating HMAC-signed
tokens. State now includes timestamp, entropy, and signature - verified
entirely from the URL parameter without cookie comparison.

Signing key derived from OAuth client credentials (HMAC of clientID
with clientSecret as key), avoiding new configuration.

Fixes #9036