### PR TITLE
fly: skip destroy confirmation when pipeline does not exist

### DIFF
--- a/fly/commands/destroy_pipeline.go
+++ b/fly/commands/destroy_pipeline.go
@@ -43,6 +43,17 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 	}
 
 	pipelineRef := command.Pipeline.Ref()
+
+	_, found, err := team.Pipeline(pipelineRef)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		fmt.Printf("`%s` does not exist\n", pipelineRef.String())
+		return nil
+	}
+
 	fmt.Printf("!!! this will remove all data for pipeline `%s`\n\n", pipelineRef.String())
 
 	confirm := command.SkipInteractive
@@ -54,16 +65,12 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 		}
 	}
 
-	found, err := team.DeletePipeline(pipelineRef)
+	_, err = team.DeletePipeline(pipelineRef)
 	if err != nil {
 		return err
 	}
 
-	if !found {
-		fmt.Printf("`%s` does not exist\n", pipelineRef.String())
-	} else {
-		fmt.Printf("`%s` deleted\n", pipelineRef.String())
-	}
+	fmt.Printf("`%s` deleted\n", pipelineRef.String())
 
 	return nil
 }


### PR DESCRIPTION
## Changes proposed by this PR

Closes #9217

- Skip the interactive confirmation prompt when the target pipeline does not exist.
- Preserve the existing behavior for existing pipelines (still prompts, then deletes).

## Notes to reviewer

### Motivation
`fly destroy-pipeline` currently prints the warning and asks for confirmation even when the pipeline does not exist, and only then reports `does not exist`. This adds an unnecessary prompt and can be confusing.

### How I verified
Using a local Concourse (quickstart):

- Non-existent pipeline no longer prompts:
  ```sh
  ./fly -t local destroy-pipeline -p definitely-not-exist-$(date +%s)
  # -> `...` does not exist
