### PR TITLE
Ensure strings passed to containerd container properties only contain UTF8 runes

### DIFF
--- a/worker/runtime/properties.go
+++ b/worker/runtime/properties.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"code.cloudfoundry.org/garden"
 )
@@ -39,6 +40,7 @@ func propertiesToLabels(properties garden.Properties) (map[string]string, error)
 		if len(key) > maxKeyLen {
 			return nil, fmt.Errorf("property name %q is too long", key[:32]+"...")
 		}
+		value = strings.ToValidUTF8(value, string(utf8.RuneError))
 		for {
 			chunkKey := key + "." + strconv.Itoa(sequenceNum)
 			valueLen := min(maxLabelLen-len(chunkKey), len(value))


### PR DESCRIPTION
## Changes proposed by this PR

closes #9205

containerd throws an error if we try and set a container property that contains non-UTF8 runes. We abuse container properties and use them to store stuff like metadata from resource get steps, which is effectively user-submitted data that we do not control. To avoid this error from containerd, we clean up the string before passing it to containerd.

This was originally reported as an issue in the github-release resource: https://github.com/concourse/github-release-resource/issues/128
