### PR TITLE
worker: add fallback to ATC streaming when P2P fails

### DIFF
--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -83,7 +83,8 @@ type Monitor struct {
 	ConcurrentRequests         map[string]*Gauge
 	ConcurrentRequestsLimitHit map[string]*Counter
 
-	VolumesStreamed Counter
+	VolumesStreamed            Counter
+	VolumesStreamedViaFallback Counter
 
 	GetStepCacheHits       Counter
 	StreamedResourceCaches Counter

--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -76,6 +76,14 @@ func tick(logger lager.Logger, m *Monitor) {
 	)
 
 	m.emit(
+		logger.Session("volumes-streamed-via-fallback"),
+		Event{
+			Name:  "volumes streamed via fallback",
+			Value: m.VolumesStreamedViaFallback.Delta(),
+		},
+	)
+
+	m.emit(
 		logger.Session("get-step-cache-hits"),
 		Event{
 			Name:  "get step cache hits",

--- a/atc/worker/streamer.go
+++ b/atc/worker/streamer.go
@@ -114,11 +114,11 @@ func (s Streamer) stream(ctx context.Context, src runtime.Artifact, dst runtime.
 	err := s.p2pStream(ctx, p2pSrc, p2pDst)
 	if err != nil {
 		// P2P streaming failed - fallback to streaming through ATC (web node)
-		logger.Info("p2p-stream-failed-falling-back-to-atc", lager.Data{
-			"error":       err.Error(),
+		logger.Error("p2p-stream-failed-falling-back-to-atc", err, lager.Data{
 			"src-worker":  p2pSrc.DBVolume().WorkerName(),
 			"dest-worker": p2pDst.DBVolume().WorkerName(),
 		})
+
 		metric.Metrics.VolumesStreamedViaFallback.Inc()
 		return s.streamThroughATC(ctx, src, dst)
 	}

--- a/atc/worker/streamer.go
+++ b/atc/worker/streamer.go
@@ -97,6 +97,8 @@ func (s Streamer) Stream(ctx context.Context, src runtime.Artifact, dst runtime.
 }
 
 func (s Streamer) stream(ctx context.Context, src runtime.Artifact, dst runtime.Volume) error {
+	logger := lagerctx.FromContext(ctx)
+
 	if !s.p2p.Enabled {
 		return s.streamThroughATC(ctx, src, dst)
 	}
@@ -109,7 +111,18 @@ func (s Streamer) stream(ctx context.Context, src runtime.Artifact, dst runtime.
 		return s.streamThroughATC(ctx, src, dst)
 	}
 
-	return s.p2pStream(ctx, p2pSrc, p2pDst)
+	err := s.p2pStream(ctx, p2pSrc, p2pDst)
+	if err != nil {
+		// P2P streaming failed - fallback to streaming through ATC (web node)
+		logger.Info("p2p-stream-failed-falling-back-to-atc", lager.Data{
+			"error":       err.Error(),
+			"src-worker":  p2pSrc.DBVolume().WorkerName(),
+			"dest-worker": p2pDst.DBVolume().WorkerName(),
+		})
+		metric.Metrics.VolumesStreamedViaFallback.Inc()
+		return s.streamThroughATC(ctx, src, dst)
+	}
+	return nil
 }
 
 func (s Streamer) streamThroughATC(ctx context.Context, src runtime.Artifact, dst runtime.Volume) error {


### PR DESCRIPTION
## Changes proposed by this PR

Related to #7017

This PR implements an improvement for volume streaming by adding automatic fallback to ATC (web node) streaming when P2P streaming fails.

### Key changes:
* When P2P streaming fails (e.g., workers on different networks, connectivity issues), automatically fall back to streaming through the ATC web node
* Added a log for when the fallback occurs
* Add new metric `volumes_streamed_via_fallback` to track fallback usage for observability

### Rationale:
I want to be able to run a small number of nodes in a different network and still have the majority of the nodes run in a seperate network and use p2p for peformance reasons.

## Notes to reviewer

* The fallback preserves the same error handling contract - if both P2P and ATC streaming fail, the error from ATC streaming is returned

## Release Note

Volume streaming now automatically falls back to streaming through the web node when peer-to-peer streaming fails. This makes the `enable-p2p-volume-streaming` flag more resilient in environments where workers may be on different networks.