### PR TITLE
db: optimize IsFirstOccurrence query for jobs with many builds

### DIFF
--- a/atc/db/versions_db.go
+++ b/atc/db/versions_db.go
@@ -35,10 +35,11 @@ func NewVersionsDB(conn DbConn, limitRows int, cache *gocache.Cache) VersionsDB 
 }
 
 func (versions VersionsDB) IsFirstOccurrence(ctx context.Context, jobID int, inputName string, versionDigest ResourceVersion, resourceID int) (bool, error) {
+	// Shortcut: check if previous non-pending build used the same resource version
 	var lastBuildID sql.NullInt64
 	err := versions.conn.QueryRowContext(ctx, `
 		SELECT id FROM builds
-		WHERE job_id = $1 AND status = 'succeeded'
+		WHERE job_id = $1 AND status <> 'pending'
 		ORDER BY id DESC
 		LIMIT 1`, jobID).Scan(&lastBuildID)
 	if err != nil && err != sql.ErrNoRows {


### PR DESCRIPTION
The original query fetched all builds for a job before filtering by version, causing 2+ second queries for jobs with 35k+ builds.

Add fast-path that checks the last successful build first. This handles the common case where a version is reused across builds, avoiding the expensive fallback query entirely.

Change fallback to use nested EXISTS instead of CTE. This filters by version first then checks job membership, and allows Postgres to stop at the first match.

Fixes #8160 but without index. TBD later on if we'd like to add an index.
