### PR TITLE
fix issue where only one of max builds/days was set would result in the opposite value not being set all

### DIFF
--- a/atc/gc/build_log_retention_calculator_test.go
+++ b/atc/gc/build_log_retention_calculator_test.go
@@ -10,62 +10,143 @@ import (
 
 var _ = Describe("BuildLogRetentionCalculator", func() {
 	It("nothing set gives all", func() {
-		logRetention := NewBuildLogRetentionCalculator(0, 0, 0, 0).BuildLogsToRetain(makeJob(0, 0, 0))
+		logRetention := NewBuildLogRetentionCalculator(
+			0, // default builds to retain
+			0, // max builds to retain
+			0, // default days to retain
+			0, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			0, // builds to retain
+			0, // days to retain
+			0, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(0))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
 	It("nothing set but job gives job", func() {
-		logRetention := NewBuildLogRetentionCalculator(0, 0, 0, 0).BuildLogsToRetain(makeJob(3, 1, 0))
+		logRetention := NewBuildLogRetentionCalculator(
+			0, // default builds to retain
+			0, // max builds to retain
+			0, // default days to retain
+			0, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			3, // builds to retain
+			0, // days to retain
+			1, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(3))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(1))
 		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(1))
 	})
 	It("default set gives default", func() {
-		logRetention := NewBuildLogRetentionCalculator(5, 0, 0, 0).BuildLogsToRetain(makeJob(0, 0, 0))
+		logRetention := NewBuildLogRetentionCalculator(
+			5, // default builds to retain
+			0, // max builds to retain
+			0, // default days to retain
+			0, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			0, // builds to retain
+			0, // days to retain
+			0, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(5))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
 	It("default and job set gives job", func() {
-		logRetention := NewBuildLogRetentionCalculator(5, 0, 0, 0).BuildLogsToRetain(makeJob(6, 2, 0))
+		logRetention := NewBuildLogRetentionCalculator(
+			5, // default builds to retain
+			0, // max builds to retain
+			0, // default days to retain
+			0, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			6, // builds to retain
+			0, // days to retain
+			2, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(6))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(2))
 		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(2))
 	})
 	It("default and job set and max set gives max if lower", func() {
-		logRetention := NewBuildLogRetentionCalculator(5, 4, 0, 0).BuildLogsToRetain(makeJob(6, 7, 0))
+		logRetention := NewBuildLogRetentionCalculator(
+			5, // default builds to retain
+			4, // max builds to retain
+			0, // default days to retain
+			0, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			6, // builds to retain
+			0, // days to retain
+			7, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(4))
 		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 		Expect(logRetention.Days).To(Equal(0))
 	})
 	It("max only set gives max", func() {
-		logRetention := NewBuildLogRetentionCalculator(0, 4, 0, 0).BuildLogsToRetain(makeJob(0, 6, 0))
+		logRetention := NewBuildLogRetentionCalculator(
+			0, // default builds to retain
+			4, // max builds to retain
+			0, // default days to retain
+			0, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			0, // builds to retain
+			0, // days to retain
+			6, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(4))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
 	It("mix of count and days with max", func() {
-		logRetention := NewBuildLogRetentionCalculator(2, 4, 3, 2).BuildLogsToRetain(makeJob(5, 8, 5))
+		logRetention := NewBuildLogRetentionCalculator(
+			2, // default builds to retain
+			4, // max builds to retain
+			3, // default days to retain
+			2, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			5, // builds to retain
+			5, // days to retain
+			8, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(4))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 		Expect(logRetention.Days).To(Equal(2))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
 	It("min success builds equals to builds", func() {
-		logRetention := NewBuildLogRetentionCalculator(2, 10, 3, 0).BuildLogsToRetain(makeJob(5, 5, 0))
+		logRetention := NewBuildLogRetentionCalculator(
+			2,  // default builds to retain
+			10, // max builds to retain
+			3,  // default days to retain
+			0,  // max days to retain
+		).BuildLogsToRetain(makeJob(
+			5, // builds to retain
+			0, // days to retain
+			5, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(5))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(5))
 		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(5))
 	})
 	It("min success builds greater than builds", func() {
-		logRetention := NewBuildLogRetentionCalculator(2, 10, 3, 0).BuildLogsToRetain(makeJob(5, 8, 0))
+		logRetention := NewBuildLogRetentionCalculator(
+			2,  // default builds to retain
+			10, // max builds to retain
+			3,  // default days to retain
+			0,  // max days to retain
+		).BuildLogsToRetain(makeJob(
+			5, // builds to retain
+			0, // days to retain
+			8, // min success to retain
+		))
 		Expect(logRetention.Builds).To(Equal(5))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
 })
 
-func makeJob(retainAmount int, retainMinSuccessAmount, retainAmountDays int) atc.JobConfig {
+func makeJob(retainAmount, retainAmountDays, retainMinSuccessAmount int) atc.JobConfig {
 	return atc.JobConfig{
 		BuildLogRetention: &atc.BuildLogRetention{
 			Builds:                 retainAmount,

--- a/atc/gc/build_log_retention_calculator_test.go
+++ b/atc/gc/build_log_retention_calculator_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var _ = Describe("BuildLogRetentionCalculator", func() {
-	It("nothing set gives all", func() {
+	It("nothing set returns zeros", func() {
 		logRetention := NewBuildLogRetentionCalculator(
 			0, // default builds to retain
 			0, // max builds to retain
@@ -24,7 +24,7 @@ var _ = Describe("BuildLogRetentionCalculator", func() {
 		Expect(logRetention.Days).To(Equal(0))
 		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
-	It("nothing set but job gives job", func() {
+	It("no default or max set, returns job values", func() {
 		logRetention := NewBuildLogRetentionCalculator(
 			0, // default builds to retain
 			0, // max builds to retain
@@ -32,18 +32,18 @@ var _ = Describe("BuildLogRetentionCalculator", func() {
 			0, // max days to retain
 		).BuildLogsToRetain(makeJob(
 			3, // builds to retain
-			0, // days to retain
+			2, // days to retain
 			1, // min success to retain
 		))
 		Expect(logRetention.Builds).To(Equal(3))
-		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.Days).To(Equal(2))
 		Expect(logRetention.MinimumSucceededBuilds).To(Equal(1))
 	})
 	It("default set gives default", func() {
 		logRetention := NewBuildLogRetentionCalculator(
 			5, // default builds to retain
 			0, // max builds to retain
-			0, // default days to retain
+			4, // default days to retain
 			0, // max days to retain
 		).BuildLogsToRetain(makeJob(
 			0, // builds to retain
@@ -51,52 +51,52 @@ var _ = Describe("BuildLogRetentionCalculator", func() {
 			0, // min success to retain
 		))
 		Expect(logRetention.Builds).To(Equal(5))
-		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.Days).To(Equal(4))
 		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
 	It("default and job set gives job", func() {
 		logRetention := NewBuildLogRetentionCalculator(
 			5, // default builds to retain
 			0, // max builds to retain
-			0, // default days to retain
+			4, // default days to retain
 			0, // max days to retain
 		).BuildLogsToRetain(makeJob(
 			6, // builds to retain
-			0, // days to retain
-			2, // min success to retain
+			3, // days to retain
+			0, // min success to retain
 		))
 		Expect(logRetention.Builds).To(Equal(6))
-		Expect(logRetention.Days).To(Equal(0))
-		Expect(logRetention.MinimumSucceededBuilds).To(Equal(2))
+		Expect(logRetention.Days).To(Equal(3))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
-	It("default and job set and max set gives max if lower", func() {
+	It("default, max, and job set, gives max if lower", func() {
 		logRetention := NewBuildLogRetentionCalculator(
 			5, // default builds to retain
-			4, // max builds to retain
-			0, // default days to retain
-			0, // max days to retain
+			6, // max builds to retain
+			5, // default days to retain
+			6, // max days to retain
 		).BuildLogsToRetain(makeJob(
-			6, // builds to retain
-			0, // days to retain
-			7, // min success to retain
+			10, // builds to retain
+			9,  // days to retain
+			0,  // min success to retain
 		))
-		Expect(logRetention.Builds).To(Equal(4))
+		Expect(logRetention.Builds).To(Equal(6))
+		Expect(logRetention.Days).To(Equal(6))
 		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
-		Expect(logRetention.Days).To(Equal(0))
 	})
 	It("max only set gives max", func() {
 		logRetention := NewBuildLogRetentionCalculator(
 			0, // default builds to retain
 			4, // max builds to retain
 			0, // default days to retain
-			0, // max days to retain
+			3, // max days to retain
 		).BuildLogsToRetain(makeJob(
 			0, // builds to retain
 			0, // days to retain
-			6, // min success to retain
+			0, // min success to retain
 		))
 		Expect(logRetention.Builds).To(Equal(4))
-		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.Days).To(Equal(3))
 		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
 	It("mix of count and days with max", func() {
@@ -126,7 +126,7 @@ var _ = Describe("BuildLogRetentionCalculator", func() {
 			5, // min success to retain
 		))
 		Expect(logRetention.Builds).To(Equal(5))
-		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.Days).To(Equal(3))
 		Expect(logRetention.MinimumSucceededBuilds).To(Equal(5))
 	})
 	It("min success builds greater than builds", func() {
@@ -141,7 +141,37 @@ var _ = Describe("BuildLogRetentionCalculator", func() {
 			8, // min success to retain
 		))
 		Expect(logRetention.Builds).To(Equal(5))
-		Expect(logRetention.Days).To(Equal(0))
+		Expect(logRetention.Days).To(Equal(3))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
+	})
+	It("when only max builds is set and job build and days are set", func() {
+		logRetention := NewBuildLogRetentionCalculator(
+			0, // default builds to retain
+			7, // max builds to retain
+			0, // default days to retain
+			0, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			5, // builds to retain
+			7, // days to retain
+			0, // min success to retain
+		))
+		Expect(logRetention.Builds).To(Equal(5))
+		Expect(logRetention.Days).To(Equal(7))
+		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
+	})
+	It("when only max days is set and job build and days are set", func() {
+		logRetention := NewBuildLogRetentionCalculator(
+			0, // default builds to retain
+			0, // max builds to retain
+			0, // default days to retain
+			7, // max days to retain
+		).BuildLogsToRetain(makeJob(
+			7, // builds to retain
+			5, // days to retain
+			0, // min success to retain
+		))
+		Expect(logRetention.Builds).To(Equal(7))
+		Expect(logRetention.Days).To(Equal(5))
 		Expect(logRetention.MinimumSucceededBuilds).To(Equal(0))
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

closes #8943 
Replaces PR #8944

* Updated the tests so they're easier to read. Seeing `NewBuildLogRetentionCalculator(4,2,0,0)` made it hard to understand what use-case we were testing. Once I did that, it became clear that the previous writer of these tests was confused themselves, as various tests didn't make sense and some were even wrong. Two existing tests failed once I fixed the code because they were incorrectly written.
* The previous PR had a nice in-line solution. I did not test that here because I wanted to avoid writing a very long boolean statement. Call me dumb, but I find it hard to reason about boolean statements when they go longer than two statements. The [truth table](https://en.wikipedia.org/wiki/Truth_table) gets too big to keep in my head.
  * The code now defaults to returning the max values, unless the default or job-level value is less than the max value. If the max value is zero, then we set it to the default or job-level value.

## Notes to reviewer

The issue #8943 has good steps to reproduce.
