### PR TITLE
Handle json null values in the resource_config_versions table during the sha256 migration

### DIFF
--- a/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.down.sql
+++ b/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.down.sql
@@ -8,8 +8,8 @@ WITH json_string_cte AS (
             '{}'
         ) AS json_string
     FROM resource_config_versions rcv
-    LEFT JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true
-    WHERE jsonb_typeof(rcv.version::jsonb) = 'object' AND rcv.version_md5 IS NULL
+    LEFT JOIN jsonb_each_text(jsonb_coalesce_empty(rcv.version::jsonb)) AS kv ON true
+    WHERE rcv.version_md5 IS NULL
     GROUP BY rcv.id, rcv.version_sha256
 ),
 hashed_json_string_cte AS (
@@ -96,3 +96,5 @@ RENAME TO resource_disabled_versions_resource_id_version_md5_uniq;
 -- resource_caches
 ALTER INDEX IF EXISTS resource_caches_resource_config_id_version_digest_params_hash_uniq
 RENAME to resource_caches_resource_config_id_version_md5_params_hash_uniq;
+
+DROP FUNCTION IF EXISTS jsonb_coalesce_empty(value jsonb);

--- a/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.down.sql
+++ b/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.down.sql
@@ -94,7 +94,7 @@ ALTER INDEX IF EXISTS resource_disabled_versions_resource_id_version_digest_uniq
 RENAME TO resource_disabled_versions_resource_id_version_md5_uniq;
 
 -- resource_caches
-ALTER INDEX IF EXISTS resource_caches_resource_config_id_version_digest_params_hash_uniq
+ALTER INDEX IF EXISTS resource_caches_rsc_config_id_version_digest_params_hash_uniq
 RENAME to resource_caches_resource_config_id_version_md5_params_hash_uniq;
 
 DROP FUNCTION IF EXISTS jsonb_coalesce_empty(value jsonb);

--- a/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.up.sql
+++ b/atc/db/migration/migrations/1747084615_switch_md5_to_sha256.up.sql
@@ -49,6 +49,15 @@ RENAME TO resource_disabled_versions_resource_id_version_digest_uniq;
 ALTER INDEX IF EXISTS resource_caches_resource_config_id_version_md5_params_hash_uniq
 RENAME to resource_caches_rsc_config_id_version_digest_params_hash_uniq;
 
+CREATE OR REPLACE FUNCTION jsonb_coalesce_empty(value jsonb)
+RETURNS jsonb AS $$
+  SELECT
+      CASE WHEN jsonb_typeof($1) != 'object'
+          THEN '{}'::jsonb
+          ELSE $1
+  END
+$$ LANGUAGE sql;
+
 -- Convert all rows to their new sha256 values
 WITH json_string_cte AS (
     SELECT
@@ -59,8 +68,7 @@ WITH json_string_cte AS (
             '{}'
         ) AS json_string
     FROM resource_config_versions rcv
-    LEFT JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true
-    WHERE jsonb_typeof(rcv.version::jsonb) = 'object'
+    LEFT JOIN jsonb_each_text(jsonb_coalesce_empty(rcv.version::jsonb)) AS kv ON true
     GROUP BY rcv.id, rcv.version_sha256
 ),
 hashed_json_string_cte AS (


### PR DESCRIPTION
## Changes proposed by this PR

closes #9432

No clue how these values got in there, but we've had multiple reports of users having versions with null json values in this table. This is a different type from SQL NULL. The `version` column has a `NOT NULL` constraint on it already.

The migraton was not computing these null json values. They got filtered out by the WHERE clause that's now been removed. This would then result in an error later on when we tried to apply a `NOT NULL` constraint on the new version_sha256 column because we'd have these rows that we filtered out and never computed values for.

Now any versions that aren't already json objects are converted to empty json objects, allowing us to properly compute them now.

## Notes to reviewer

Using a local instance of Concourse 7.14, I made my `resource_config_versions` table look like this. I manually inserted the second record with the `some_md5` value. The value in this column doesn't matter for reproducing the problem or verifying the fix. We don't modify the values in this column during the migration.

```
id|version            |version_md5                     |metadata|check_order|resource_config_scope_id|span_context|
--+-------------------+--------------------------------+--------+-----------+------------------------+------------+
 1|{"version": "mock"}|8b60d2cd04609ea4cf585ee063babf48|null    |          1|                       1|{}          |
 4|null               |some_md5                        |null    |          0|                       1|            |
```

I then ran this slightly stripped down version of the problem query from the migration:

```sql
WITH json_string_cte AS ( 
     SELECT 
         rcv.id, 
         COALESCE( 
             '{' || string_agg('"' || kv.key || '":"' || kv.value || '"', ',' ORDER BY kv.key) || '}', 
             '{}' 
         ) AS json_string 
     FROM resource_config_versions rcv 
     LEFT JOIN jsonb_each_text(rcv.version::jsonb) AS kv ON true 
     WHERE jsonb_typeof(rcv.version::jsonb) = 'object' 
     GROUP BY rcv.id
 ), 
 hashed_json_string_cte AS ( 
     SELECT 
         json_string_cte.id, 
         encode(digest(json_string_cte.json_string, 'sha256'), 'hex') AS new_version_sha256 
     FROM json_string_cte 
 ) 
 select * FROM hashed_json_string_cte;
```

Which only returned one row, when it should return two:

```
id|new_version_sha256                                              |
--+----------------------------------------------------------------+
 1|dc5503a03b7a16ff473d3628846a4f7d62fac2d7f69b16a5808cd3d9270474c3|
```
We've missed converting a record!

Running the updated query + function:

```sql
CREATE OR REPLACE FUNCTION jsonb_coalesce_empty(value jsonb)
RETURNS jsonb AS $$
  SELECT
      CASE WHEN jsonb_typeof($1) != 'object'
          THEN '{}'::jsonb
          ELSE $1
  END
$$ LANGUAGE sql;

WITH json_string_cte AS ( 
     SELECT 
         rcv.id, 
         COALESCE(
            '{' || string_agg('"' || kv.key || '":"' || kv.value || '"', ',' ORDER BY kv.key) || '}',
            '{}'
        ) AS json_string
     FROM resource_config_versions rcv
     LEFT JOIN jsonb_each_text(jsonb_coalesce_empty(rcv.version::jsonb)) AS kv ON true 
     GROUP BY rcv.id
 ), 
 hashed_json_string_cte AS ( 
     SELECT 
         json_string_cte.id, 
         json_string_cte.json_string, --added for verification
         encode(digest(json_string_cte.json_string, 'sha256'), 'hex') AS new_version_sha256 
     FROM json_string_cte 
 ) 
 select * FROM hashed_json_string_cte;
```

It now returns all the records:
```
id|json_string       |new_version_sha256                                              |
--+------------------+----------------------------------------------------------------+
 1|{"version":"mock"}|dc5503a03b7a16ff473d3628846a4f7d62fac2d7f69b16a5808cd3d9270474c3|
 4|{}                |44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a|
```