### PR TITLE
Add metadata from get steps to the local build var

### DIFF
--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -253,6 +253,8 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 			delegate.UpdateResourceVersion(logger, step.plan.Resource, versionResult)
 		}
 
+		state.AddLocalVar(step.plan.Name, AsMap(versionResult.Metadata), false)
+
 		succeeded = true
 	}
 
@@ -525,4 +527,12 @@ func (step *GetStep) resourceMountVolume(mounts []runtime.VolumeMount) runtime.V
 		}
 	}
 	return nil
+}
+
+func AsMap(metadata []atc.MetadataField) map[string]any {
+	result := make(map[string]any, len(metadata))
+	for _, kv := range metadata {
+		result[kv.Name] = kv.Value
+	}
+	return result
 }

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -734,6 +734,11 @@ var _ = Describe("GetStep", func() {
 			Expect(fakeDelegate.UpdateResourceVersionCallCount()).To(Equal(1))
 		})
 
+		It("adds metadata to the build variables", func() {
+			value, _, _ := runState.Get(vars.Reference{Source: ".", Path: getPlan.Name, Fields: []string{"some"}})
+			Expect(value).To(Equal("metadata"))
+		})
+
 		It("does not return an err", func() {
 			Expect(stepErr).ToNot(HaveOccurred())
 		})


### PR DESCRIPTION
## Changes proposed by this PR

Metadata from `get` steps are added to the local build var `((.:))` under the name of the get step. E.g.:

```yaml
- get: repo
```
Will then have all it's metadata available under the var `((.:repo.<metadata-field-name))`.

Example from CI:
<img width="785" height="389" alt="image" src="https://github.com/user-attachments/assets/1ed8c69a-33f4-47b8-8559-86ba14c4e78c" />
Will then have the following vars available in the build for later steps to use:
* `((.:repo.commit))`
* `((.:repo.author))`
* `((.:repo.author_date))`
* etc.
