### PR TITLE
Validate unknown fields in inline task configs

### DIFF
--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -2000,6 +2000,30 @@ var _ = Describe("ValidateConfig", func() {
 				})
 			})
 
+			Context("when an inline task config has unknown fields (e.g. typo like 'ouputs')", func() {
+				BeforeEach(func() {
+					job.PlanSequence = append(job.PlanSequence, atc.Step{
+						Config: &atc.TaskStep{
+							Name: "task",
+							Config: &atc.TaskConfig{
+								Platform: "linux",
+								Run: atc.TaskRunConfig{
+									Path: "/bin/true",
+								},
+								UnknownFields: map[string]*json.RawMessage{"ouputs": nil},
+							},
+						},
+					})
+
+					config.Jobs = append(config.Jobs, job)
+				})
+
+				It("returns an error", func() {
+					Expect(errorMessages).To(HaveLen(1))
+					Expect(errorMessages[0]).To(ContainSubstring(`jobs.some-other-job.plan.do[0].task(task).config: unknown fields ["ouputs"]`))
+				})
+			})
+
 			Context("when an across step is valid", func() {
 				BeforeEach(func() {
 					job.PlanSequence = append(job.PlanSequence, atc.Step{

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -98,6 +98,14 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 	if plan.Config != nil {
 		validator.pushContext(".config")
 
+		if len(plan.Config.UnknownFields) > 0 {
+			var fieldNames []string
+			for field := range plan.Config.UnknownFields {
+				fieldNames = append(fieldNames, field)
+			}
+			validator.recordErrorf("unknown fields %+q", fieldNames)
+		}
+
 		if err := plan.Config.Validate(); err != nil {
 			if validationErr, ok := err.(TaskValidationError); ok {
 				for _, msg := range validationErr.Errors {

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -136,7 +136,7 @@ func (step Step) MarshalJSON() ([]byte, error) {
 }
 
 // See the note about json tags here: https://golang.org/pkg/encoding/json/#Marshal
-func deleteKnownFields(rawStepConfig map[string]*json.RawMessage, step StepConfig) {
+func deleteKnownFields(rawStepConfig map[string]*json.RawMessage, step any) {
 	stepType := reflect.TypeOf(step).Elem()
 	for i := 0; i < stepType.NumField(); i++ {
 		field := stepType.Field(i)

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -395,7 +395,7 @@ var factoryTests = []StepTest{
 			across:
 			- var: var1
 			  values: [1, 2, 3]
-			  bogus_field: lol what ru gonna do about it 
+			  bogus_field: lol what ru gonna do about it
 		`,
 
 		Err: `error unmarshaling JSON: while decoding JSON: malformed across step: json: unknown field "bogus_field"`,
@@ -584,6 +584,7 @@ func (test StepTest) Run(s *StepsSuite) {
 	var step atc.Step
 	actualErr := yaml.Unmarshal([]byte(cleanIndents), &step)
 	if test.Err != "" {
+		s.Error(actualErr)
 		s.Contains(actualErr.Error(), test.Err)
 		return
 	} else {

--- a/atc/task.go
+++ b/atc/task.go
@@ -68,23 +68,8 @@ func (ir *ImageResource) ApplySourceDefaults(resourceTypes ResourceTypes) {
 	}
 }
 
-// taskConfigKnownFields lists all valid JSON field names for TaskConfig.
-// This is used by UnmarshalJSON to detect unknown fields like typos.
-var taskConfigKnownFields = map[string]bool{
-	"platform":         true,
-	"rootfs_uri":       true,
-	"image_resource":   true,
-	"container_limits": true,
-	"params":           true,
-	"run":              true,
-	"inputs":           true,
-	"outputs":          true,
-	"caches":           true,
-}
-
 // UnmarshalJSON implements custom unmarshaling for TaskConfig to detect
 // unknown fields (like typos such as "ouputs" instead of "outputs").
-// reference: https://github.com/concourse/concourse/issues/8923
 func (config *TaskConfig) UnmarshalJSON(data []byte) error {
 	// First, unmarshal into a map to capture all fields
 	var rawConfig map[string]*json.RawMessage
@@ -101,14 +86,9 @@ func (config *TaskConfig) UnmarshalJSON(data []byte) error {
 
 	*config = TaskConfig(alias)
 
-	// Detect unknown fields
-	for key := range rawConfig {
-		if !taskConfigKnownFields[key] {
-			if config.UnknownFields == nil {
-				config.UnknownFields = make(map[string]*json.RawMessage)
-			}
-			config.UnknownFields[key] = rawConfig[key]
-		}
+	deleteKnownFields(rawConfig, config)
+	if len(rawConfig) != 0 {
+		config.UnknownFields = rawConfig
 	}
 
 	return nil

--- a/atc/task.go
+++ b/atc/task.go
@@ -84,6 +84,7 @@ var taskConfigKnownFields = map[string]bool{
 
 // UnmarshalJSON implements custom unmarshaling for TaskConfig to detect
 // unknown fields (like typos such as "ouputs" instead of "outputs").
+// reference: https://github.com/concourse/concourse/issues/8923
 func (config *TaskConfig) UnmarshalJSON(data []byte) error {
 	// First, unmarshal into a map to capture all fields
 	var rawConfig map[string]*json.RawMessage

--- a/atc/task.go
+++ b/atc/task.go
@@ -36,6 +36,11 @@ type TaskConfig struct {
 
 	// Path to cached directory that will be shared between builds for the same task.
 	Caches []TaskCacheConfig `json:"caches,omitempty"`
+
+	// UnknownFields holds any fields that were present in the config but not
+	// recognized. This is used for validation to report typos like "ouputs"
+	// instead of "outputs".
+	UnknownFields map[string]*json.RawMessage `json:"-"`
 }
 
 type ImageResource struct {
@@ -63,11 +68,68 @@ func (ir *ImageResource) ApplySourceDefaults(resourceTypes ResourceTypes) {
 	}
 }
 
+// taskConfigKnownFields lists all valid JSON field names for TaskConfig.
+// This is used by UnmarshalJSON to detect unknown fields like typos.
+var taskConfigKnownFields = map[string]bool{
+	"platform":         true,
+	"rootfs_uri":       true,
+	"image_resource":   true,
+	"container_limits": true,
+	"params":           true,
+	"run":              true,
+	"inputs":           true,
+	"outputs":          true,
+	"caches":           true,
+}
+
+// UnmarshalJSON implements custom unmarshaling for TaskConfig to detect
+// unknown fields (like typos such as "ouputs" instead of "outputs").
+func (config *TaskConfig) UnmarshalJSON(data []byte) error {
+	// First, unmarshal into a map to capture all fields
+	var rawConfig map[string]*json.RawMessage
+	if err := json.Unmarshal(data, &rawConfig); err != nil {
+		return err
+	}
+
+	// Use a type alias to avoid infinite recursion
+	type taskConfigAlias TaskConfig
+	var alias taskConfigAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	*config = TaskConfig(alias)
+
+	// Detect unknown fields
+	for key := range rawConfig {
+		if !taskConfigKnownFields[key] {
+			if config.UnknownFields == nil {
+				config.UnknownFields = make(map[string]*json.RawMessage)
+			}
+			config.UnknownFields[key] = rawConfig[key]
+		}
+	}
+
+	return nil
+}
+
 func NewTaskConfig(configBytes []byte) (TaskConfig, error) {
 	var config TaskConfig
-	err := yaml.UnmarshalStrict(configBytes, &config, yaml.DisallowUnknownFields)
+	// Note: yaml.UnmarshalStrict's DisallowUnknownFields doesn't work with
+	// custom UnmarshalJSON methods, so we rely on UnknownFields being populated
+	// by our UnmarshalJSON and check it explicitly below.
+	err := yaml.Unmarshal(configBytes, &config)
 	if err != nil {
 		return TaskConfig{}, err
+	}
+
+	// Check for unknown fields (e.g., typos like "ouputs" instead of "outputs")
+	if len(config.UnknownFields) > 0 {
+		var fieldNames []string
+		for field := range config.UnknownFields {
+			fieldNames = append(fieldNames, field)
+		}
+		return TaskConfig{}, fmt.Errorf("unknown fields: %v", fieldNames)
 	}
 
 	err = config.Validate()

--- a/atc/task_test.go
+++ b/atc/task_test.go
@@ -182,7 +182,7 @@ intputs: []
 run: {path: a/file}
 `)
 					_, err := NewTaskConfig(data)
-					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("unknown fields: [intputs]"))
 				})
 			})
 


### PR DESCRIPTION
## Changes proposed by this PR                                                                                                                                                                              
                                                                                                                                                                                                              
  closes #8923                                                                                                                                                                                                
                                                                                                                                                                                                              
  _Make sure to follow all [PR requirements](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements)._                                                                  
                                                                                                                                                                                                              
  * Add `UnknownFields` field to `TaskConfig` struct to capture unrecognized fields during JSON unmarshaling                                                                                                  
  * Implement custom `UnmarshalJSON` for `TaskConfig` to detect fields not in `taskConfigKnownFields`                                                                                                         
  * Update `StepValidator.VisitTask` to report validation errors when unknown fields are found in inline task configs                                                                                         
  * Update `NewTaskConfig` to return an error when unknown fields are detected (for external task files)                                                                                                      
  * Add test case for inline task config with unknown fields (e.g., typo like `ouputs`)                                                                                                                       
                                                                                                                                                                                                              
  ## Notes to reviewer                                                                                                                                                                                        
                                                                                                                                                                                                              
  Before this change, typos in inline task configs (e.g., `ouputs` instead of `outputs`) were silently ignored and only failed at runtime with confusing errors like "missing inputs".                        
                                                                                                                                                                                                              
  After this change:                                                                                                                                                                                          
  ```yaml                                                                                                                                                                                                     
  - task: build                                                                                                                                                                                               
    config:                                                                                                                                                                                                   
      platform: linux                                                                                                                                                                                         
      ouputs:  # typo                                                                                                                                                                                         
      - name: my-output                                                                                                                                                                                       
  ```                                                                                                                                                                                                            
  Will return a clear validation error at fly set-pipeline time:                                                                                                                                              
  jobs.build.plan.task(build).config: unknown fields ["ouputs"]                                                                                                                                               
                                                                                                                                                                                                              
  Release Note                                                                                                                                                                                                
                                                                                                                                                                                                              
  - Inline task configurations now validate field names and report errors for unknown fields (typos like ouputs instead of outputs)  