### PR TITLE
fix fly/integration/ tests on Windows

### DIFF
--- a/fly/commands/internal/interaction/confirm.go
+++ b/fly/commands/internal/interaction/confirm.go
@@ -3,7 +3,6 @@ package interaction
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -22,7 +21,7 @@ func Confirm(prompt string) (bool, error) {
 	i.Width = 3
 
 	m, err := tea.NewProgram(confirmModel{input: i},
-		tea.WithInput(os.Stdin)).Run()
+		tea.WithInput(checkStdin())).Run()
 	if err != nil {
 		return false, err
 	}

--- a/fly/commands/internal/interaction/input.go
+++ b/fly/commands/internal/interaction/input.go
@@ -3,7 +3,6 @@ package interaction
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -32,7 +31,7 @@ func InputProgram(prompt string, isSensitive bool) *tea.Program {
 	if isSensitive {
 		i.EchoMode = textinput.EchoNone
 	}
-	return tea.NewProgram(InputModel{input: i}, tea.WithInput(os.Stdin))
+	return tea.NewProgram(InputModel{input: i}, tea.WithInput(checkStdin()))
 }
 
 var _ tea.Model = InputModel{}

--- a/fly/commands/internal/interaction/selector.go
+++ b/fly/commands/internal/interaction/selector.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -55,7 +54,7 @@ func Select(prompt string, items []list.Item) (any, error) {
 	l.KeyMap.ShowFullHelp.Unbind()
 
 	done, err := tea.NewProgram(selectModel{prompt: prompt, list: l},
-		tea.WithInput(os.Stdin)).Run()
+		tea.WithInput(checkStdin())).Run()
 	if err != nil {
 		return nil, err
 	}

--- a/fly/commands/internal/interaction/stdin.go
+++ b/fly/commands/internal/interaction/stdin.go
@@ -1,0 +1,20 @@
+package interaction
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// https://github.com/charmbracelet/bubbletea/issues/964
+func checkStdin() io.Reader {
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		return os.Stdin
+	}
+	return safeReader{Reader: os.Stdin}
+}
+
+type safeReader struct {
+	io.Reader
+}

--- a/fly/commands/internal/interaction/token.go
+++ b/fly/commands/internal/interaction/token.go
@@ -2,7 +2,6 @@ package interaction
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -17,7 +16,7 @@ func TokenProgram() *tea.Program {
 	i.PromptStyle = lipgloss.NewStyle()
 	i.EchoMode = textinput.EchoNone
 	i.Focus()
-	return tea.NewProgram(TokenModel{input: i}, tea.WithInput(os.Stdin))
+	return tea.NewProgram(TokenModel{input: i}, tea.WithInput(checkStdin()))
 }
 
 var _ tea.Model = TokenModel{}

--- a/fly/integration/hijack_test.go
+++ b/fly/integration/hijack_test.go
@@ -407,6 +407,9 @@ var _ = Describe("hijack", func() {
 			fmt.Fprint(stdin, "j")
 			time.Sleep(time.Millisecond)
 			fmt.Fprint(stdin, "\r")
+			// not 100% what happens, but it seems the underlying pipe gets
+			// broken and sending something to stdin gets it working again
+			fmt.Fprintf(stdin, "reset stdin\r\n")
 
 			Eventually(hijacked).Should(BeClosed())
 
@@ -526,6 +529,9 @@ var _ = Describe("hijack", func() {
 
 				_, err = fmt.Fprintf(stdin, "\r")
 				Expect(err).NotTo(HaveOccurred())
+				// not 100% what happens, but it seems the underlying pipe gets
+				// broken and sending something to stdin gets it working again
+				fmt.Fprintf(stdin, "reset stdin\r\n")
 
 				Eventually(hijacked).Should(BeClosed())
 

--- a/fly/integration/set_team_test.go
+++ b/fly/integration/set_team_test.go
@@ -61,8 +61,8 @@ var _ = Describe("set-team", func() {
 
 						Eventually(sess.Out).ShouldNot(gbytes.Say("role viewer:"))
 
-						sess.Interrupt()
-						Eventually(sess).Should(gexec.Exit(1))
+						sess.Kill()
+						Eventually(sess).ShouldNot(gexec.Exit(0))
 					})
 				})
 
@@ -84,8 +84,8 @@ var _ = Describe("set-team", func() {
 
 						Eventually(sess.Out).ShouldNot(gbytes.Say("role viewer:"))
 
-						sess.Interrupt()
-						Eventually(sess).Should(gexec.Exit())
+						sess.Kill()
+						Eventually(sess).ShouldNot(gexec.Exit(0))
 					})
 				})
 			})
@@ -121,8 +121,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -155,8 +155,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- github:some-org:some-team"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -194,8 +194,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org:some-space:auditor"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-guid"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -228,8 +228,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- ldap:some-group"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -262,8 +262,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- oauth:some-group"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -296,8 +296,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 		})
@@ -531,8 +531,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -554,8 +554,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("- cf:myorg-2:myspace"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:myspace-guid"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -575,8 +575,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- ldap:my-group"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -598,8 +598,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- oauth:cool-scope-name"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 
@@ -619,8 +619,8 @@ var _ = Describe("set-team", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- github:samson-org:samson-team"))
 
-					sess.Interrupt()
-					Eventually(sess).Should(gexec.Exit(1))
+					sess.Kill()
+					Eventually(sess).ShouldNot(gexec.Exit(0))
 				})
 			})
 		})


### PR DESCRIPTION
## Changes proposed by this PR

I noticed the `fly/integration` tests were failing in CI.

* Make stdin safe for tests by wrapping stdin. It seems we ran into this issue, but the windows variant of it
  https://github.com/charmbracelet/bubbletea/issues/964
  * Underlying error we get on Windows is `error: error creating cancelreader: failed to prepare console input: get console mode: The handle is invalid.`
* Use `kill()` instead of `Interrupt()` for better cross-platform testing behaviour (looking at you WINDOWS)
  * `Interrupt()` didn't kill the process on Windows, `Kill()` does
  * Changed the exit code check. When using `Kill()`, on unix systems we get `128 + signal`, while Windows gets `1`. So now we just check that it's a non-zero exit code.

I also manually verified that the tests run successfully on macOS, Linux, and Windows. I also manually installed and tested fly commands with prompt interactions `fly intercept/login/set-pipeline` on all three systems.