### PR TITLE
Add flag to disable secret redaction

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -260,7 +260,7 @@ type RunCommand struct {
 
 	FeatureFlags struct {
 		EnableGlobalResources                bool `long:"enable-global-resources" description:"Enable equivalent resources across pipelines and teams to share a single version history."`
-		EnableRedactSecrets                  bool `long:"enable-redact-secrets" description:"DEPRECATED: Secrets are always redacted from build logs. This flag has no effect."`
+		EnableRedactSecrets                  bool `long:"enable-redact-secrets" description:"DEPRECATED: Secrets are always redacted from build logs. This flag has no effect. See --disable-redact-secrets to turn secret redaction off."`
 		EnableBuildRerunWhenWorkerDisappears bool `long:"enable-rerun-when-worker-disappears" description:"Enable automatically build rerun when worker disappears or a network error occurs"`
 		EnableAcrossStep                     bool `long:"enable-across-step" description:"DEPRECATED: The across step is always enabled and this config has no effect."`
 		EnablePipelineInstances              bool `long:"enable-pipeline-instances" description:"DEPRECATED: Pipeline instances are always enabled and this config has no effect."`
@@ -282,6 +282,8 @@ type RunCommand struct {
 	NumGoroutineThreshold int `long:"num-goroutine-threshold" description:"When number of goroutines reaches to this threshold, then slow down current ATC. This helps distribute workloads across ATCs evenly."`
 
 	DBNotificationBusQueueSize int `long:"db-notification-bus-queue-size" default:"10000" description:"DB notification bus queue size, default is 10000. If UI often misses loading running build logs, then consider to increase the queue size."`
+
+	DisableRedactSecrets bool `long:"disable-redact-secrets" description:"Disables secret redaction in build logs."`
 }
 
 type Migration struct {
@@ -560,6 +562,7 @@ func (cmd *RunCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 	atc.DefaultCheckInterval = cmd.ResourceCheckingInterval
 	atc.DefaultWebhookInterval = cmd.ResourceWithWebhookCheckingInterval
 	atc.DefaultResourceTypeInterval = cmd.ResourceTypeCheckingInterval
+	atc.DisableRedactSecrets = cmd.DisableRedactSecrets
 
 	if cmd.FeatureFlags.EnablePipelineInstances {
 		commandSession.Info("deprecated", lager.Data{
@@ -575,7 +578,7 @@ func (cmd *RunCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 
 	if cmd.FeatureFlags.EnableRedactSecrets {
 		commandSession.Info("deprecated", lager.Data{
-			"message": "--enable-redact-secrets/CONCOURSE_ENABLE_REDACT_SECRETS is deprecated and has no effect. This feature is always enabled.",
+			"message": "--enable-redact-secrets/CONCOURSE_ENABLE_REDACT_SECRETS is deprecated and has no effect. To disable secret redaction use --disable-redact-secrets/CONCOURSE_DISABLE_REDACT_SECRETS.",
 		})
 	}
 

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1279,13 +1279,14 @@ func (cmd *RunCommand) backendComponents(
 }
 
 func (cmd *RunCommand) compression() compression.Compression {
-	if cmd.StreamingArtifactsCompression == "zstd" {
+	switch cmd.StreamingArtifactsCompression {
+	case "zstd":
 		return compression.NewZstdCompression()
-	} else if cmd.StreamingArtifactsCompression == "s2" {
+	case "s2":
 		return compression.NewS2Compression()
-	} else if cmd.StreamingArtifactsCompression == "raw" {
+	case "raw":
 		return compression.NewNoCompression()
-	} else {
+	default:
 		return compression.NewGzipCompression()
 	}
 }
@@ -1779,7 +1780,7 @@ type Closer interface {
 
 func constructLockConns(driverName, connectionString string) ([lock.FactoryCount]*sql.DB, error) {
 	conns := [lock.FactoryCount]*sql.DB{}
-	for i := 0; i < lock.FactoryCount; i++ {
+	for i := range lock.FactoryCount {
 		dbConn, err := sql.Open(driverName, connectionString)
 		if err != nil {
 			return conns, err

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -31,7 +31,7 @@ func NewCheckDelegate(
 	policyChecker policy.Checker,
 ) exec.CheckDelegate {
 	return &checkDelegate{
-		BuildStepDelegate: NewBuildStepDelegate(build, plan.ID, state, clock, policyChecker),
+		BuildStepDelegate: NewBuildStepDelegate(build, plan.ID, state, clock, policyChecker, atc.DisableRedactSecrets),
 
 		build:       build,
 		plan:        plan.Check,

--- a/atc/engine/delegate_factory.go
+++ b/atc/engine/delegate_factory.go
@@ -32,7 +32,7 @@ func (delegate DelegateFactory) TaskDelegate(state exec.RunState) exec.TaskDeleg
 }
 
 func (delegate DelegateFactory) RunDelegate(state exec.RunState) exec.RunDelegate {
-	return NewBuildStepDelegate(delegate.build, delegate.plan.ID, state, clock.NewClock(), delegate.policyChecker)
+	return NewBuildStepDelegate(delegate.build, delegate.plan.ID, state, clock.NewClock(), delegate.policyChecker, atc.DisableRedactSecrets)
 }
 
 func (delegate DelegateFactory) CheckDelegate(state exec.RunState) exec.CheckDelegate {
@@ -40,7 +40,7 @@ func (delegate DelegateFactory) CheckDelegate(state exec.RunState) exec.CheckDel
 }
 
 func (delegate DelegateFactory) BuildStepDelegate(state exec.RunState) exec.BuildStepDelegate {
-	return NewBuildStepDelegate(delegate.build, delegate.plan.ID, state, clock.NewClock(), delegate.policyChecker)
+	return NewBuildStepDelegate(delegate.build, delegate.plan.ID, state, clock.NewClock(), delegate.policyChecker, atc.DisableRedactSecrets)
 }
 
 func (delegate DelegateFactory) SetPipelineStepDelegate(state exec.RunState) exec.SetPipelineStepDelegate {

--- a/atc/engine/get_delegate.go
+++ b/atc/engine/get_delegate.go
@@ -22,7 +22,7 @@ func NewGetDelegate(
 	policyChecker policy.Checker,
 ) exec.GetDelegate {
 	return &getDelegate{
-		BuildStepDelegate: NewBuildStepDelegate(build, planID, state, clock, policyChecker),
+		BuildStepDelegate: NewBuildStepDelegate(build, planID, state, clock, policyChecker, atc.DisableRedactSecrets),
 
 		eventOrigin: event.Origin{ID: event.OriginID(planID)},
 		build:       build,

--- a/atc/engine/put_delegate.go
+++ b/atc/engine/put_delegate.go
@@ -22,7 +22,7 @@ func NewPutDelegate(
 	policyChecker policy.Checker,
 ) exec.PutDelegate {
 	return &putDelegate{
-		BuildStepDelegate: NewBuildStepDelegate(build, planID, state, clock, policyChecker),
+		BuildStepDelegate: NewBuildStepDelegate(build, planID, state, clock, policyChecker, atc.DisableRedactSecrets),
 
 		eventOrigin: event.Origin{ID: event.OriginID(planID)},
 		build:       build,

--- a/atc/engine/task_delegate.go
+++ b/atc/engine/task_delegate.go
@@ -25,7 +25,7 @@ func NewTaskDelegate(
 	lockFactory lock.LockFactory,
 ) exec.TaskDelegate {
 	return &taskDelegate{
-		BuildStepDelegate: NewBuildStepDelegate(build, planID, state, clock, policyChecker),
+		BuildStepDelegate: NewBuildStepDelegate(build, planID, state, clock, policyChecker, atc.DisableRedactSecrets),
 
 		eventOrigin: event.Origin{ID: event.OriginID(planID)},
 		planID:      planID,

--- a/atc/feature_flags.go
+++ b/atc/feature_flags.go
@@ -17,3 +17,7 @@ func FeatureFlags() map[string]bool {
 		"resource_causality":     EnableResourceCausality,
 	}
 }
+
+var (
+	DisableRedactSecrets bool
+)

--- a/cmd/concourse/main.go
+++ b/cmd/concourse/main.go
@@ -28,10 +28,10 @@ func main() {
 	twentythousandtonnesofcrudeoil.TheEnvironmentIsPerfectlySafe(parser, "CONCOURSE_")
 
 	_, err := parser.Parse()
-	handleError(parser, err)
+	handleError(err)
 }
 
-func handleError(helpParser *flags.Parser, err error) {
+func handleError(err error) {
 	if err != nil {
 		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
 			fmt.Println(err)


### PR DESCRIPTION
## Changes proposed by this PR

closes #9424 

Our flag parser does not support default values on bool types, so I had
to add a new flag that's the inverse of the old flag. The old flag
remains deprecated.

I also took a simpler approach to turning secret redaction on and off.
Instead of having a whole separate struct, we take a fast-path if
redaction is disabled. It's functionally the same as the previous setup,
just less code.
