### PR TITLE
force postgres to update table stats for `builds` after after the rerun_of migration

### DIFF
--- a/atc/db/migration/migrations/1765921815_rerun_of_bigint.up.sql
+++ b/atc/db/migration/migrations/1765921815_rerun_of_bigint.up.sql
@@ -16,3 +16,8 @@ ALTER INDEX order_job_builds_by_rerun_of_or_id_idx RENAME TO order_job_builds_by
 CREATE INDEX order_job_builds_by_rerun_of_or_id_idx
   ON builds (job_id, COALESCE(rerun_of, id) DESC, id DESC)
   WHERE job_id IS NOT NULL;
+
+-- Table stats are outdated after creating the above indexes. After testing,
+-- found that we needed to force postgres to update stats on builds, otherwise
+-- query plans were severly inefficient when querying the new run_of column.
+ANALYZE builds;


### PR DESCRIPTION
## Changes proposed by this PR

Blocks the v8 release.

Postgres was making a very inefficient query plan when running queries that used the new `rerun_of` column. I ran the following query against a local copy of the ci.concourse-ci.org database:

```sql
SELECT max(id) FROM builds WHERE status NOT IN ('pending', 'started') AND job_id = 490 AND rerun_of = 249530173
```

On 7.14.3 I got this query plan:
```
Aggregate  (cost=8.46..8.47 rows=1 width=8) (actual time=0.289..0.289 rows=1 loops=1)
  ->  Index Scan using rerun_of_builds_idx on builds  (cost=0.43..8.46 rows=1 width=8) (actual time=0.287..0.287 rows=0 loops=1)
        Index Cond: (rerun_of = 249530173)
        Filter: ((status <> ALL ('{pending,started}'::build_status[])) AND (job_id = 490))
Planning Time: 8.150 ms
Execution Time: 0.318 ms
```

After applying all 8.0 migrations, the exact same query returned this query plan:
```
Result  (cost=300.57..300.58 rows=1 width=8) (actual time=7406.027..7406.028 rows=1 loops=1)
  InitPlan 1
    ->  Limit  (cost=0.43..300.57 rows=1 width=8) (actual time=7406.025..7406.026 rows=0 loops=1)
          ->  Index Scan using builds_ordered_by_job_id_idx on builds  (cost=0.43..1431067.81 rows=4768 width=8) (actual time=7406.025..7406.025 rows=0 loops=1)
                Index Cond: (job_id = 490)
                Filter: ((status <> ALL ('{pending,started}'::build_status[])) AND (rerun_of = 249530173))
                Rows Removed by Filter: 962450
Planning Time: 4.567 ms
Execution Time: 7406.039 ms
```

The key difference between the two is that the `rerun_of_builds_idx` is not being used. After running `ANALYZE builds;` though, they query plan started using the new index:

```
Aggregate  (cost=8.46..8.47 rows=1 width=8) (actual time=0.062..0.063 rows=1 loops=1)
  ->  Index Scan using rerun_of_builds_idx on builds  (cost=0.43..8.46 rows=1 width=8) (actual time=0.056..0.057 rows=0 loops=1)
        Index Cond: (rerun_of = 249530173)
        Filter: ((status <> ALL ('{pending,started}'::build_status[])) AND (job_id = 490))
Planning Time: 0.854 ms
Execution Time: 0.283 ms
```

I also tested the rerun_of_old variant of the query, which is what will be more commonly run:
```sql
SELECT max(id) FROM builds WHERE status NOT IN ('pending', 'started') AND job_id = 490 AND (rerun_of = 249530173 or rerun_of_old = 249530173)
```

It initially had the same issue, not using `rerun_of_builds_idx`. After updating the table stats, it did:

```
Aggregate  (cost=12.90..12.91 rows=1 width=8) (actual time=1.601..1.602 rows=1 loops=1)
  ->  Bitmap Heap Scan on builds  (cost=8.88..12.90 rows=1 width=8) (actual time=1.598..1.599 rows=0 loops=1)
        Recheck Cond: ((rerun_of = 249530173) OR (rerun_of_old = 249530173))
        Filter: ((status <> ALL ('{pending,started}'::build_status[])) AND (job_id = 490))
        ->  BitmapOr  (cost=8.88..8.88 rows=1 width=0) (actual time=1.593..1.594 rows=0 loops=1)
              ->  Bitmap Index Scan on rerun_of_builds_idx  (cost=0.00..4.44 rows=1 width=0) (actual time=0.010..0.010 rows=0 loops=1)
                    Index Cond: (rerun_of = 249530173)
              ->  Bitmap Index Scan on rerun_of_old_builds_idx  (cost=0.00..4.44 rows=1 width=0) (actual time=1.582..1.582 rows=0 loops=1)
                    Index Cond: (rerun_of_old = 249530173)
Planning Time: 0.407 ms
Execution Time: 1.624 ms
```

# More Context

This was all initially noticed when I tried upgrading ci.concourse-ci.org to 8.0 RC-1. The database CPU shot up to 30-40%. It was previously under 10% before the upgrade.

I checked for long running queries and found multiple `UPDATE/DELETE` statements taking 10s of minutes to run. All these queries reference columns that have a foreign key constraint on the `builds.id` key.
```
# First number is the number of queries with the same statement that are waiting
48	00:36:16.599476	DELETE FROM build_image_resource_caches WHERE (job_id = $1 AND build_id < $2)
8	00:08:22.112364	UPDATE jobs SET transition_build_id = $1 WHERE id = $2
1	00:09:26.396551	DELETE FROM resource_cache_uses rcu USING builds b WHERE (rcu.build_id = b.id AND b.interceptible = false)
```

I ran more queries to see what was blocking all these `UPDATE` queries and eventually found this query:
```
5	00:01:09.904392	SELECT max(id) FROM builds WHERE status NOT IN ('pending', 'started') AND job_id = $1 AND (rerun_of = $2 OR rerun_of_old = $3)
```

This query ends up getting a shared lock on the `builds` table when it runs, which blocks all the `UPDATE/DELETE` statements from getting their exclusive row locks, which does extend to the `builds` table because of their foreign key constraint on the `builds.id` key.