### PR TITLE
fix BUILD_URL when a pipeline has instance vars

### DIFF
--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -480,6 +480,7 @@ func (factory *stepperFactory) stepMetadata(
 		PipelineID:           build.PipelineID(),
 		PipelineName:         build.PipelineName(),
 		PipelineInstanceVars: build.PipelineInstanceVars(),
+		InstanceVarsQuery:    build.PipelineRef().QueryParams(),
 		ExternalURL:          externalURL,
 	}
 	if exposeBuildCreatedBy && build.CreatedBy() != nil {

--- a/atc/exec/step_metadata.go
+++ b/atc/exec/step_metadata.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"sort"
-	"strings"
 )
 
 type StepMetadata struct {
@@ -18,6 +16,7 @@ type StepMetadata struct {
 	PipelineID           int
 	PipelineName         string
 	PipelineInstanceVars map[string]any
+	InstanceVarsQuery    url.Values
 	ExternalURL          string
 	CreatedBy            string
 }
@@ -77,16 +76,8 @@ func (metadata StepMetadata) Env() []string {
 					metadata.JobName,
 					metadata.BuildName)
 
-				if len(metadata.PipelineInstanceVars) > 0 {
-					var queryParams []string
-					for key, value := range metadata.PipelineInstanceVars {
-						queryParams = append(queryParams,
-							fmt.Sprintf("vars.%s=%s",
-								url.QueryEscape(key),
-								url.QueryEscape(fmt.Sprintf("%v", value))))
-					}
-					sort.Strings(queryParams)
-					buildURL += "?" + strings.Join(queryParams, "&")
+				if len(metadata.InstanceVarsQuery) > 0 {
+					buildURL += "?" + metadata.InstanceVarsQuery.Encode()
 				}
 			}
 


### PR DESCRIPTION
## Changes proposed by this PR

A user on discord noted that when `BUILD_URL` had instance vars it was missing the quotes `"` or `%22` in the url. Using the URL would result in visiting a page showing HTTP 404.

In CI we have an example of instance pipelines and a build URL to one of them looks like this:

```
https://ci.concourse-ci.org/teams/examples/pipelines/instance-groups/jobs/initial-job/builds/1?vars.first=%22initial%22&vars.hello=%22HAL%22&vars.number=%229000%22
```

Instead, what a user was seeing was a URL like this (re-using the URL above):
```
https://ci.concourse-ci.org/teams/examples/pipelines/instance-groups/jobs/initial-job/builds/1?vars.first=initial&vars.hello=HAL&vars.number=9000
```

Which is missing the quotes `%22` around each var value. Following this URL leads to a HTTP 404 page.

These quotes are a side-effect of the json encoding and decoding we do of the instance vars in other places in the code.