### PR TITLE
fix windows copy and enable debug logging for baggageclaim tests

### DIFF
--- a/worker/baggageclaim/integration/baggageclaim/suite_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/suite_test.go
@@ -95,6 +95,7 @@ func (bcr *BaggageClaimRunner) Start() {
 		Name: "baggageclaim",
 		Command: exec.Command(
 			bcr.path,
+			"--log-level", "debug",
 			"--bind-port", strconv.Itoa(bcr.port),
 			"--debug-bind-port", strconv.Itoa(8099+GinkgoParallelProcess()),
 			"--volumes", bcr.volumeDir,

--- a/worker/baggageclaim/volume/copy/copy_windows.go
+++ b/worker/baggageclaim/volume/copy/copy_windows.go
@@ -38,8 +38,9 @@ func robocopy(args ...string) error {
 			if exitErr.ExitCode() > 1 {
 				return errors.Join(err, errors.New(string(exitErr.Stderr)))
 			}
+		} else {
+			return err
 		}
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Changes proposed by this PR

Previous PR #9451 I made a mistake when refactoring. Reverts that change and also sets the log level to debug for the baggageclaim/intgration test suite.
