### PR TITLE
Replace rerun_of column with new bigint version

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -96,7 +96,7 @@ var buildsQuery = psql.Select(`
 		b.aborted,
 		b.completed,
 		b.inputs_ready,
-		b.rerun_of,
+		COALESCE(b.rerun_of, b.rerun_of_old) AS rerun_of,
 		rb.name,
 		b.rerun_number,
 		b.span_context,
@@ -107,7 +107,7 @@ var buildsQuery = psql.Select(`
 	JoinClause("LEFT OUTER JOIN resources r ON b.resource_id = r.id").
 	JoinClause("LEFT OUTER JOIN pipelines p ON b.pipeline_id = p.id").
 	JoinClause("LEFT OUTER JOIN teams t ON b.team_id = t.id").
-	JoinClause("LEFT OUTER JOIN builds rb ON rb.id = b.rerun_of").
+	JoinClause("LEFT OUTER JOIN builds rb ON (rb.id = b.rerun_of OR rb.id = b.rerun_of_old)").
 	JoinClause("LEFT OUTER JOIN build_comments bc ON b.id = bc.build_id")
 
 var latestCompletedBuildQuery = psql.Select("max(id)").
@@ -2124,7 +2124,10 @@ func latestCompletedNonRerunBuild(tx Tx, jobID int) (int, error) {
 	var latestNonRerunId int
 	err := latestCompletedBuildQuery.
 		Where(sq.Eq{"job_id": jobID}).
-		Where(sq.Eq{"rerun_of": nil}).
+		Where(sq.And{
+			sq.Eq{"rerun_of": nil},
+			sq.Eq{"rerun_of_old": nil},
+		}).
 		RunWith(tx).
 		QueryRow().
 		Scan(&latestNonRerunId)
@@ -2144,7 +2147,10 @@ func updateNextBuildForJob(tx Tx, jobID int, latestNonRerunId int) error {
 			INNER JOIN jobs j ON j.id = b.job_id
 			WHERE b.job_id = $1
 			AND b.status IN ('pending', 'started')
-			AND (b.rerun_of IS NULL OR b.rerun_of = $2)
+			AND (
+				(b.rerun_of IS NULL AND b.rerun_of_old IS NULL) OR
+				(b.rerun_of = $2 OR b.rerun_of_old = $2)
+			)
 		)
 		WHERE j.id = $1
 	`, jobID, latestNonRerunId)
@@ -2158,7 +2164,10 @@ func updateLatestCompletedBuildForJob(tx Tx, jobID int, latestNonRerunId int) er
 	var latestRerunId sql.NullString
 	err := latestCompletedBuildQuery.
 		Where(sq.Eq{"job_id": jobID}).
-		Where(sq.Eq{"rerun_of": latestNonRerunId}).
+		Where(sq.Or{
+			sq.Eq{"rerun_of": latestNonRerunId},
+			sq.Eq{"rerun_of_old": latestNonRerunId},
+		}).
 		RunWith(tx).
 		QueryRow().
 		Scan(&latestRerunId)

--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -278,7 +278,7 @@ func getBuildsWithDates(buildsQuery sq.SelectBuilder, page Page, conn DbConn, lo
 	}
 
 	buildsQuery = buildsQuery.
-		OrderBy("COALESCE(b.rerun_of, b.id) DESC, b.id DESC").
+		OrderBy("COALESCE(b.rerun_of, b.rerun_of_old, b.id) DESC, b.id DESC").
 		Limit(uint64(page.Limit))
 
 	rows, err := buildsQuery.RunWith(conn).Query()
@@ -318,8 +318,8 @@ func getBuildsWithPagination(buildsQuery sq.SelectBuilder, page Page, conn DbCon
 
 	buildsQuery = buildsQuery.Limit(uint64(page.Limit))
 
-	desc := "COALESCE(b.rerun_of, b.id) DESC, b.id DESC"
-	asc := "COALESCE(b.rerun_of, b.id) ASC, b.id ASC"
+	desc := "COALESCE(b.rerun_of, b.rerun_of_old, b.id) DESC, b.id DESC"
+	asc := "COALESCE(b.rerun_of, b.rerun_of_old, b.id) ASC, b.id ASC"
 	if chronological {
 		desc = "b.id DESC"
 		asc = "b.id ASC"
@@ -385,7 +385,7 @@ func getBuildsWithPagination(buildsQuery sq.SelectBuilder, page Page, conn DbCon
 
 	row := origBuildsQuery.
 		Where(sq.Lt{"b.id": oldestBuild.ID()}).
-		OrderBy("COALESCE(b.rerun_of, b.id) DESC, b.id DESC").
+		OrderBy("COALESCE(b.rerun_of, b.rerun_of_old, b.id) DESC, b.id DESC").
 		Limit(1).
 		RunWith(tx).
 		QueryRow()
@@ -403,7 +403,7 @@ func getBuildsWithPagination(buildsQuery sq.SelectBuilder, page Page, conn DbCon
 
 	row = origBuildsQuery.
 		Where(sq.Gt{"b.id": newestBuild.ID()}).
-		OrderBy("COALESCE(b.rerun_of, b.id) ASC, b.id ASC").
+		OrderBy("COALESCE(b.rerun_of, b.rerun_of_old, b.id) ASC, b.id ASC").
 		Limit(1).
 		RunWith(tx).
 		QueryRow()

--- a/atc/db/component_factory.go
+++ b/atc/db/component_factory.go
@@ -82,9 +82,6 @@ func (f *componentFactory) CreateOrUpdate(c atc.Component) (Component, error) {
 		`).
 		RunWith(tx).
 		QueryRow()
-	if err != nil {
-		return nil, err
-	}
 
 	err = scanComponent(obj, row)
 	if err != nil {

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -799,7 +799,7 @@ func (j *job) GetPendingBuilds() ([]Build, error) {
 			"b.job_id": j.id,
 			"b.status": BuildStatusPending,
 		}).
-		OrderBy("COALESCE(b.rerun_of, b.id) ASC, b.id ASC").
+		OrderBy("COALESCE(b.rerun_of, b.rerun_of_old, b.id) ASC, b.id ASC").
 		RunWith(j.conn).
 		Query()
 	if err != nil {
@@ -1280,7 +1280,7 @@ func (j *job) finishedBuild(tx Tx) (Build, error) {
 func (j *job) getNewRerunBuildName(tx Tx, buildID int) (string, int, error) {
 	var rerunNum int
 	var buildName string
-	err := psql.Select("b.name", "( SELECT COUNT(id) FROM builds WHERE rerun_of = b.id )").
+	err := psql.Select("b.name", "( SELECT COUNT(id) FROM builds WHERE (rerun_of = b.id OR rerun_of_old = b.id) )").
 		From("builds b").
 		Where(sq.Eq{
 			"b.id": buildID,

--- a/atc/db/migration/encryption_test.go
+++ b/atc/db/migration/encryption_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Encryption", func() {
 		db, err = sql.Open("pgx", postgresRunner.DataSourceName())
 		Expect(err).NotTo(HaveOccurred())
 
-		for i := 0; i < lock.FactoryCount; i++ {
+		for i := range lock.FactoryCount {
 			lockDB[i], err = sql.Open("pgx", postgresRunner.DataSourceName())
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/atc/db/migration/migration.go
+++ b/atc/db/migration/migration.go
@@ -257,7 +257,7 @@ func (helper *migrator) Migrate(newKey, oldKey *encryption.Key, toVersion int) e
 		// special case - if the old key is not provided but the new key is,
 		// this might mean the data was not encrypted, or that it was encrypted with newKey
 		strategy = encryption.NewFallbackStrategy(newKey, encryption.NewNoEncryption())
-	} else if newKey == nil {
+	} else {
 		strategy = encryption.NewNoEncryption()
 	}
 

--- a/atc/db/migration/migration_test.go
+++ b/atc/db/migration/migration_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Migration", func() {
 		db, err = sql.Open("pgx", postgresRunner.DataSourceName())
 		Expect(err).NotTo(HaveOccurred())
 
-		for i := 0; i < lock.FactoryCount; i++ {
+		for i := range lock.FactoryCount {
 			lockDB[i], err = sql.Open("pgx", postgresRunner.DataSourceName())
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -562,7 +562,7 @@ func SetupSchemaFromFile(db *sql.DB, path string) {
 	migrations, err := os.ReadFile(path)
 	Expect(err).NotTo(HaveOccurred())
 
-	for _, migration := range strings.Split(string(migrations), ";") {
+	for migration := range strings.SplitSeq(string(migrations), ";") {
 		_, err = db.Exec(migration)
 		Expect(err).NotTo(HaveOccurred())
 	}

--- a/atc/db/migration/migrations/1765921815_rerun_of_bigint.down.sql
+++ b/atc/db/migration/migrations/1765921815_rerun_of_bigint.down.sql
@@ -1,0 +1,16 @@
+
+DROP INDEX rerun_of_builds_idx;
+ALTER INDEX rerun_of_old_builds_idx RENAME TO rerun_of_builds_idx;
+
+DROP INDEX succeeded_builds_ordering_with_rerun_builds_idx;
+ALTER INDEX succeeded_builds_ordering_with_rerun_old_builds_idx RENAME TO succeeded_builds_ordering_with_rerun_builds_idx;
+
+DROP INDEX order_builds_by_rerun_of_or_id_idx;
+ALTER INDEX order_builds_by_rerun_of_old_or_id_idx RENAME TO order_builds_by_rerun_of_or_id_idx;
+
+DROP INDEX order_job_builds_by_rerun_of_or_id_idx;
+ALTER INDEX order_job_builds_by_rerun_of_old_or_id_idx RENAME TO order_job_builds_by_rerun_of_or_id_idx;
+
+ALTER TABLE builds DROP COLUMN "rerun_of";
+
+ALTER TABLE builds RENAME COLUMN "rerun_of_old" TO "rerun_of";

--- a/atc/db/migration/migrations/1765921815_rerun_of_bigint.up.sql
+++ b/atc/db/migration/migrations/1765921815_rerun_of_bigint.up.sql
@@ -1,0 +1,18 @@
+
+ALTER TABLE builds RENAME COLUMN "rerun_of" TO "rerun_of_old";
+
+ALTER TABLE builds ADD COLUMN "rerun_of" bigint REFERENCES builds (id) ON DELETE CASCADE;
+
+ALTER INDEX rerun_of_builds_idx RENAME TO rerun_of_old_builds_idx;
+CREATE INDEX rerun_of_builds_idx ON builds (rerun_of);
+
+ALTER INDEX succeeded_builds_ordering_with_rerun_builds_idx RENAME TO succeeded_builds_ordering_with_rerun_old_builds_idx;
+CREATE INDEX succeeded_builds_ordering_with_rerun_builds_idx ON builds (job_id, rerun_of, COALESCE(rerun_of, id) DESC, id DESC) WHERE status = 'succeeded';
+
+ALTER INDEX order_builds_by_rerun_of_or_id_idx RENAME TO order_builds_by_rerun_of_old_or_id_idx;
+CREATE INDEX order_builds_by_rerun_of_or_id_idx ON builds((COALESCE(rerun_of, id)) DESC, id DESC);
+
+ALTER INDEX order_job_builds_by_rerun_of_or_id_idx RENAME TO order_job_builds_by_rerun_of_old_or_id_idx;
+CREATE INDEX order_job_builds_by_rerun_of_or_id_idx
+  ON builds (job_id, COALESCE(rerun_of, id) DESC, id DESC)
+  WHERE job_id IS NOT NULL;

--- a/atc/db/migration/open_helper_test.go
+++ b/atc/db/migration/open_helper_test.go
@@ -25,7 +25,7 @@ var _ = Describe("OpenHelper", func() {
 		db, err = sql.Open("pgx", postgresRunner.DataSourceName())
 		Expect(err).NotTo(HaveOccurred())
 
-		for i := 0; i < lock.FactoryCount; i++ {
+		for i := range lock.FactoryCount {
 			lockDB[i], err = sql.Open("pgx", postgresRunner.DataSourceName())
 			Expect(err).NotTo(HaveOccurred())
 		}

--- a/atc/db/migration/parser.go
+++ b/atc/db/migration/parser.go
@@ -56,7 +56,7 @@ func (p *Parser) ParseFileToMigration(migrationName string) (migration, error) {
 	}
 
 	migrationContents = string(migrationBytes)
-	migration.Strategy = determineMigrationStrategy(migrationName, migrationContents)
+	migration.Strategy = determineMigrationStrategy(migrationName)
 
 	switch migration.Strategy {
 	case GoMigration:
@@ -84,7 +84,7 @@ func determineDirection(migrationName string) (string, error) {
 	return matches[1], nil
 }
 
-func determineMigrationStrategy(migrationName string, migrationContents string) Strategy {
+func determineMigrationStrategy(migrationName string) Strategy {
 	if strings.HasSuffix(migrationName, ".go") {
 		return GoMigration
 	} else {


### PR DESCRIPTION
## Changes proposed by this PR

closes #8499 and #9029

* Renames existing `rerun_of` to `rerun_of_old` in the `builds` table
* Adds a new column named `rerun_of` with type bigint
* Rename indexes where `rerun_of_old` is used and create copies of the indexes referencing the new `rerun_of` column

## Notes to reviewer

Tldr of the issue was that once your build id's surpassed the size supported by `int` in Postgresql, trying to re-run a build with an id larger than `int` would fail because the `rerun_of` column was of type `int`.

See the comments in #8499 which explains why we went this route. Tldr: shipping long-running migrations in an OSS project is hard.

## TODO

- [ ] ~Migration-level test that I can add? As-is, the db and scheduler tests are passing. I think I can add some tests in `atc/db/migration`~ Deciding to skip this, doesn't seem to result in long-term value IMO
- [x] Manual tests:
  - [x] New rerun builds can be created of existing builds (rerun and non-rerun builds) after upgrading
  - [x] Resource versions that passed old builds (before this migration) still pass downstream as expected