### PR TITLE
Have task steps fallback to the container's ENTRYPOINT/CMD if run.path is not specified

### DIFF
--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -1113,7 +1113,6 @@ var _ = Describe("ValidateConfig", func() {
 					Expect(errorMessages).To(HaveLen(1))
 					Expect(errorMessages[0]).To(ContainSubstring("invalid jobs:"))
 					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].task(some-resource).config: missing 'platform'"))
-					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].task(some-resource).config: missing path to executable to run"))
 				})
 			})
 

--- a/atc/task.go
+++ b/atc/task.go
@@ -93,10 +93,6 @@ func (config TaskConfig) Validate() error {
 		errors = append(errors, "missing 'platform'")
 	}
 
-	if config.Run.Path == "" {
-		errors = append(errors, "missing path to executable to run")
-	}
-
 	errors = append(errors, config.validateInputContainsNames()...)
 	errors = append(errors, config.validateOutputContainsNames()...)
 

--- a/atc/task_test.go
+++ b/atc/task_test.go
@@ -390,8 +390,8 @@ run: {path: a/file}
 				invalidConfig.Run.Path = ""
 			})
 
-			It("returns an error", func() {
-				Expect(invalidConfig.Validate()).To(MatchError(ContainSubstring("missing path to executable to run")))
+			It("does not return an error", func() {
+				Expect(invalidConfig.Validate()).To(BeNil())
 			})
 		})
 


### PR DESCRIPTION
## Changes proposed by this PR

Related to this discussion https://github.com/orgs/concourse/discussions/9394

This was not the first time I'd seen this request come up. Thought about a couple different approaches and eventually realized this was a viable path forward to making Concourse leverage more of the OCI spec.

## Notes to reviewer

This PR relies on the registry-image resource (https://github.com/concourse/registry-image-resource/pull/394) exporting the ENTRYPOINT/CMD in the `metadata.json` file that sits alongside the `rootfs/` directory. We already ask users to rely on this resource to pull in images in the rootfs format, so users don't need to do anything new.

We already rely on users to use this resource for pulling in container images that Concourse can understand. Our rootfs format is also specific to us. I thought we might share it with Guardian, but looking at their GRootfs package, this does not appear to be the case.

This change also makes the `run.path` in a Task's config optional now. I've added an error message that clearly explains that users need to either set a `run.path` or an ENTRYPOINT/CMD.

Nothing changes for tasks targeting Windows/Darwin workers.

I tested this manually with the guardian and containerd runtimes to ensure there was nothing unexpected happening with either runtime.

```yaml
resource_types:
  - name: registry-image
    type: registry-image
    source:
      repository: docker.io/taylorsilva/registry-image
      tag: entrypoint

resources:
  - name: mock
    type: mock

  - name: hello
    type: registry-image
    source:
      repository: docker.io/concourse/test-image-entrypoint
      tag: latest

jobs:
  - name: job-1
    plan:
      - get: hello
      - in_parallel:
          - task: run
            image: hello
            config:
              platform: linux
          - task: check
            image: mock
            config:
              platform: linux
```

<img width="1239" height="270" alt="image" src="https://github.com/user-attachments/assets/4b699fcc-ddda-4876-b23f-251542194491" />


## Release Note

A task's `run.path` is no longer required. Concourse will fallback to a container's ENTRYPOINT/CMD if it's been set. Concourse follows the same execution rules as Docker, which is:

1. ENTRYPOINT first
2. Append CMD as args. Concourse will then
3. Append any args defined in the task's config (`run.args`)

If `run.path` is defined, then ENTRYPOINT/CMD are ignored.