### PR TITLE
Show deprecated warning message for pipelines that use job.build_logs_to_retain

### DIFF
--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -356,6 +356,13 @@ func validateJobs(c atc.Config) ([]atc.ConfigWarning, error) {
 			errorMessages = append(errorMessages, identifier+" has no name")
 		}
 
+		if job.BuildLogsToRetain != 0 {
+			warnings = append(warnings, atc.ConfigWarning{
+				Type:    "deprecated_field",
+				Message: fmt.Sprintf("%s.build_logs_to_retain is deprecated. Use build_log_retention instead.", identifier),
+			})
+		}
+
 		if job.BuildLogRetention != nil && job.BuildLogsToRetain != 0 {
 			errorMessages = append(
 				errorMessages,

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -2171,6 +2171,18 @@ var _ = Describe("ValidateConfig", func() {
 			})
 		})
 
+		Context("when a job has build_logs_to_retain configured", func() {
+			BeforeEach(func() {
+				config.Jobs[0].BuildLogsToRetain = 1
+			})
+
+			It("returns a warning", func() {
+				Expect(warnings).To(HaveLen(1))
+				Expect(warnings[0].Type).To(Equal("deprecated_field"))
+				Expect(warnings[0].Message).To(ContainSubstring(".build_logs_to_retain is deprecated. Use build_log_retention instead."))
+			})
+		})
+
 		Context("when a job has negative build_log_retention values", func() {
 			BeforeEach(func() {
 				config.Jobs[0].BuildLogRetention = &atc.BuildLogRetention{

--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -10,7 +10,9 @@ type JobConfig struct {
 	Interruptible        bool     `json:"interruptible,omitempty"`
 	SerialGroups         []string `json:"serial_groups,omitempty"`
 	RawMaxInFlight       int      `json:"max_in_flight,omitempty"`
-	BuildLogsToRetain    int      `json:"build_logs_to_retain,omitempty"`
+
+	// Deprecated: users should use BuildLogRetention
+	BuildLogsToRetain int `json:"build_logs_to_retain,omitempty"`
 
 	BuildLogRetention *BuildLogRetention `json:"build_log_retention,omitempty"`
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #9270 

* A warning message is now displayed for any pipelines that use `job.build_logs_to_retain`

Users will see a message like this when setting a pipeline with fly:
<img width="848" height="65" alt="image" src="https://github.com/user-attachments/assets/60b3d1a9-c166-44e5-9003-38eaa4204b3e" />

```
DEPRECATION WARNING:
  - jobs.job-1.build_logs_to_retain is deprecated. Use build_log_retention instead.
```