### PR TITLE
feat: allow glob patterning for get.passed

### DIFF
--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/concourse/concourse/atc"
@@ -528,13 +529,10 @@ func detectCycle(j atc.JobConfig, visited map[string]JobState, pipelineConfig at
 	err := j.StepConfig().Visit(atc.StepRecursor{
 		OnGet: func(step *atc.GetStep) error {
 			for _, nextJobGlob := range step.Passed {
-				g, err := glob.Compile(nextJobGlob)
-				if err != nil {
-					return err
-				}
-
 				for _, job := range pipelineConfig.Jobs {
-					if g.Match(job.Name) {
+					matched, _ := path.Match(nextJobGlob, job.Name)
+
+					if matched {
 						if err := detectCycle(job, visited, pipelineConfig); err != nil {
 							return err
 						}

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -1802,13 +1803,10 @@ func insertJobPipes(tx Tx, jobConfigs atc.JobConfigs, resourceNameToID map[strin
 func insertJobInput(tx Tx, step *atc.GetStep, jobName string, resourceNameToID map[string]int, jobNameToID map[string]int) error {
 	if len(step.Passed) != 0 {
 		for _, passedJobGlob := range step.Passed {
-			g, err := glob.Compile(passedJobGlob)
-			if err != nil {
-				return err
-			}
-
 			for job, jobID := range jobNameToID {
-				if g.Match(job) {
+				matched, _ := path.Match(passedJobGlob, job)
+
+				if matched {
 					var version sql.NullString
 					if step.Version != nil {
 						versionJSON, err := step.Version.MarshalJSON()

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -2459,6 +2459,78 @@ var _ = Describe("Team", func() {
 			Expect(found).To(BeFalse())
 		})
 
+		Context("save get glob passed", func() {
+			var (
+				newConfig atc.Config
+			)
+
+			BeforeEach(func() {
+				newConfig = atc.Config{
+					Resources: atc.ResourceConfigs{
+						{
+							Name: "some-resource",
+							Type: "some-type",
+							Source: atc.Source{
+								"source-config": "some-value",
+							},
+							Icon: "some-icon",
+						},
+					},
+
+					ResourceTypes: atc.ResourceTypes{
+						{
+							Name: "some-resource-type",
+							Type: "some-type",
+							Source: atc.Source{
+								"source-config": "some-value",
+							},
+						},
+					},
+
+					Jobs: atc.JobConfigs{
+						{
+							Name: "final-tasking",
+
+							Public: true,
+
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:     "some-input",
+										Resource: "some-resource",
+										Params: atc.Params{
+											"some-param": "some-value",
+										},
+										Passed:  []string{"job-*"},
+										Trigger: true,
+									},
+								},
+							},
+						},
+						{
+							Name: "job-1",
+						},
+						{
+							Name: "job-2",
+						},
+					},
+				}
+			})
+
+			It("resolves appropriately", func() {
+				pipeline, _, err := team.SavePipeline(pipelineRef, newConfig, 0, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				job, found, err := pipeline.Job("final-tasking")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				jobConfig, err := job.Config()
+				getStep := jobConfig.PlanSequence[0].Config.(*atc.GetStep)
+				Expect(getStep.Passed).To(ConsistOf("job-*"))
+			})
+		})
+
 		Context("update job names but keeps history", func() {
 			BeforeEach(func() {
 				newJobConfig := atc.JobConfig{

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -2,10 +2,9 @@ package atc
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"time"
-
-	"github.com/gobwas/glob"
 )
 
 // StepValidator is a StepVisitor which validates each step that visits it,
@@ -143,15 +142,11 @@ func (validator *StepValidator) VisitGet(step *GetStep) error {
 	validator.pushContext(".passed")
 
 	for _, jobGlob := range step.Passed {
-		g, err := glob.Compile(jobGlob)
-		if err != nil {
-			validator.recordErrorf("invalid glob expression '%s'", jobGlob)
-			continue
-		}
-
 		foundJob := false
 		for _, jobConfig := range validator.config.Jobs {
-			if g.Match(jobConfig.Name) {
+			matched, _ := path.Match(jobGlob, jobConfig.Name)
+
+			if matched {
 				foundJob = true
 
 				foundResource := false


### PR DESCRIPTION
## Changes proposed by this PR

closes #9299

* Updates various validation logic to support glob matching for get.passed

## Notes to reviewer

Implementation initially generated by Google Gemini. Improved slightly post code review. Implementation tested locally.

## Release Note

* `get.passed` can now take a Glob pattern to search for jobs, similar to `groups`

## Pipeline Examples

<details>

<summary>Existing Logic</summary>

```yaml
---
resources:
  - name: every-30s
    type: time
    icon: clock-outline
    source:
      interval: 30s

jobs:
  - name: job-prod
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-2-prod
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-15
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-3
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
        passed:
          - job-2-prod
          - job-prod
          - job-15
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]
```

</details>

<details>

<summary>Strict Glob Logic</summary>

```yaml
---
resources:
  - name: every-30s
    type: time
    icon: clock-outline
    source:
      interval: 30s

jobs:
  - name: job-prod
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-2-prod
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-15
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-3
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
        passed:
          - "*-prod"
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]
```

</details>

<details>

<summary>Mixed Logic</summary>

```yaml
---
resources:
  - name: every-30s
    type: time
    icon: clock-outline
    source:
      interval: 30s

jobs:
  - name: job-prod
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-2-prod
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-15
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-3
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
        passed:
          - "*-prod"
          - job-15
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]
```

</details>


<details>

<summary>Failing Logic</summary>

```yaml
---
resources:
  - name: every-30s
    type: time
    icon: clock-outline
    source:
      interval: 30s

jobs:
  - name: job-prod
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-2-prod
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-15
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]

  - name: job-3
    public: true
    build_log_retention:
      builds: 50
    plan:
      - get: every-30s
        trigger: true
        passed:
          - "*-prod"
          - job-15
          - "*-test"
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]
```

</details>

