### PR TITLE
Windows: Ensure robocopy doesn't retry on errors for 347 days

### DIFF
--- a/worker/baggageclaim/volume/copy/copy_windows.go
+++ b/worker/baggageclaim/volume/copy/copy_windows.go
@@ -1,11 +1,23 @@
 package copy
 
 import (
+	"errors"
 	"os/exec"
 )
 
 func Cp(followSymlinks bool, src, dest string) error {
-	args := []string{"/e", "/nfl", "/ndl", "/mt"}
+	args := []string{
+		"/e",   // copy subdir's even if they're empty
+		"/nfl", // don't log ever file copied
+		"/ndl", // don't log ever dir copied
+		"/mt",  // do multi-thread copying, defaults to 8 threads
+
+		// retrying has a default value of 1 million with 30s waits, which is
+		// 347 days of retrying. Let's override that.
+		"/r:5", // retry any failed copy up to 5 times
+		"/w:5", // wait 5 seconds between each retry
+	}
+
 	if !followSymlinks {
 		args = append(args, "/sl")
 	}
@@ -24,7 +36,7 @@ func robocopy(args ...string) error {
 		// 1 means that files were copied successfully. Google for additional error codes.
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if exitErr.ExitCode() > 1 {
-				return err
+				return errors.Join(err, errors.New(string(exitErr.Stderr)))
 			}
 		} else {
 			return err


### PR DESCRIPTION
## Changes proposed by this PR

Related to #9382 but does not close it.

* Robocopy's default retry settings are crazy. Instead we retry up to 5 times with a 5 second wait in-between each retry.
* Realized that if robocopy does error, we do not bubble up the error. This PR ensures we don't throw the error away now
* Robocopy docs for reference: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy
