### PR TITLE
fix: across step showing failed when nested retry succeeds

### DIFF
--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -160,6 +160,7 @@ mostSevereStepState model stepTree =
                 case step.buildStep of
                     Concourse.BuildStepDo _ ->
                         state
+
                     _ ->
                         case stepStateOrdering step.state state of
                             LT ->
@@ -323,8 +324,10 @@ activeStepIds model tree =
         Retry _ trees ->
             trees
                 |> Array.toList
-                |> List.Extra.takeWhile (mostSevereStepState model >> (/=) StepStateSucceeded)
-                |> List.concatMap (activeStepIds model)
+                |> List.filter (treeIsActive model)
+                |> List.Extra.last
+                |> Maybe.map (activeStepIds model)
+                |> Maybe.withDefault []
 
 
 updateTreeNodeAt : StepID -> (StepTree -> StepTree) -> StepTree -> StepTree


### PR DESCRIPTION
activeStepIds for Retry used takeWhile to collect attempts until success, which excluded the successful attempt itself. Parent steps then only saw failed attempts when computing severity.

Changed to only include the last active attempt's steps, since that represents the retry's actual outcome.

Fixes #7565
