### PR TITLE
More fixes for rerun_of indexes

### DIFF
--- a/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.up.sql
+++ b/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.up.sql
@@ -81,6 +81,9 @@ ALTER TABLE resource_config_versions
 ADD CONSTRAINT resource_config_scope_id_and_version_sha256_unique
 UNIQUE (resource_config_scope_id, version_sha256);
 
+-- ensure lookups using version_md5 are still fast
+CREATE INDEX resource_config_scope_id_and_version_md5_idx ON resource_config_versions(resource_config_scope_id, version_md5);
+
 CREATE INDEX resource_config_versions_check_order_idx
 ON resource_config_versions (resource_config_scope_id, check_order DESC);
 

--- a/atc/db/migration/migrations/1765921815_rerun_of_bigint.down.sql
+++ b/atc/db/migration/migrations/1765921815_rerun_of_bigint.down.sql
@@ -3,13 +3,15 @@ DROP INDEX rerun_of_builds_idx;
 ALTER INDEX rerun_of_old_builds_idx RENAME TO rerun_of_builds_idx;
 
 DROP INDEX succeeded_builds_ordering_with_rerun_builds_idx;
-ALTER INDEX succeeded_builds_ordering_with_rerun_old_builds_idx RENAME TO succeeded_builds_ordering_with_rerun_builds_idx;
+CREATE INDEX succeeded_builds_ordering_with_rerun_builds_idx ON builds (job_id, rerun_of, COALESCE(rerun_of, id) DESC, id DESC) WHERE status = 'succeeded';
 
 DROP INDEX order_builds_by_rerun_of_or_id_idx;
-ALTER INDEX order_builds_by_rerun_of_old_or_id_idx RENAME TO order_builds_by_rerun_of_or_id_idx;
+CREATE INDEX order_builds_by_rerun_of_or_id_idx ON builds((COALESCE(rerun_of, id)) DESC, id DESC);
 
 DROP INDEX order_job_builds_by_rerun_of_or_id_idx;
-ALTER INDEX order_job_builds_by_rerun_of_old_or_id_idx RENAME TO order_job_builds_by_rerun_of_or_id_idx;
+CREATE INDEX order_job_builds_by_rerun_of_or_id_idx
+  ON builds (job_id, COALESCE(rerun_of, id) DESC, id DESC)
+  WHERE job_id IS NOT NULL;
 
 ALTER TABLE builds DROP COLUMN "rerun_of";
 

--- a/atc/db/migration/migrations/1765921815_rerun_of_bigint.up.sql
+++ b/atc/db/migration/migrations/1765921815_rerun_of_bigint.up.sql
@@ -6,19 +6,22 @@ ALTER TABLE builds ADD COLUMN "rerun_of" bigint REFERENCES builds (id) ON DELETE
 ALTER INDEX rerun_of_builds_idx RENAME TO rerun_of_old_builds_idx;
 CREATE INDEX rerun_of_builds_idx ON builds (rerun_of);
 
-ALTER INDEX succeeded_builds_ordering_with_rerun_builds_idx RENAME TO succeeded_builds_ordering_with_rerun_old_builds_idx;
-CREATE INDEX succeeded_builds_ordering_with_rerun_builds_idx ON builds (job_id, rerun_of, COALESCE(rerun_of, id) DESC, id DESC) WHERE status = 'succeeded';
+DROP INDEX succeeded_builds_ordering_with_rerun_builds_idx;
+CREATE INDEX succeeded_builds_ordering_with_rerun_builds_idx ON builds (job_id)
+    INCLUDE (id, rerun_of, rerun_of_old)
+    WHERE status = 'succeeded';
 
-ALTER INDEX order_builds_by_rerun_of_or_id_idx RENAME TO order_builds_by_rerun_of_old_or_id_idx;
-CREATE INDEX order_builds_by_rerun_of_or_id_idx ON builds((COALESCE(rerun_of, id)) DESC, id DESC);
+DROP INDEX order_builds_by_rerun_of_or_id_idx;
+CREATE INDEX order_builds_by_rerun_of_or_id_idx ON builds(
+    COALESCE(rerun_of, rerun_of_old, id) DESC,
+    id DESC);
 
-ALTER INDEX order_job_builds_by_rerun_of_or_id_idx RENAME TO order_job_builds_by_rerun_of_old_or_id_idx;
+DROP INDEX order_job_builds_by_rerun_of_or_id_idx;
 CREATE INDEX order_job_builds_by_rerun_of_or_id_idx ON builds (
     job_id,
     COALESCE(rerun_of, rerun_of_old, id) DESC,
     id DESC
-)
-WHERE job_id IS NOT NULL;
+) WHERE job_id IS NOT NULL;
 
 -- Table stats are outdated after creating the above indexes. After testing,
 -- found that we needed to force postgres to update stats on builds, otherwise

--- a/atc/db/migration/migrations/1765921815_rerun_of_bigint.up.sql
+++ b/atc/db/migration/migrations/1765921815_rerun_of_bigint.up.sql
@@ -13,9 +13,12 @@ ALTER INDEX order_builds_by_rerun_of_or_id_idx RENAME TO order_builds_by_rerun_o
 CREATE INDEX order_builds_by_rerun_of_or_id_idx ON builds((COALESCE(rerun_of, id)) DESC, id DESC);
 
 ALTER INDEX order_job_builds_by_rerun_of_or_id_idx RENAME TO order_job_builds_by_rerun_of_old_or_id_idx;
-CREATE INDEX order_job_builds_by_rerun_of_or_id_idx
-  ON builds (job_id, COALESCE(rerun_of, id) DESC, id DESC)
-  WHERE job_id IS NOT NULL;
+CREATE INDEX order_job_builds_by_rerun_of_or_id_idx ON builds (
+    job_id,
+    COALESCE(rerun_of, rerun_of_old, id) DESC,
+    id DESC
+)
+WHERE job_id IS NOT NULL;
 
 -- Table stats are outdated after creating the above indexes. After testing,
 -- found that we needed to force postgres to update stats on builds, otherwise


### PR DESCRIPTION
## Changes proposed by this PR

Related to #9416 

More index related fixes for slow db queries.

DB performance was better after the last PR, settling around 8%. That is sadly still double what it was before, ~4%.

The query modified in this PR currently takes 10-14s to run. By splitting the query up it goes down to a few milliseconds.

I've already applied the indexes to CI and things are a bit faster now. I'm hoping this query is the last outstanding item. We'll see after I apply the next RC.