### PR TITLE
feat(web): show red/orange background on group tabs when jobs fail or error

### DIFF
--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -16,6 +16,7 @@ module Pipeline.Pipeline exposing
 import Application.Models exposing (Session)
 import Colors
 import Concourse
+import Concourse.BuildStatus exposing (BuildStatus(..))
 import DateFormat
 import EffectTransformer exposing (ET)
 import Favorites
@@ -682,6 +683,9 @@ viewSubPage session model =
 viewGroupsBar : { a | hovered : HoverState.HoverState } -> Model -> Html Message
 viewGroupsBar session model =
     let
+        jobs =
+            Maybe.withDefault [] model.fetchedJobs
+
         groupList =
             case model.pipeline of
                 RemoteData.Success pipeline ->
@@ -690,6 +694,7 @@ viewGroupsBar session model =
                             { selectedGroups = selectedGroupsOrDefault model
                             , pipelineLocator = model.pipelineLocator
                             , hovered = session.hovered
+                            , jobs = jobs
                             }
                         )
                         pipeline.groups
@@ -711,15 +716,25 @@ viewGroup :
         | selectedGroups : List String
         , pipelineLocator : Concourse.PipelineIdentifier
         , hovered : HoverState.HoverState
+        , jobs : List Concourse.Job
     }
     -> Int
     -> Concourse.PipelineGroup
     -> Html Message
-viewGroup { selectedGroups, pipelineLocator, hovered } idx grp =
+viewGroup { selectedGroups, pipelineLocator, hovered, jobs } idx grp =
     let
         url =
             Routes.toString <|
                 Routes.Pipeline { id = pipelineLocator, groups = [ grp.name ] }
+
+        groupJobs =
+            List.filter (\job -> List.member grp.name job.groups) jobs
+
+        hasFailedJob =
+            List.any (jobHasStatus BuildStatusFailed) groupJobs
+
+        hasErroredJob =
+            List.any (jobHasStatus BuildStatusErrored) groupJobs
     in
     Html.a
         ([ Html.Attributes.href <| url
@@ -730,9 +745,23 @@ viewGroup { selectedGroups, pipelineLocator, hovered } idx grp =
             ++ Styles.groupItem
                 { selected = List.member grp.name selectedGroups
                 , hovered = HoverState.isHovered (JobGroup idx) hovered
+                , hasFailedJob = hasFailedJob
+                , hasErroredJob = hasErroredJob
                 }
         )
         [ Html.text grp.name ]
+
+
+{-| Check if a job's finished build has the given status
+-}
+jobHasStatus : BuildStatus -> Concourse.Job -> Bool
+jobHasStatus status job =
+    case job.finishedBuild of
+        Just build ->
+            build.status == status
+
+        Nothing ->
+            False
 
 
 jobAppearsInGroups : List String -> Concourse.Job -> Bool

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -730,11 +730,15 @@ viewGroup { selectedGroups, pipelineLocator, hovered, jobs } idx grp =
         groupJobs =
             List.filter (\job -> List.member grp.name job.groups) jobs
 
-        hasFailedJob =
-            List.any (jobHasStatus BuildStatusFailed) groupJobs
-
-        hasErroredJob =
-            List.any (jobHasStatus BuildStatusErrored) groupJobs
+        ( hasFailedJob, hasErroredJob ) =
+            List.foldl
+                (\job ( failedAcc, erroredAcc ) ->
+                    ( failedAcc || jobHasStatus BuildStatusFailed job
+                    , erroredAcc || jobHasStatus BuildStatusErrored job
+                    )
+                )
+                ( False, False )
+                groupJobs
     in
     Html.a
         ([ Html.Attributes.href <| url

--- a/web/elm/src/Pipeline/Styles.elm
+++ b/web/elm/src/Pipeline/Styles.elm
@@ -24,13 +24,21 @@ groupsBar =
     ]
 
 
-groupItem : { selected : Bool, hovered : Bool } -> List (Html.Attribute msg)
-groupItem { selected, hovered } =
+groupItem : { selected : Bool, hovered : Bool, hasFailedJob : Bool, hasErroredJob : Bool } -> List (Html.Attribute msg)
+groupItem { selected, hovered, hasFailedJob, hasErroredJob } =
     [ style "font-size" "14px"
-    , style "background" Colors.groupBackground
     , style "margin" "5px"
     , style "padding" "10px"
     ]
+        ++ (if hasErroredJob then
+                [ style "background" Colors.error ]
+
+            else if hasFailedJob then
+                [ style "background" Colors.failure ]
+
+            else
+                [ style "background" Colors.groupBackground ]
+           )
         ++ (if selected then
                 [ style "opacity" "1"
                 , style "border" <| "1px solid " ++ Colors.groupBorderSelected


### PR DESCRIPTION
Group tabs in the pipeline view now display a colored background based on the status of jobs within that group:
- Colors.failure when any job in the group has a failed finished build
- Colors.error when any job has an errored finished build
- Error takes precedence over failure when both exist

This allows users to quickly identify problematic groups without having to expand each group to see individual job statuses.

Fixes #3172