### PR TITLE
Fix down migration to fully restore rerun_of indexes

### DIFF
--- a/atc/db/migration/migrations/1765921815_rerun_of_bigint.down.sql
+++ b/atc/db/migration/migrations/1765921815_rerun_of_bigint.down.sql
@@ -3,16 +3,17 @@ DROP INDEX rerun_of_builds_idx;
 ALTER INDEX rerun_of_old_builds_idx RENAME TO rerun_of_builds_idx;
 
 DROP INDEX succeeded_builds_ordering_with_rerun_builds_idx;
-CREATE INDEX succeeded_builds_ordering_with_rerun_builds_idx ON builds (job_id, rerun_of, COALESCE(rerun_of, id) DESC, id DESC) WHERE status = 'succeeded';
-
 DROP INDEX order_builds_by_rerun_of_or_id_idx;
-CREATE INDEX order_builds_by_rerun_of_or_id_idx ON builds((COALESCE(rerun_of, id)) DESC, id DESC);
-
 DROP INDEX order_job_builds_by_rerun_of_or_id_idx;
-CREATE INDEX order_job_builds_by_rerun_of_or_id_idx
-  ON builds (job_id, COALESCE(rerun_of, id) DESC, id DESC)
-  WHERE job_id IS NOT NULL;
 
 ALTER TABLE builds DROP COLUMN "rerun_of";
 
 ALTER TABLE builds RENAME COLUMN "rerun_of_old" TO "rerun_of";
+
+CREATE INDEX succeeded_builds_ordering_with_rerun_builds_idx ON builds (job_id, rerun_of, COALESCE(rerun_of, id) DESC, id DESC) WHERE status = 'succeeded';
+
+CREATE INDEX order_builds_by_rerun_of_or_id_idx ON builds((COALESCE(rerun_of, id)) DESC, id DESC);
+
+CREATE INDEX order_job_builds_by_rerun_of_or_id_idx
+  ON builds (job_id, COALESCE(rerun_of, id) DESC, id DESC)
+  WHERE job_id IS NOT NULL;


### PR DESCRIPTION
## Changes proposed by this PR

While testing the v8 migration, we found that running the down migration for rerun_of didn’t fully restore the original indexes. Some indexes (`succeeded_builds_ordering_with_rerun_builds_idx`, `order_builds_by_rerun_of_or_id_idx`, `order_job_builds_by_rerun_of_or_id_idx`) were removed when the rerun_of column was dropped. This caused the up migration to fail if run again and prevented the database from being fully reverted to its original state.

This PR restructure down migration by:

- [x] Dropping the indexes created on the `rerun_of` column 
- [x] Then drop `rerun_of` column and rename "rerun_of_old" to "rerun_of"
- [x] Recreating the other dependent indexes (succeeded_builds_ordering_with_rerun_builds_idx, order_builds_by_rerun_of_or_id_idx, order_job_builds_by_rerun_of_or_id_idx) after restoring the original column, so nothing is missing.

With these changes, the migration is fully reversible and running `up -> down -> up` works as expected without missing indexes.

## Notes to reviewer

- Check that the original indexes are correctly restored after running the down migration.
- Verify that `up -> down -> up`  runs successfully without errors.
