### PR TITLE
Add SameSite attribute to authentication and CSRF cookies

### DIFF
--- a/skymarshal/token/middleware.go
+++ b/skymarshal/token/middleware.go
@@ -39,6 +39,7 @@ func (m *middleware) UnsetAuthToken(w http.ResponseWriter) {
 		MaxAge:   -1,
 		Secure:   m.secureCookies,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	})
 }
 
@@ -50,6 +51,7 @@ func (m *middleware) SetAuthToken(w http.ResponseWriter, tokenStr string, expiry
 		Expires:  expiry,
 		HttpOnly: true,
 		Secure:   m.secureCookies,
+		SameSite: http.SameSiteLaxMode,
 	})
 
 	return nil
@@ -70,6 +72,7 @@ func (m *middleware) UnsetCSRFToken(w http.ResponseWriter) {
 		MaxAge:   -1,
 		Secure:   m.secureCookies,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	})
 }
 
@@ -81,6 +84,7 @@ func (m *middleware) SetCSRFToken(w http.ResponseWriter, csrfToken string, expir
 		Expires:  expiry,
 		Secure:   m.secureCookies,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	})
 
 	return nil
@@ -101,6 +105,7 @@ func (m *middleware) UnsetStateToken(w http.ResponseWriter) {
 		MaxAge:   -1,
 		Secure:   m.secureCookies,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	})
 }
 
@@ -112,6 +117,7 @@ func (m *middleware) SetStateToken(w http.ResponseWriter, stateToken string, exp
 		Expires:  expiry,
 		Secure:   m.secureCookies,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	})
 
 	return nil

--- a/skymarshal/token/middleware_test.go
+++ b/skymarshal/token/middleware_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Token Middleware", func() {
 				Expect(cookies[0].Name).To(Equal("skymarshal_auth"))
 				Expect(cookies[0].Expires.Unix()).To(Equal(expiry.Unix()))
 				Expect(cookies[0].Value).To(Equal("blah"))
+				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
 			})
 		})
 
@@ -74,6 +75,7 @@ var _ = Describe("Token Middleware", func() {
 				Expect(cookies).To(HaveLen(1))
 				Expect(cookies[0].Name).To(Equal("skymarshal_auth"))
 				Expect(cookies[0].Value).To(Equal(""))
+				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
 			})
 		})
 	})
@@ -107,6 +109,7 @@ var _ = Describe("Token Middleware", func() {
 				Expect(cookies[0].Name).To(Equal("skymarshal_csrf"))
 				Expect(cookies[0].Expires.Unix()).To(Equal(expiry.Unix()))
 				Expect(cookies[0].Value).To(Equal("blah"))
+				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
 			})
 		})
 
@@ -120,6 +123,7 @@ var _ = Describe("Token Middleware", func() {
 				Expect(cookies).To(HaveLen(1))
 				Expect(cookies[0].Name).To(Equal("skymarshal_csrf"))
 				Expect(cookies[0].Value).To(Equal(""))
+				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
 			})
 		})
 	})
@@ -153,6 +157,7 @@ var _ = Describe("Token Middleware", func() {
 				Expect(cookies[0].Name).To(Equal("skymarshal_state"))
 				Expect(cookies[0].Expires.Unix()).To(Equal(expiry.Unix()))
 				Expect(cookies[0].Value).To(Equal("blah"))
+				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
 			})
 		})
 
@@ -166,6 +171,7 @@ var _ = Describe("Token Middleware", func() {
 				Expect(cookies).To(HaveLen(1))
 				Expect(cookies[0].Name).To(Equal("skymarshal_state"))
 				Expect(cookies[0].Value).To(Equal(""))
+				Expect(cookies[0].SameSite).To(Equal(http.SameSiteLaxMode))
 			})
 		})
 	})


### PR DESCRIPTION
## Changes proposed by this PR

closes #9388

_Make sure to follow all [PR requirements](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements)._

* Add SameSite attribute to authentication and CSRF cookies, to add a layer of CSRF protection


Docs: https://pkg.go.dev/net/http#SameSite
