### PR TITLE
Fix down migration cleanup for resource_config_versions_version_md5 index

### DIFF
--- a/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.down.sql
+++ b/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.down.sql
@@ -70,6 +70,7 @@ ALTER TABLE resource_config_versions
 ALTER COLUMN version_md5 SET NOT NULL;
 
 DROP INDEX resource_config_scope_id_and_version_md5_idx;
+DROP INDEX resource_config_versions_version_md5;
 
 -- Revert column renames from version_digest back to version_md5
 ALTER TABLE build_resource_config_version_inputs


### PR DESCRIPTION
## Changes proposed by this PR

related to #9404

While validating v8 in one of our environments, we discovered that the down migration does not drop the `resource_config_versions_version_md5` index. As a result, re-running the up migration fails because the index already exists.

## Notes to reviewer

#### Steps to reproduce:
Apply the up migration from #9404, roll it back using the down migration, then run the migration again.
