### PR TITLE
Error on duplicate keys while not breaking pipelines that use yaml merge keys `<<`

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -10,6 +10,7 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagerctx"
+	yamlv3 "go.yaml.in/yaml/v3"
 	"sigs.k8s.io/yaml"
 
 	"github.com/concourse/concourse/atc"

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -231,7 +231,10 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 	}
 
 	fmt.Fprintf(stdout, "done\n")
-	logger.Info("saved-pipeline", lager.Data{"team": team.Name(), "pipeline": pipeline.Name()})
+	logger.Info("saved-pipeline", lager.Data{
+		"team":     team.Name(),
+		"pipeline": pipeline.Name()},
+	)
 	delegate.Finished(logger, true)
 
 	return true, nil

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -173,6 +173,9 @@ jobs:
 		fakeTeamFactory.GetByIDReturns(fakeTeam)
 		fakeBuildFactory.BuildReturns(fakeBuild, true, nil)
 
+		fakeTeam.PipelineReturns(nil, false, nil)
+		fakeBuild.SavePipelineReturns(fakePipeline, true, nil)
+
 		fakeAgent = new(policyfakes.FakeAgent)
 		fakeAgent.CheckReturns(policy.PassedPolicyCheck(), nil)
 		fakePolicyAgentFactory.NewAgentReturns(fakeAgent, nil)
@@ -234,7 +237,7 @@ jobs:
 			})
 		})
 
-		Context("when pipeline file exists but bad syntax", func() {
+		Context("when pipeline file exists but has bad syntax", func() {
 			BeforeEach(func() {
 				fakeStreamer.StreamFileReturns(&fakeReadCloser{str: badPipelineContentWithInvalidSyntax}, nil)
 			})
@@ -290,11 +293,6 @@ jobs:
 			})
 
 			Context("when specified pipeline not found", func() {
-				BeforeEach(func() {
-					fakeTeam.PipelineReturns(nil, false, nil)
-					fakeBuild.SavePipelineReturns(fakePipeline, true, nil)
-				})
-
 				It("should save the pipeline", func() {
 					Expect(fakeBuild.SavePipelineCallCount()).To(Equal(1))
 					ref, _, _, _, paused := fakeBuild.SavePipelineArgsForCall(0)
@@ -422,7 +420,6 @@ jobs:
 						Team:         "foo-team",
 						InstanceVars: atc.InstanceVars{"branch": "feature/foo"},
 					}
-					fakeBuild.SavePipelineReturns(fakePipeline, false, nil)
 				})
 
 				It("should save the pipeline itself", func() {
@@ -462,8 +459,6 @@ jobs:
 
 				Context("when team is set to the empty string", func() {
 					BeforeEach(func() {
-						fakeBuild.PipelineReturns(fakePipeline, true, nil)
-						fakeBuild.SavePipelineReturns(fakePipeline, false, nil)
 						spPlan.Team = ""
 					})
 
@@ -497,9 +492,6 @@ jobs:
 								1,
 								fakeUserCurrentTeam, true, nil,
 							)
-
-							fakeBuild.PipelineReturns(fakePipeline, true, nil)
-							fakeBuild.SavePipelineReturns(fakePipeline, false, nil)
 						})
 
 						It("should finish successfully", func() {
@@ -523,9 +515,6 @@ jobs:
 						Context("when the current team is an admin team", func() {
 							BeforeEach(func() {
 								fakeUserCurrentTeam.AdminReturns(true)
-
-								fakeBuild.PipelineReturns(fakePipeline, true, nil)
-								fakeBuild.SavePipelineReturns(fakePipeline, false, nil)
 							})
 
 							It("should finish successfully", func() {

--- a/fly/commands/internal/templatehelpers/yaml_template.go
+++ b/fly/commands/internal/templatehelpers/yaml_template.go
@@ -7,6 +7,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/vars"
+	yamlv3 "go.yaml.in/yaml/v3"
 	"sigs.k8s.io/yaml"
 )
 
@@ -43,9 +44,9 @@ func (yamlTemplate YamlTemplateWithParams) Evaluate(strict bool) ([]byte, error)
 	if strict {
 		// We use a generic map here, since templates are not evaluated yet.
 		// (else a template string may cause an error when a struct is expected)
-		// If we don't check Strict now, then the subsequent steps will mask any
-		// duplicate key errors.
-		err = yaml.UnmarshalStrict(config, make(map[string]any))
+		// If we don't check for duplicate keys now, then the subsequent steps
+		// will mask any duplicate key errors.
+		err = yamlv3.Unmarshal(config, make(map[string]any))
 		if err != nil {
 			return nil, fmt.Errorf("error parsing yaml before applying templates: %s", err.Error())
 		}

--- a/fly/commands/internal/validatepipelinehelpers/validate_test.go
+++ b/fly/commands/internal/validatepipelinehelpers/validate_test.go
@@ -166,11 +166,11 @@ jobs:
 		})
 		It("fails to validate a pipeline with duplicate keys", func() {
 			err := validatepipelinehelpers.Validate(dupkeyPipeline, false, false)
-			Expect(err.Error()).To(ContainSubstring("key \"resource_types\" already set in map"))
+			Expect(err.Error()).To(ContainSubstring(`mapping key "resource_types" already defined`))
 		})
 		It("fails to validate a pipeline with unknown keys with strict", func() {
 			err := validatepipelinehelpers.Validate(unknownKeyPipeline, true, false)
-			Expect(err.Error()).To(ContainSubstring("json: unknown field \"anchors\""))
+			Expect(err.Error()).To(ContainSubstring(`json: unknown field "anchors"`))
 		})
 		It("validates a pipeline with unknown keys", func() {
 			err := validatepipelinehelpers.Validate(unknownKeyPipeline, false, false)

--- a/fly/integration/fixtures/testConfigMergeKeys.yml
+++ b/fly/integration/fixtures/testConfigMergeKeys.yml
@@ -1,0 +1,15 @@
+base_job: &base_job
+  name: job
+  plan:
+    - get: resource-that-doesnt-exist
+
+groups: []
+resources:
+  - name: some-resource
+    type: some-type
+    source:
+      source-config: some-value
+jobs:
+  - <<: *base_job
+    plan:
+      - get: some-resource

--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -270,6 +270,28 @@ var _ = Describe("Fly CLI", func() {
 				})
 			})
 
+			Context("when using yaml merge keys", func() {
+				It("succeeds", func() {
+					flyCmd := exec.Command(
+						flyPath, "-t", targetName,
+						"set-pipeline",
+						"--pipeline", "awesome-pipeline",
+						"-c", "fixtures/testConfigMergeKeys.yml",
+					)
+
+					stdin, err := flyCmd.StdinPipe()
+					Expect(err).NotTo(HaveOccurred())
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+					no(stdin)
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(0))
+				})
+			})
+
 			Context("when a var is specified with -v", func() {
 				BeforeEach(func() {
 					expectSaveConfig(atc.Config{

--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Fly CLI", func() {
 					flyCmd := exec.Command(
 						flyPath, "-t", targetName,
 						"set-pipeline",
-						"-n",
+						"--non-interactive",
 						"--pipeline", "awesome-pipeline",
 						"-c", "fixtures/testConfigDuplicate.yml",
 					)
@@ -263,7 +263,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(sess.Err).Should(gbytes.Say("error parsing yaml before applying templates"))
-					Eventually(sess.Err).Should(gbytes.Say("key \"resources\" already set in map"))
+					Eventually(sess.Err).Should(gbytes.Say(`mapping key "resources" already defined`))
 
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(1))
@@ -333,7 +333,7 @@ this is super secure
 						flyCmd := exec.Command(
 							flyPath, "-t", targetName,
 							"set-pipeline",
-							"-n",
+							"--non-interactive",
 							"--pipeline", "awesome-pipeline",
 							"-c", "fixtures/vars-pipeline.yml",
 							"-l", "fixtures/vars-pipeline-params-a.yml",
@@ -392,7 +392,7 @@ this is super secure
 						flyCmd := exec.Command(
 							flyPath, "-t", targetName,
 							"set-pipeline",
-							"-n",
+							"--non-interactive",
 							"--pipeline", "awesome-pipeline",
 							"-c", "fixtures/vars-pipeline.yml",
 							"-l", "fixtures/vars-pipeline-params-a.yml",
@@ -457,7 +457,7 @@ this is super secure
 						flyCmd := exec.Command(
 							flyPath, "-t", targetName,
 							"set-pipeline",
-							"-n",
+							"--non-interactive",
 							"--pipeline", "awesome-pipeline",
 							"-c", "fixtures/vars-pipeline.yml",
 							"-l", "fixtures/vars-pipeline-params-a.yml",
@@ -510,7 +510,7 @@ this is super secure
 						flyCmd := exec.Command(
 							flyPath, "-t", targetName,
 							"set-pipeline",
-							"-n",
+							"--non-interactive",
 							"--pipeline", "awesome-pipeline",
 							"-c", "fixtures/nested-vars-pipeline.yml",
 							"-v", "source.a=foo",
@@ -570,7 +570,7 @@ this is super secure
 						flyCmd := exec.Command(
 							flyPath, "-t", targetName,
 							"set-pipeline",
-							"-n",
+							"--non-interactive",
 							"--pipeline", "awesome-pipeline",
 							"-c", "fixtures/vars-pipeline.yml",
 							"-l", "fixtures/vars-pipeline-params-a.yml",
@@ -593,7 +593,7 @@ this is super secure
 								flyCmd := exec.Command(
 									flyPath, "-t", targetName,
 									"set-pipeline",
-									"-n",
+									"--non-interactive",
 									"--pipeline", "awesome-pipeline",
 									"-c", "fixtures/vars-pipeline.yml",
 									"-l", "fixtures/vars-pipeline-params-a.yml",
@@ -639,7 +639,7 @@ this is super secure
 								flyCmd := exec.Command(
 									flyPath, "-t", targetName,
 									"set-pipeline",
-									"-n",
+									"--non-interactive",
 									"--pipeline", "awesome-pipeline",
 									"-c", "fixtures/vars-pipeline.yml",
 									"-l", "fixtures/vars-pipeline-params-a.yml",

--- a/fly/integration/validate_pipeline_test.go
+++ b/fly/integration/validate_pipeline_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Fly CLI", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(sess.Err).Should(gbytes.Say("error parsing yaml before applying templates"))
-			Eventually(sess.Err).Should(gbytes.Say("key \"resources\" already set in map"))
+			Eventually(sess.Err).Should(gbytes.Say(`mapping key "resources" already defined`))
 
 			<-sess.Exited
 			Expect(sess.ExitCode()).To(Equal(1))
@@ -124,6 +124,7 @@ var _ = Describe("Fly CLI", func() {
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(gbytes.Say("looks good"))
 
 			<-sess.Exited
 			Expect(sess.ExitCode()).To(Equal(0))

--- a/fly/integration/validate_pipeline_test.go
+++ b/fly/integration/validate_pipeline_test.go
@@ -100,6 +100,21 @@ var _ = Describe("Fly CLI", func() {
 			Expect(sess.ExitCode()).To(Equal(1))
 		})
 
+		It("returns valid when there are merge keys", func() {
+			flyCmd := exec.Command(
+				flyPath,
+				"validate-pipeline",
+				"-c", "fixtures/testConfigMergeKeys.yml",
+			)
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(gbytes.Say("looks good"))
+
+			<-sess.Exited
+			Expect(sess.ExitCode()).To(Equal(0))
+		})
+
 		It("returns valid on a pipeline with unknown keys", func() {
 			flyCmd := exec.Command(
 				flyPath,


### PR DESCRIPTION
## Changes proposed by this PR

closes #9329 and keeps the behaviour from #9197

* Pipelines with duplicate keys will have errors returned, which was originally done by #9197, which will land in v8 of Concourse 
* Pipelines using yaml merge keys `<<` will no longer return "duplicate key" errors from the yaml parser (only an issue if you ran Concourse/fly off of the `master` branch)
* Ensured parity of behaviour between `fly [set/validate]-pipeline` and the `set_pipeline` step. All three now do basic yaml validity checks using `go.yaml.in/yaml/v3`

## Notes to reviewer

#9197 changed the behaviour of Concourse so it would error if you gave it a pipeline that contained duplicate keys anywhere in it. This was achieved by using the `UnmarshalStrict()` function from `sigs.k8s.io/yaml`.

That function uses the `UnmarshalStrict()` (yes, same name) from the `go.yaml.in/yaml/v2` package, which has a bug where it will return a "duplicate key" error if a merge key `<<` has keys of the same name. The yaml spec says the key should not be overridden by the merge, but the parser appears to merge the keys and creates an incorrect yaml file as a result.
This bug is not present in `go.yaml.in/yaml/v3`.

The main reason to use `sigs.k8s.io/yaml` is because it will us json tags annotated on our Go structs. `go.yaml.in/yaml` does not use json tags, you have to use yaml tags in your structs. So we use `sigs.k8s.io/yaml` in most places.

That said, we don't need to use `sigs.k8s.io/yaml` in this case when we want to generally check if the yaml is valid yaml. We can directly use `go.yaml.in/yaml/v3` for general yaml validity, which is what I've done here.
