### PR TITLE
Make error helpful when failing to stream rootfs metadata file

### DIFF
--- a/atc/worker/gardenruntime/image.go
+++ b/atc/worker/gardenruntime/image.go
@@ -63,7 +63,7 @@ func (worker *Worker) fetchImageForContainer(
 		imageMetadataReader, err := worker.streamer.StreamFile(ctx, imageSpec.ImageArtifact, ImageMetadataFile)
 		if err != nil {
 			logger.Error("failed-to-stream-metadata-file", err)
-			return FetchedImage{}, fmt.Errorf("stream image metadata file: %w", err)
+			return FetchedImage{}, fmt.Errorf("stream image metadata file: %w. Is the image in rootfs format?", err)
 		}
 
 		metadata, err := loadMetadata(imageMetadataReader)


### PR DESCRIPTION
## Changes proposed by this PR

From a convo with @drich10.

Users usually see this error if a container is not in rootfs format:

```
find or create container on worker ci-workers-worker-1: stream image metadata file: file not found
```

Users don't know what file Concourse was trying to get and this will most likely only happen when the container image is not in rootfs format. New error message appends `Is the image in rootfs format?` to the end of the error.