### PR TITLE
fix: variable shadowing, implicit global, and missing icon in copy

### DIFF
--- a/web/public/graph.mjs
+++ b/web/public/graph.mjs
@@ -285,7 +285,7 @@ Graph.prototype.collapseEquivalentNodes = function() {
       continue;
     }
 
-    byEqv = byRank[node.equivalentBy];
+    var byEqv = byRank[node.equivalentBy];
     if (byEqv === undefined) {
       byEqv = [];
       byRank[node.equivalentBy] = byEqv;
@@ -592,6 +592,7 @@ GraphNode.prototype.copy = function() {
   return new GraphNode({
     id: this.id,
     name: this.name,
+    icon: this.icon,
     class: this.class,
     status: this.status,
     repeatable: this.repeatable,

--- a/web/public/index.mjs
+++ b/web/public/index.mjs
@@ -167,8 +167,8 @@ function redrawFunction(svg, jobs, resources, newUrl) {
       if (graphNodes[i].status == "failed") {
         var xCenter = graphNodes[i].position().x + (graphNodes[i].width() / 2)
         var found = false
-        for (var i in failureCenters) {
-          if (Math.abs(xCenter - failureCenters[i]) < epsilon) {
+        for (var j in failureCenters) {
+          if (Math.abs(xCenter - failureCenters[j]) < epsilon) {
             found = true
             break
           }


### PR DESCRIPTION
- index.mjs: rename inner loop var `i` to `j` in failureCenters loop to prevent shadowing outer graphNodes loop variable
- graph.mjs: add missing `var` before `byEqv` in collapseEquivalentNodes to prevent implicit global variable creation
- graph.mjs: add missing `icon` property to GraphNode.copy() so spacing nodes retain their icon when cloned
