### PR TITLE
revert #9330 but keep using sha256 instead of sha1

### DIFF
--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -177,7 +177,7 @@ func (factory *coreStepFactory) TaskStep(
 	containerMetadata db.ContainerMetadata,
 	delegateFactory DelegateFactory,
 ) exec.Step {
-	sum := sha256.Sum256(fmt.Appendf([]byte{}, "%d", time.Now().Unix()))
+	sum := sha256.Sum256([]byte(plan.Task.Name))
 	containerMetadata.WorkingDirectory = filepath.Join("/tmp", "build", fmt.Sprintf("%x", sum[:4]))
 
 	taskStep := exec.NewTaskStep(


### PR DESCRIPTION
## Changes proposed by this PR

closes #9425

* sadly users have now written tasks that rely on this consistent working directory convention and I'd prefer to not break existing pipelines for users. The reported issue was due to a tool that expects consistent full build paths
* still using sha256 over sha1 because it makes it easier for Concourse to be used in high security envs