### PR TITLE
Refactor 9419 to have AsMap() as a func on []MetadataField

### DIFF
--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Versions API", func() {
 							Version: atc.Version{
 								"some": "version",
 							},
-							Metadata: []atc.MetadataField{
+							Metadata: atc.Metadata{
 								{
 									Name:  "some",
 									Value: "metadata",
@@ -100,7 +100,7 @@ var _ = Describe("Versions API", func() {
 							Version: atc.Version{
 								"some": "version",
 							},
-							Metadata: []atc.MetadataField{
+							Metadata: atc.Metadata{
 								{
 									Name:  "some",
 									Value: "metadata",
@@ -329,7 +329,7 @@ var _ = Describe("Versions API", func() {
 									"some": "version",
 									"ref":  "foo",
 								},
-								Metadata: []atc.MetadataField{
+								Metadata: atc.Metadata{
 									{
 										Name:  "some",
 										Value: "metadata",
@@ -343,7 +343,7 @@ var _ = Describe("Versions API", func() {
 									"some": "version",
 									"ref":  "blah",
 								},
-								Metadata: []atc.MetadataField{
+								Metadata: atc.Metadata{
 									{
 										Name:  "some",
 										Value: "metadata",

--- a/atc/build_inputs_outputs.go
+++ b/atc/build_inputs_outputs.go
@@ -18,8 +18,8 @@ type PublicBuildOutput struct {
 }
 
 type ResourceVersion struct {
-	ID       int             `json:"id"`
-	Metadata []MetadataField `json:"metadata,omitempty"`
-	Version  Version         `json:"version"`
-	Enabled  bool            `json:"enabled"`
+	ID       int      `json:"id"`
+	Metadata Metadata `json:"metadata,omitempty"`
+	Version  Version  `json:"version"`
+	Enabled  bool     `json:"enabled"`
 }

--- a/atc/db/dbfakes/fake_resource_cache_factory.go
+++ b/atc/db/dbfakes/fake_resource_cache_factory.go
@@ -55,11 +55,11 @@ type FakeResourceCacheFactory struct {
 		result1 db.ResourceConfigMetadataFields
 		result2 error
 	}
-	UpdateResourceCacheMetadataStub        func(db.ResourceCache, []atc.MetadataField) error
+	UpdateResourceCacheMetadataStub        func(db.ResourceCache, atc.Metadata) error
 	updateResourceCacheMetadataMutex       sync.RWMutex
 	updateResourceCacheMetadataArgsForCall []struct {
 		arg1 db.ResourceCache
-		arg2 []atc.MetadataField
+		arg2 atc.Metadata
 	}
 	updateResourceCacheMetadataReturns struct {
 		result1 error
@@ -271,21 +271,16 @@ func (fake *FakeResourceCacheFactory) ResourceCacheMetadataReturnsOnCall(i int, 
 	}{result1, result2}
 }
 
-func (fake *FakeResourceCacheFactory) UpdateResourceCacheMetadata(arg1 db.ResourceCache, arg2 []atc.MetadataField) error {
-	var arg2Copy []atc.MetadataField
-	if arg2 != nil {
-		arg2Copy = make([]atc.MetadataField, len(arg2))
-		copy(arg2Copy, arg2)
-	}
+func (fake *FakeResourceCacheFactory) UpdateResourceCacheMetadata(arg1 db.ResourceCache, arg2 atc.Metadata) error {
 	fake.updateResourceCacheMetadataMutex.Lock()
 	ret, specificReturn := fake.updateResourceCacheMetadataReturnsOnCall[len(fake.updateResourceCacheMetadataArgsForCall)]
 	fake.updateResourceCacheMetadataArgsForCall = append(fake.updateResourceCacheMetadataArgsForCall, struct {
 		arg1 db.ResourceCache
-		arg2 []atc.MetadataField
-	}{arg1, arg2Copy})
+		arg2 atc.Metadata
+	}{arg1, arg2})
 	stub := fake.UpdateResourceCacheMetadataStub
 	fakeReturns := fake.updateResourceCacheMetadataReturns
-	fake.recordInvocation("UpdateResourceCacheMetadata", []interface{}{arg1, arg2Copy})
+	fake.recordInvocation("UpdateResourceCacheMetadata", []interface{}{arg1, arg2})
 	fake.updateResourceCacheMetadataMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -302,13 +297,13 @@ func (fake *FakeResourceCacheFactory) UpdateResourceCacheMetadataCallCount() int
 	return len(fake.updateResourceCacheMetadataArgsForCall)
 }
 
-func (fake *FakeResourceCacheFactory) UpdateResourceCacheMetadataCalls(stub func(db.ResourceCache, []atc.MetadataField) error) {
+func (fake *FakeResourceCacheFactory) UpdateResourceCacheMetadataCalls(stub func(db.ResourceCache, atc.Metadata) error) {
 	fake.updateResourceCacheMetadataMutex.Lock()
 	defer fake.updateResourceCacheMetadataMutex.Unlock()
 	fake.UpdateResourceCacheMetadataStub = stub
 }
 
-func (fake *FakeResourceCacheFactory) UpdateResourceCacheMetadataArgsForCall(i int) (db.ResourceCache, []atc.MetadataField) {
+func (fake *FakeResourceCacheFactory) UpdateResourceCacheMetadataArgsForCall(i int) (db.ResourceCache, atc.Metadata) {
 	fake.updateResourceCacheMetadataMutex.RLock()
 	defer fake.updateResourceCacheMetadataMutex.RUnlock()
 	argsForCall := fake.updateResourceCacheMetadataArgsForCall[i]

--- a/atc/db/resource_cache_factory.go
+++ b/atc/db/resource_cache_factory.go
@@ -24,7 +24,7 @@ type ResourceCacheFactory interface {
 	// Since we need to pass it recursively in ResourceConfig.
 	// Also, metadata will be available to us before we create resource cache so this
 	// method can be removed at that point. See  https://github.com/concourse/concourse/issues/534
-	UpdateResourceCacheMetadata(ResourceCache, []atc.MetadataField) error
+	UpdateResourceCacheMetadata(ResourceCache, atc.Metadata) error
 	ResourceCacheMetadata(ResourceCache) (ResourceConfigMetadataFields, error)
 
 	FindResourceCacheByID(id int) (ResourceCache, bool, error)
@@ -164,7 +164,7 @@ func (f *resourceCacheFactory) FindOrCreateResourceCache(
 	}, nil
 }
 
-func (f *resourceCacheFactory) UpdateResourceCacheMetadata(resourceCache ResourceCache, metadata []atc.MetadataField) error {
+func (f *resourceCacheFactory) UpdateResourceCacheMetadata(resourceCache ResourceCache, metadata atc.Metadata) error {
 	metadataJSON, err := json.Marshal(metadata)
 	if err != nil {
 		return err

--- a/atc/db/resource_config_version.go
+++ b/atc/db/resource_config_version.go
@@ -29,7 +29,7 @@ type ResourceConfigMetadataField struct {
 
 type ResourceConfigMetadataFields []ResourceConfigMetadataField
 
-func NewResourceConfigMetadataFields(atcm []atc.MetadataField) ResourceConfigMetadataFields {
+func NewResourceConfigMetadataFields(atcm atc.Metadata) ResourceConfigMetadataFields {
 	metadata := make([]ResourceConfigMetadataField, len(atcm))
 	for i, md := range atcm {
 		metadata[i] = ResourceConfigMetadataField{
@@ -41,8 +41,8 @@ func NewResourceConfigMetadataFields(atcm []atc.MetadataField) ResourceConfigMet
 	return metadata
 }
 
-func (rmf ResourceConfigMetadataFields) ToATCMetadata() []atc.MetadataField {
-	metadata := make([]atc.MetadataField, len(rmf))
+func (rmf ResourceConfigMetadataFields) ToATCMetadata() atc.Metadata {
+	metadata := make(atc.Metadata, len(rmf))
 	for i, md := range rmf {
 		metadata[i] = atc.MetadataField{
 			Name:  md.Name,

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -859,7 +859,7 @@ var _ = Describe("Resource", func() {
 						"commit": "v" + strconv.Itoa(i),
 					})
 
-					var metadata []atc.MetadataField
+					var metadata atc.Metadata
 
 					for _, v := range rcv.Metadata() {
 						metadata = append(metadata, atc.MetadataField(v))
@@ -965,7 +965,7 @@ var _ = Describe("Resource", func() {
 				for i := 0; i < 10; i++ {
 					rcv := scenario.ResourceVersion("some-resource", atc.Version{"ref": "v" + strconv.Itoa(i)})
 
-					var metadata []atc.MetadataField
+					var metadata atc.Metadata
 
 					for _, v := range rcv.Metadata() {
 						metadata = append(metadata, atc.MetadataField(v))
@@ -1060,7 +1060,7 @@ var _ = Describe("Resource", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
-					Expect(historyPage[0].Metadata).To(Equal([]atc.MetadataField{{Name: "name1", Value: "value1"}}))
+					Expect(historyPage[0].Metadata).To(Equal(atc.Metadata{{Name: "name1", Value: "value1"}}))
 				})
 
 				It("maintains existing metadata after same version is saved with no metadata", func() {
@@ -1071,7 +1071,7 @@ var _ = Describe("Resource", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
-					Expect(historyPage[0].Metadata).To(Equal([]atc.MetadataField{{Name: "name1", Value: "value1"}}))
+					Expect(historyPage[0].Metadata).To(Equal(atc.Metadata{{Name: "name1", Value: "value1"}}))
 				})
 
 				It("updates metadata after same version is saved with different metadata", func() {
@@ -1083,7 +1083,7 @@ var _ = Describe("Resource", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
-					Expect(historyPage[0].Metadata).To(Equal([]atc.MetadataField{{Name: "name-new", Value: "value-new"}}))
+					Expect(historyPage[0].Metadata).To(Equal(atc.Metadata{{Name: "name-new", Value: "value-new"}}))
 				})
 			})
 
@@ -1117,7 +1117,7 @@ var _ = Describe("Resource", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
-					Expect(historyPage[0].Metadata).To(Equal([]atc.MetadataField{{Name: "name1", Value: "value1"}}))
+					Expect(historyPage[0].Metadata).To(Equal(atc.Metadata{{Name: "name1", Value: "value1"}}))
 				})
 			})
 		})
@@ -1153,7 +1153,7 @@ var _ = Describe("Resource", func() {
 				for i := 1; i < 5; i++ {
 					rcv := scenario.ResourceVersion("some-resource", atc.Version{"ref": "v" + strconv.Itoa(i)})
 
-					var metadata []atc.MetadataField
+					var metadata atc.Metadata
 
 					for _, v := range rcv.Metadata() {
 						metadata = append(metadata, atc.MetadataField(v))

--- a/atc/engine/get_delegate_test.go
+++ b/atc/engine/get_delegate_test.go
@@ -52,7 +52,7 @@ var _ = Describe("GetDelegate", func() {
 
 		info = resource.VersionResult{
 			Version:  atc.Version{"foo": "bar"},
-			Metadata: []atc.MetadataField{{Name: "baz", Value: "shmaz"}},
+			Metadata: atc.Metadata{{Name: "baz", Value: "shmaz"}},
 		}
 
 		fakePolicyChecker = new(policyfakes.FakeChecker)

--- a/atc/engine/put_delegate_test.go
+++ b/atc/engine/put_delegate_test.go
@@ -48,7 +48,7 @@ var _ = Describe("PutDelegate", func() {
 
 		info = resource.VersionResult{
 			Version:  atc.Version{"foo": "bar"},
-			Metadata: []atc.MetadataField{{Name: "baz", Value: "shmaz"}},
+			Metadata: atc.Metadata{{Name: "baz", Value: "shmaz"}},
 		}
 
 		fakePolicyChecker = new(policyfakes.FakeChecker)

--- a/atc/event/deprecated_events.go
+++ b/atc/event/deprecated_events.go
@@ -185,44 +185,44 @@ type StartV10 struct {
 }
 
 type FinishGetV10 struct {
-	Origin          OriginV20           `json:"origin"`
-	Plan            GetPlanV40          `json:"plan"`
-	ExitStatus      int                 `json:"exit_status"`
-	FetchedVersion  atc.Version         `json:"version"`
-	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+	Origin          OriginV20    `json:"origin"`
+	Plan            GetPlanV40   `json:"plan"`
+	ExitStatus      int          `json:"exit_status"`
+	FetchedVersion  atc.Version  `json:"version"`
+	FetchedMetadata atc.Metadata `json:"metadata,omitempty"`
 }
 
 func (FinishGetV10) EventType() atc.EventType  { return "finish-get" }
 func (FinishGetV10) Version() atc.EventVersion { return "1.0" }
 
 type FinishGetV20 struct {
-	Origin          OriginV30           `json:"origin"`
-	Plan            GetPlanV40          `json:"plan"`
-	ExitStatus      int                 `json:"exit_status"`
-	FetchedVersion  atc.Version         `json:"version"`
-	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+	Origin          OriginV30    `json:"origin"`
+	Plan            GetPlanV40   `json:"plan"`
+	ExitStatus      int          `json:"exit_status"`
+	FetchedVersion  atc.Version  `json:"version"`
+	FetchedMetadata atc.Metadata `json:"metadata,omitempty"`
 }
 
 func (FinishGetV20) EventType() atc.EventType  { return "finish-get" }
 func (FinishGetV20) Version() atc.EventVersion { return "2.0" }
 
 type FinishPutV10 struct {
-	Origin          OriginV20           `json:"origin"`
-	Plan            PutPlanV40          `json:"plan"`
-	CreatedVersion  atc.Version         `json:"version"`
-	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`
-	ExitStatus      int                 `json:"exit_status"`
+	Origin          OriginV20    `json:"origin"`
+	Plan            PutPlanV40   `json:"plan"`
+	CreatedVersion  atc.Version  `json:"version"`
+	CreatedMetadata atc.Metadata `json:"metadata,omitempty"`
+	ExitStatus      int          `json:"exit_status"`
 }
 
 func (FinishPutV10) EventType() atc.EventType  { return "finish-put" }
 func (FinishPutV10) Version() atc.EventVersion { return "1.0" }
 
 type FinishPutV20 struct {
-	Origin          OriginV30           `json:"origin"`
-	Plan            PutPlanV40          `json:"plan"`
-	CreatedVersion  atc.Version         `json:"version"`
-	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`
-	ExitStatus      int                 `json:"exit_status"`
+	Origin          OriginV30    `json:"origin"`
+	Plan            PutPlanV40   `json:"plan"`
+	CreatedVersion  atc.Version  `json:"version"`
+	CreatedMetadata atc.Metadata `json:"metadata,omitempty"`
+	ExitStatus      int          `json:"exit_status"`
 }
 
 func (FinishPutV20) EventType() atc.EventType  { return "finish-put" }
@@ -271,9 +271,9 @@ func (InitializeTaskV20) EventType() atc.EventType  { return "initialize-task" }
 func (InitializeTaskV20) Version() atc.EventVersion { return "2.0" }
 
 type InputV20 struct {
-	Plan            InputV20InputPlan   `json:"plan"`
-	FetchedVersion  atc.Version         `json:"version"`
-	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+	Plan            InputV20InputPlan `json:"plan"`
+	FetchedVersion  atc.Version       `json:"version"`
+	FetchedMetadata atc.Metadata      `json:"metadata,omitempty"`
 }
 
 func (InputV20) EventType() atc.EventType  { return "input" }
@@ -282,7 +282,7 @@ func (InputV20) Version() atc.EventVersion { return "2.0" }
 type OutputV20 struct {
 	Plan            OutputV20OutputPlan `json:"plan"`
 	CreatedVersion  atc.Version         `json:"version"`
-	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+	CreatedMetadata atc.Metadata        `json:"metadata,omitempty"`
 }
 
 func (OutputV20) EventType() atc.EventType  { return "output" }
@@ -412,22 +412,22 @@ const (
 )
 
 type FinishGetV30 struct {
-	Origin          OriginV40           `json:"origin"`
-	Plan            GetPlanV40          `json:"plan"`
-	ExitStatus      int                 `json:"exit_status"`
-	FetchedVersion  atc.Version         `json:"version"`
-	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+	Origin          OriginV40    `json:"origin"`
+	Plan            GetPlanV40   `json:"plan"`
+	ExitStatus      int          `json:"exit_status"`
+	FetchedVersion  atc.Version  `json:"version"`
+	FetchedMetadata atc.Metadata `json:"metadata,omitempty"`
 }
 
 func (FinishGetV30) EventType() atc.EventType  { return "finish-get" }
 func (FinishGetV30) Version() atc.EventVersion { return "3.0" }
 
 type FinishPutV30 struct {
-	Origin          OriginV40           `json:"origin"`
-	Plan            PutPlanV40          `json:"plan"`
-	CreatedVersion  atc.Version         `json:"version"`
-	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`
-	ExitStatus      int                 `json:"exit_status"`
+	Origin          OriginV40    `json:"origin"`
+	Plan            PutPlanV40   `json:"plan"`
+	CreatedVersion  atc.Version  `json:"version"`
+	CreatedMetadata atc.Metadata `json:"metadata,omitempty"`
+	ExitStatus      int          `json:"exit_status"`
 }
 
 func (FinishPutV30) EventType() atc.EventType  { return "finish-put" }
@@ -469,22 +469,22 @@ type PutPlanV40 struct {
 }
 
 type FinishGetV40 struct {
-	Origin          Origin              `json:"origin"`
-	Plan            GetPlanV40          `json:"plan"`
-	ExitStatus      int                 `json:"exit_status"`
-	FetchedVersion  atc.Version         `json:"version"`
-	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+	Origin          Origin       `json:"origin"`
+	Plan            GetPlanV40   `json:"plan"`
+	ExitStatus      int          `json:"exit_status"`
+	FetchedVersion  atc.Version  `json:"version"`
+	FetchedMetadata atc.Metadata `json:"metadata,omitempty"`
 }
 
 func (FinishGetV40) EventType() atc.EventType  { return EventTypeFinishGet }
 func (FinishGetV40) Version() atc.EventVersion { return "4.0" }
 
 type FinishPutV40 struct {
-	Origin          Origin              `json:"origin"`
-	Plan            PutPlanV40          `json:"plan"`
-	CreatedVersion  atc.Version         `json:"version"`
-	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`
-	ExitStatus      int                 `json:"exit_status"`
+	Origin          Origin       `json:"origin"`
+	Plan            PutPlanV40   `json:"plan"`
+	CreatedVersion  atc.Version  `json:"version"`
+	CreatedMetadata atc.Metadata `json:"metadata,omitempty"`
+	ExitStatus      int          `json:"exit_status"`
 }
 
 func (FinishPutV40) EventType() atc.EventType  { return EventTypeFinishPut }

--- a/atc/event/events.go
+++ b/atc/event/events.go
@@ -183,11 +183,11 @@ func (StartGet) EventType() atc.EventType  { return EventTypeStartGet }
 func (StartGet) Version() atc.EventVersion { return "1.0" }
 
 type FinishGet struct {
-	Origin          Origin              `json:"origin"`
-	Time            int64               `json:"time"`
-	ExitStatus      int                 `json:"exit_status"`
-	FetchedVersion  atc.Version         `json:"version"`
-	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+	Origin          Origin       `json:"origin"`
+	Time            int64        `json:"time"`
+	ExitStatus      int          `json:"exit_status"`
+	FetchedVersion  atc.Version  `json:"version"`
+	FetchedMetadata atc.Metadata `json:"metadata,omitempty"`
 }
 
 func (FinishGet) EventType() atc.EventType  { return EventTypeFinishGet }
@@ -210,11 +210,11 @@ func (StartPut) EventType() atc.EventType  { return EventTypeStartPut }
 func (StartPut) Version() atc.EventVersion { return "1.0" }
 
 type FinishPut struct {
-	Origin          Origin              `json:"origin"`
-	Time            int64               `json:"time"`
-	ExitStatus      int                 `json:"exit_status"`
-	CreatedVersion  atc.Version         `json:"version"`
-	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+	Origin          Origin       `json:"origin"`
+	Time            int64        `json:"time"`
+	ExitStatus      int          `json:"exit_status"`
+	CreatedVersion  atc.Version  `json:"version"`
+	CreatedMetadata atc.Metadata `json:"metadata,omitempty"`
 }
 
 func (FinishPut) EventType() atc.EventType  { return EventTypeFinishPut }

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -253,7 +253,7 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 			delegate.UpdateResourceVersion(logger, step.plan.Resource, versionResult)
 		}
 
-		state.AddLocalVar(step.plan.Name, AsMap(versionResult.Metadata), false)
+		state.AddLocalVar(step.plan.Name, versionResult.Metadata.AsMap(), false)
 
 		succeeded = true
 	}
@@ -527,12 +527,4 @@ func (step *GetStep) resourceMountVolume(mounts []runtime.VolumeMount) runtime.V
 		}
 	}
 	return nil
-}
-
-func AsMap(metadata []atc.MetadataField) map[string]any {
-	result := make(map[string]any, len(metadata))
-	for _, kv := range metadata {
-		result[kv.Name] = kv.Value
-	}
-	return result
 }

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -318,7 +318,7 @@ var _ = Describe("GetStep", func() {
 					Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
 					_, exitStatus, versionResult := fakeDelegate.FinishedArgsForCall(0)
 					Expect(exitStatus).To(Equal(exec.ExitStatus(0)))
-					Expect(versionResult.Metadata).To(Equal([]atc.MetadataField{
+					Expect(versionResult.Metadata).To(Equal(atc.Metadata{
 						{Name: "some", Value: "metadata"},
 					}))
 				})
@@ -334,7 +334,7 @@ var _ = Describe("GetStep", func() {
 
 					chosenContainer.ProcessDefs[0].Stub.Output = resource.VersionResult{
 						Version:  atc.Version{"some": "version"},
-						Metadata: []atc.MetadataField{{Name: "some", Value: "metadata"}},
+						Metadata: atc.Metadata{{Name: "some", Value: "metadata"}},
 					}
 				})
 
@@ -369,7 +369,7 @@ var _ = Describe("GetStep", func() {
 					_, status, info := fakeDelegate.FinishedArgsForCall(0)
 					Expect(status).To(Equal(exec.ExitStatus(0)))
 					Expect(info.Version).To(Equal(atc.Version{"some": "version"}))
-					Expect(info.Metadata).To(Equal([]atc.MetadataField{{Name: "some", Value: "metadata"}}))
+					Expect(info.Metadata).To(Equal(atc.Metadata{{Name: "some", Value: "metadata"}}))
 				})
 
 				It("does not log any info messages", func() {
@@ -432,7 +432,7 @@ var _ = Describe("GetStep", func() {
 
 					chosenContainer.ProcessDefs[0].Stub.Output = resource.VersionResult{
 						Version:  atc.Version{"some": "version"},
-						Metadata: []atc.MetadataField{{Name: "some", Value: "metadata"}},
+						Metadata: atc.Metadata{{Name: "some", Value: "metadata"}},
 					}
 				})
 
@@ -451,7 +451,7 @@ var _ = Describe("GetStep", func() {
 					_, status, info := fakeDelegate.FinishedArgsForCall(0)
 					Expect(status).To(Equal(exec.ExitStatus(0)))
 					Expect(info.Version).To(Equal(atc.Version{"some": "version"}))
-					Expect(info.Metadata).To(Equal([]atc.MetadataField{{Name: "some", Value: "metadata"}}))
+					Expect(info.Metadata).To(Equal(atc.Metadata{{Name: "some", Value: "metadata"}}))
 				})
 
 				It("does not log any info messages", func() {
@@ -697,7 +697,7 @@ var _ = Describe("GetStep", func() {
 		BeforeEach(func() {
 			chosenContainer.ProcessDefs[0].Stub.Output = resource.VersionResult{
 				Version:  atc.Version{"some": "version"},
-				Metadata: []atc.MetadataField{{Name: "some", Value: "metadata"}},
+				Metadata: atc.Metadata{{Name: "some", Value: "metadata"}},
 			}
 		})
 
@@ -727,7 +727,7 @@ var _ = Describe("GetStep", func() {
 			_, status, info := fakeDelegate.FinishedArgsForCall(0)
 			Expect(status).To(Equal(exec.ExitStatus(0)))
 			Expect(info.Version).To(Equal(atc.Version{"some": "version"}))
-			Expect(info.Metadata).To(Equal([]atc.MetadataField{{Name: "some", Value: "metadata"}}))
+			Expect(info.Metadata).To(Equal(atc.Metadata{{Name: "some", Value: "metadata"}}))
 		})
 
 		It("saves the version for the resource", func() {

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -84,7 +84,7 @@ var _ = Describe("PutStep", func() {
 
 		versionResult = resource.VersionResult{
 			Version:  atc.Version{"some": "version"},
-			Metadata: []atc.MetadataField{{Name: "some", Value: "metadata"}},
+			Metadata: atc.Metadata{{Name: "some", Value: "metadata"}},
 		}
 
 		chosenWorker = runtimetest.NewWorker("worker").
@@ -419,7 +419,7 @@ var _ = Describe("PutStep", func() {
 		Expect(actualSource).To(Equal(atc.Source{"some": "super-secret-source"}))
 		Expect(irc).To(BeNil())
 		Expect(info.Version).To(Equal(atc.Version{"some": "version"}))
-		Expect(info.Metadata).To(Equal([]atc.MetadataField{{Name: "some", Value: "metadata"}}))
+		Expect(info.Metadata).To(Equal(atc.Metadata{{Name: "some", Value: "metadata"}}))
 	})
 
 	Context("when using a custom resource type", func() {
@@ -622,7 +622,7 @@ var _ = Describe("PutStep", func() {
 			_, status, info := fakeDelegate.FinishedArgsForCall(0)
 			Expect(status).To(Equal(exec.ExitStatus(0)))
 			Expect(info.Version).To(Equal(atc.Version{"some": "version"}))
-			Expect(info.Metadata).To(Equal([]atc.MetadataField{{Name: "some", Value: "metadata"}}))
+			Expect(info.Metadata).To(Equal(atc.Metadata{{Name: "some", Value: "metadata"}}))
 		})
 
 		It("stores the version as the step result", func() {

--- a/atc/resource/resource.go
+++ b/atc/resource/resource.go
@@ -17,8 +17,8 @@ const resourceProcessID = "resource"
 const resultCachePropertyName = "concourse:resource-result"
 
 type VersionResult struct {
-	Version  atc.Version         `json:"version"`
-	Metadata []atc.MetadataField `json:"metadata,omitempty"`
+	Version  atc.Version  `json:"version"`
+	Metadata atc.Metadata `json:"metadata,omitempty"`
 }
 
 type Resource struct {

--- a/atc/resource_types.go
+++ b/atc/resource_types.go
@@ -12,6 +12,16 @@ type MetadataField struct {
 	Value string `json:"value"`
 }
 
+type Metadata []MetadataField
+
+func (m Metadata) AsMap() map[string]any {
+	result := make(map[string]any, len(m))
+	for _, v := range m {
+		result[v.Name] = v.Value
+	}
+	return result
+}
+
 type Source map[string]any
 
 func (src Source) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
## Changes proposed by this PR

Refactor of #9419 

Ended up replacing all instances of `[]atc.MetadataField` with `atc.Metadata` for consistency across the codebase.