### PR TITLE
Volume sweeper removes orphaned volume artifacts

### DIFF
--- a/atc/worker/gardenruntime/gardenruntimetest/baggageclaim.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/baggageclaim.go
@@ -11,7 +11,10 @@ import (
 
 	"github.com/concourse/concourse/atc/runtime/runtimetest"
 	"github.com/concourse/concourse/worker/baggageclaim"
+	bclient "github.com/concourse/concourse/worker/baggageclaim/client"
 )
+
+var _ bclient.Client = (*Baggageclaim)(nil)
 
 type Baggageclaim struct {
 	Volumes []*Volume
@@ -85,6 +88,10 @@ func (b *Baggageclaim) DestroyVolume(_ context.Context, handle string) error {
 	b.Volumes = b.FilteredVolumes(func(v *Volume) bool {
 		return v.handle != handle
 	})
+	return nil
+}
+
+func (b *Baggageclaim) CleanupOrphanedVolumes(_ context.Context) error {
 	return nil
 }
 

--- a/worker/baggageclaim/api/handler.go
+++ b/worker/baggageclaim/api/handler.go
@@ -48,6 +48,7 @@ func NewHandler(
 		baggageclaim.StreamP2pOut:            http.HandlerFunc(volumeServer.StreamP2pOut),
 		baggageclaim.DestroyVolume:           http.HandlerFunc(volumeServer.DestroyVolume),
 		baggageclaim.DestroyVolumes:          http.HandlerFunc(volumeServer.DestroyVolumes),
+		baggageclaim.CleanupOrphanedVolumes:  http.HandlerFunc(volumeServer.CleanupOrphanedVolumes),
 
 		baggageclaim.GetP2pUrl: http.HandlerFunc(p2pServer.GetP2pUrl),
 	}

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -291,6 +291,24 @@ func (vs *VolumeServer) DestroyVolumes(w http.ResponseWriter, req *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (vs *VolumeServer) CleanupOrphanedVolumes(w http.ResponseWriter, req *http.Request) {
+	hLog := vs.logger.Session("cleanup-orphaned-volumes")
+
+	hLog.Debug("start")
+	defer hLog.Debug("done")
+
+	ctx := lagerctx.NewContext(req.Context(), hLog)
+
+	err := vs.volumeRepo.CleanupOrphanedVolumes(ctx)
+	if err != nil {
+		hLog.Error("failed-to-cleanup-orphaned-volumes", err)
+		RespondWithError(w, err, http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (vs *VolumeServer) ListVolumes(w http.ResponseWriter, req *http.Request) {
 	hLog := vs.logger.Session("list-volumes")
 

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -307,7 +307,7 @@ func (vs *VolumeServer) ListVolumes(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	volumes, _, err := vs.volumeRepo.ListVolumes(ctx, properties)
+	volumes, err := vs.volumeRepo.ListVolumes(ctx, properties)
 	if err != nil {
 		hLog.Error("failed-to-list-volumes", err)
 		RespondWithError(w, ErrListVolumesFailed, http.StatusInternalServerError)

--- a/worker/baggageclaim/api/volume_server_test.go
+++ b/worker/baggageclaim/api/volume_server_test.go
@@ -1298,6 +1298,17 @@ var _ = Describe("Volume Server", func() {
 			})
 		})
 	})
+
+	Describe("cleanup orphaned volumes", func() {
+		It("returns 204 on success", func() {
+			recorder := httptest.NewRecorder()
+
+			request, _ := http.NewRequest("POST", "/volumes/cleanup-orphans", nil)
+			handler.ServeHTTP(recorder, request)
+
+			Expect(recorder.Code).To(Equal(http.StatusNoContent))
+		})
+	})
 })
 
 func encStrategy(strategy map[string]string) *json.RawMessage {

--- a/worker/baggageclaim/baggageclaimfakes/fake_client.go
+++ b/worker/baggageclaim/baggageclaimfakes/fake_client.go
@@ -9,6 +9,17 @@ import (
 )
 
 type FakeClient struct {
+	CleanupOrphanedVolumesStub        func(context.Context) error
+	cleanupOrphanedVolumesMutex       sync.RWMutex
+	cleanupOrphanedVolumesArgsForCall []struct {
+		arg1 context.Context
+	}
+	cleanupOrphanedVolumesReturns struct {
+		result1 error
+	}
+	cleanupOrphanedVolumesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	CreateVolumeStub        func(context.Context, string, baggageclaim.VolumeSpec) (baggageclaim.Volume, error)
 	createVolumeMutex       sync.RWMutex
 	createVolumeArgsForCall []struct {
@@ -80,6 +91,67 @@ type FakeClient struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeClient) CleanupOrphanedVolumes(arg1 context.Context) error {
+	fake.cleanupOrphanedVolumesMutex.Lock()
+	ret, specificReturn := fake.cleanupOrphanedVolumesReturnsOnCall[len(fake.cleanupOrphanedVolumesArgsForCall)]
+	fake.cleanupOrphanedVolumesArgsForCall = append(fake.cleanupOrphanedVolumesArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.CleanupOrphanedVolumesStub
+	fakeReturns := fake.cleanupOrphanedVolumesReturns
+	fake.recordInvocation("CleanupOrphanedVolumes", []interface{}{arg1})
+	fake.cleanupOrphanedVolumesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) CleanupOrphanedVolumesCallCount() int {
+	fake.cleanupOrphanedVolumesMutex.RLock()
+	defer fake.cleanupOrphanedVolumesMutex.RUnlock()
+	return len(fake.cleanupOrphanedVolumesArgsForCall)
+}
+
+func (fake *FakeClient) CleanupOrphanedVolumesCalls(stub func(context.Context) error) {
+	fake.cleanupOrphanedVolumesMutex.Lock()
+	defer fake.cleanupOrphanedVolumesMutex.Unlock()
+	fake.CleanupOrphanedVolumesStub = stub
+}
+
+func (fake *FakeClient) CleanupOrphanedVolumesArgsForCall(i int) context.Context {
+	fake.cleanupOrphanedVolumesMutex.RLock()
+	defer fake.cleanupOrphanedVolumesMutex.RUnlock()
+	argsForCall := fake.cleanupOrphanedVolumesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) CleanupOrphanedVolumesReturns(result1 error) {
+	fake.cleanupOrphanedVolumesMutex.Lock()
+	defer fake.cleanupOrphanedVolumesMutex.Unlock()
+	fake.CleanupOrphanedVolumesStub = nil
+	fake.cleanupOrphanedVolumesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) CleanupOrphanedVolumesReturnsOnCall(i int, result1 error) {
+	fake.cleanupOrphanedVolumesMutex.Lock()
+	defer fake.cleanupOrphanedVolumesMutex.Unlock()
+	fake.CleanupOrphanedVolumesStub = nil
+	if fake.cleanupOrphanedVolumesReturnsOnCall == nil {
+		fake.cleanupOrphanedVolumesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.cleanupOrphanedVolumesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeClient) CreateVolume(arg1 context.Context, arg2 string, arg3 baggageclaim.VolumeSpec) (baggageclaim.Volume, error) {

--- a/worker/baggageclaim/client.go
+++ b/worker/baggageclaim/client.go
@@ -73,6 +73,11 @@ type Client interface {
 	// DestroyVolume returns an error if the volume deletion fails. It does not
 	// return an error if the volume was not found on the server.
 	DestroyVolume(context.Context, string) error
+
+	// CleanupOrphanedVolumes removes stale dead directory entries and
+	// orphaned driver-specific resources (e.g. overlay layers) that are
+	// not associated with any live or initializing volume.
+	CleanupOrphanedVolumes(context.Context) error
 }
 
 //counterfeiter:generate . Volume

--- a/worker/baggageclaim/client/client.go
+++ b/worker/baggageclaim/client/client.go
@@ -239,6 +239,26 @@ func (c *client) DestroyVolume(ctx context.Context, handle string) error {
 	return nil
 }
 
+func (c *client) CleanupOrphanedVolumes(ctx context.Context) error {
+	request, err := c.generateRequest(ctx, baggageclaim.CleanupOrphanedVolumes, rata.Params{}, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := c.httpClient(ctx).Do(request)
+	if err != nil {
+		return err
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNoContent {
+		return getError(response)
+	}
+
+	return nil
+}
+
 func (c *client) newVolume(apiVolume baggageclaim.VolumeResponse) baggageclaim.Volume {
 	volume := &clientVolume{
 		handle: apiVolume.Handle,

--- a/worker/baggageclaim/routes.go
+++ b/worker/baggageclaim/routes.go
@@ -3,11 +3,12 @@ package baggageclaim
 import "github.com/tedsuo/rata"
 
 const (
-	ListVolumes    = "ListVolumes"
-	GetVolume      = "GetVolume"
-	CreateVolume   = "CreateVolume"
-	DestroyVolume  = "DestroyVolume"
-	DestroyVolumes = "DestroyVolumes"
+	ListVolumes            = "ListVolumes"
+	GetVolume              = "GetVolume"
+	CreateVolume           = "CreateVolume"
+	DestroyVolume          = "DestroyVolume"
+	DestroyVolumes         = "DestroyVolumes"
+	CleanupOrphanedVolumes = "CleanupOrphanedVolumes"
 
 	CreateVolumeAsync       = "CreateVolumeAsync"
 	CreateVolumeAsyncCancel = "CreateVolumeAsyncCancel"
@@ -26,6 +27,7 @@ const (
 var Routes = rata.Routes{
 	{Path: "/volumes", Method: "GET", Name: ListVolumes},
 	{Path: "/volumes", Method: "POST", Name: CreateVolume},
+	{Path: "/volumes/cleanup-orphans", Method: "POST", Name: CleanupOrphanedVolumes},
 
 	{Path: "/volumes-async", Method: "POST", Name: CreateVolumeAsync},
 	{Path: "/volumes-async/:handle", Method: "GET", Name: CreateVolumeAsyncCheck},

--- a/worker/baggageclaim/volume/driver.go
+++ b/worker/baggageclaim/volume/driver.go
@@ -10,4 +10,5 @@ type Driver interface {
 	CreateCopyOnWriteLayer(FilesystemInitVolume, FilesystemLiveVolume) error
 
 	Recover(Filesystem) error
+	RemoveOrphanedResources(knownHandles map[string]struct{}) error
 }

--- a/worker/baggageclaim/volume/driver/btrfs.go
+++ b/worker/baggageclaim/volume/driver/btrfs.go
@@ -145,3 +145,8 @@ func (driver *BtrFSDriver) Recover(volume.Filesystem) error {
 	// nothing to do
 	return nil
 }
+
+func (driver *BtrFSDriver) RemoveOrphanedResources(_ map[string]struct{}) error {
+	// nothing to do. btrfs volumes live under the managed volume/ directory
+	return nil
+}

--- a/worker/baggageclaim/volume/driver/naive.go
+++ b/worker/baggageclaim/volume/driver/naive.go
@@ -30,3 +30,8 @@ func (driver *NaiveDriver) Recover(volume.Filesystem) error {
 	// nothing to do
 	return nil
 }
+
+func (driver *NaiveDriver) RemoveOrphanedResources(_ map[string]struct{}) error {
+	// nothing to do. naive volumes live under the managed volume/ directory
+	return nil
+}

--- a/worker/baggageclaim/volume/repository_test.go
+++ b/worker/baggageclaim/volume/repository_test.go
@@ -1218,6 +1218,37 @@ var _ = Describe("Repository", func() {
 			})
 		})
 	})
+
+	Describe("CleanupOrphanedVolumes", func() {
+		var cleanupErr error
+
+		JustBeforeEach(func() {
+			cleanupErr = repository.CleanupOrphanedVolumes(context.Background())
+		})
+
+		Context("when CleanupOrphanedEntries succeeds", func() {
+			BeforeEach(func() {
+				fakeFilesystem.CleanupOrphanedEntriesReturns(nil)
+			})
+
+			It("delegates to filesystem.CleanupOrphanedEntries", func() {
+				Expect(cleanupErr).ToNot(HaveOccurred())
+				Expect(fakeFilesystem.CleanupOrphanedEntriesCallCount()).To(Equal(1))
+			})
+		})
+
+		Context("when CleanupOrphanedEntries fails", func() {
+			expectedErr := errors.New("cleanup-failed")
+
+			BeforeEach(func() {
+				fakeFilesystem.CleanupOrphanedEntriesReturns(expectedErr)
+			})
+
+			It("returns the error", func() {
+				Expect(cleanupErr).To(Equal(expectedErr))
+			})
+		})
+	})
 })
 
 var _ = Describe("LimitedReader", func() {

--- a/worker/baggageclaim/volume/repository_test.go
+++ b/worker/baggageclaim/volume/repository_test.go
@@ -421,9 +421,8 @@ var _ = Describe("Repository", func() {
 		var (
 			queryProperties volume.Properties
 
-			corruptedVolumes []string
-			volumes          volume.Volumes
-			listErr          error
+			volumes volume.Volumes
+			listErr error
 		)
 
 		BeforeEach(func() {
@@ -431,7 +430,7 @@ var _ = Describe("Repository", func() {
 		})
 
 		JustBeforeEach(func() {
-			volumes, corruptedVolumes, listErr = repository.ListVolumes(context.Background(), queryProperties)
+			volumes, listErr = repository.ListVolumes(context.Background(), queryProperties)
 		})
 
 		Context("when volumes are found in the filesystem", func() {
@@ -546,7 +545,7 @@ var _ = Describe("Repository", func() {
 							fakeVolume2.LoadPropertiesReturns(nil, errors.New("nope"))
 						})
 
-						It("returns corrupted and working volumes", func() {
+						It("returns only working volumes", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
 									Handle:     "handle-1",
@@ -567,8 +566,6 @@ var _ = Describe("Repository", func() {
 									Privileged: false,
 								},
 							}))
-
-							Expect(corruptedVolumes).To(ConsistOf(fakeVolume2.Handle()))
 						})
 					})
 				})
@@ -619,7 +616,7 @@ var _ = Describe("Repository", func() {
 							fakeVolume2.LoadPropertiesReturns(nil, errors.New("nope"))
 						})
 
-						It("returns corrupted and working volumes", func() {
+						It("returns only working volumes", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
 									Handle:     "handle-1",
@@ -628,8 +625,6 @@ var _ = Describe("Repository", func() {
 									Privileged: true,
 								},
 							}))
-
-							Expect(corruptedVolumes).To(ConsistOf(fakeVolume2.Handle()))
 						})
 					})
 				})

--- a/worker/baggageclaim/volume/volumefakes/fake_driver.go
+++ b/worker/baggageclaim/volume/volumefakes/fake_driver.go
@@ -53,6 +53,17 @@ type FakeDriver struct {
 	recoverReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RemoveOrphanedResourcesStub        func(map[string]struct{}) error
+	removeOrphanedResourcesMutex       sync.RWMutex
+	removeOrphanedResourcesArgsForCall []struct {
+		arg1 map[string]struct{}
+	}
+	removeOrphanedResourcesReturns struct {
+		result1 error
+	}
+	removeOrphanedResourcesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -298,6 +309,67 @@ func (fake *FakeDriver) RecoverReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.recoverReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeDriver) RemoveOrphanedResources(arg1 map[string]struct{}) error {
+	fake.removeOrphanedResourcesMutex.Lock()
+	ret, specificReturn := fake.removeOrphanedResourcesReturnsOnCall[len(fake.removeOrphanedResourcesArgsForCall)]
+	fake.removeOrphanedResourcesArgsForCall = append(fake.removeOrphanedResourcesArgsForCall, struct {
+		arg1 map[string]struct{}
+	}{arg1})
+	stub := fake.RemoveOrphanedResourcesStub
+	fakeReturns := fake.removeOrphanedResourcesReturns
+	fake.recordInvocation("RemoveOrphanedResources", []interface{}{arg1})
+	fake.removeOrphanedResourcesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeDriver) RemoveOrphanedResourcesCallCount() int {
+	fake.removeOrphanedResourcesMutex.RLock()
+	defer fake.removeOrphanedResourcesMutex.RUnlock()
+	return len(fake.removeOrphanedResourcesArgsForCall)
+}
+
+func (fake *FakeDriver) RemoveOrphanedResourcesCalls(stub func(map[string]struct{}) error) {
+	fake.removeOrphanedResourcesMutex.Lock()
+	defer fake.removeOrphanedResourcesMutex.Unlock()
+	fake.RemoveOrphanedResourcesStub = stub
+}
+
+func (fake *FakeDriver) RemoveOrphanedResourcesArgsForCall(i int) map[string]struct{} {
+	fake.removeOrphanedResourcesMutex.RLock()
+	defer fake.removeOrphanedResourcesMutex.RUnlock()
+	argsForCall := fake.removeOrphanedResourcesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeDriver) RemoveOrphanedResourcesReturns(result1 error) {
+	fake.removeOrphanedResourcesMutex.Lock()
+	defer fake.removeOrphanedResourcesMutex.Unlock()
+	fake.RemoveOrphanedResourcesStub = nil
+	fake.removeOrphanedResourcesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeDriver) RemoveOrphanedResourcesReturnsOnCall(i int, result1 error) {
+	fake.removeOrphanedResourcesMutex.Lock()
+	defer fake.removeOrphanedResourcesMutex.Unlock()
+	fake.RemoveOrphanedResourcesStub = nil
+	if fake.removeOrphanedResourcesReturnsOnCall == nil {
+		fake.removeOrphanedResourcesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.removeOrphanedResourcesReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/worker/baggageclaim/volume/volumefakes/fake_filesystem.go
+++ b/worker/baggageclaim/volume/volumefakes/fake_filesystem.go
@@ -8,6 +8,16 @@ import (
 )
 
 type FakeFilesystem struct {
+	CleanupOrphanedEntriesStub        func() error
+	cleanupOrphanedEntriesMutex       sync.RWMutex
+	cleanupOrphanedEntriesArgsForCall []struct {
+	}
+	cleanupOrphanedEntriesReturns struct {
+		result1 error
+	}
+	cleanupOrphanedEntriesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ListVolumesStub        func() ([]volume.FilesystemLiveVolume, error)
 	listVolumesMutex       sync.RWMutex
 	listVolumesArgsForCall []struct {
@@ -50,6 +60,59 @@ type FakeFilesystem struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeFilesystem) CleanupOrphanedEntries() error {
+	fake.cleanupOrphanedEntriesMutex.Lock()
+	ret, specificReturn := fake.cleanupOrphanedEntriesReturnsOnCall[len(fake.cleanupOrphanedEntriesArgsForCall)]
+	fake.cleanupOrphanedEntriesArgsForCall = append(fake.cleanupOrphanedEntriesArgsForCall, struct {
+	}{})
+	stub := fake.CleanupOrphanedEntriesStub
+	fakeReturns := fake.cleanupOrphanedEntriesReturns
+	fake.recordInvocation("CleanupOrphanedEntries", []interface{}{})
+	fake.cleanupOrphanedEntriesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeFilesystem) CleanupOrphanedEntriesCallCount() int {
+	fake.cleanupOrphanedEntriesMutex.RLock()
+	defer fake.cleanupOrphanedEntriesMutex.RUnlock()
+	return len(fake.cleanupOrphanedEntriesArgsForCall)
+}
+
+func (fake *FakeFilesystem) CleanupOrphanedEntriesCalls(stub func() error) {
+	fake.cleanupOrphanedEntriesMutex.Lock()
+	defer fake.cleanupOrphanedEntriesMutex.Unlock()
+	fake.CleanupOrphanedEntriesStub = stub
+}
+
+func (fake *FakeFilesystem) CleanupOrphanedEntriesReturns(result1 error) {
+	fake.cleanupOrphanedEntriesMutex.Lock()
+	defer fake.cleanupOrphanedEntriesMutex.Unlock()
+	fake.CleanupOrphanedEntriesStub = nil
+	fake.cleanupOrphanedEntriesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeFilesystem) CleanupOrphanedEntriesReturnsOnCall(i int, result1 error) {
+	fake.cleanupOrphanedEntriesMutex.Lock()
+	defer fake.cleanupOrphanedEntriesMutex.Unlock()
+	fake.CleanupOrphanedEntriesStub = nil
+	if fake.cleanupOrphanedEntriesReturnsOnCall == nil {
+		fake.cleanupOrphanedEntriesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.cleanupOrphanedEntriesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeFilesystem) ListVolumes() ([]volume.FilesystemLiveVolume, error) {

--- a/worker/baggageclaim/volume/volumefakes/fake_repository.go
+++ b/worker/baggageclaim/volume/volumefakes/fake_repository.go
@@ -82,7 +82,7 @@ type FakeRepository struct {
 		result2 bool
 		result3 error
 	}
-	ListVolumesStub        func(context.Context, volume.Properties) (volume.Volumes, []string, error)
+	ListVolumesStub        func(context.Context, volume.Properties) (volume.Volumes, error)
 	listVolumesMutex       sync.RWMutex
 	listVolumesArgsForCall []struct {
 		arg1 context.Context
@@ -90,13 +90,11 @@ type FakeRepository struct {
 	}
 	listVolumesReturns struct {
 		result1 volume.Volumes
-		result2 []string
-		result3 error
+		result2 error
 	}
 	listVolumesReturnsOnCall map[int]struct {
 		result1 volume.Volumes
-		result2 []string
-		result3 error
+		result2 error
 	}
 	SetPrivilegedStub        func(context.Context, string, bool) error
 	setPrivilegedMutex       sync.RWMutex
@@ -518,7 +516,7 @@ func (fake *FakeRepository) GetVolumeReturnsOnCall(i int, result1 volume.Volume,
 	}{result1, result2, result3}
 }
 
-func (fake *FakeRepository) ListVolumes(arg1 context.Context, arg2 volume.Properties) (volume.Volumes, []string, error) {
+func (fake *FakeRepository) ListVolumes(arg1 context.Context, arg2 volume.Properties) (volume.Volumes, error) {
 	fake.listVolumesMutex.Lock()
 	ret, specificReturn := fake.listVolumesReturnsOnCall[len(fake.listVolumesArgsForCall)]
 	fake.listVolumesArgsForCall = append(fake.listVolumesArgsForCall, struct {
@@ -533,9 +531,9 @@ func (fake *FakeRepository) ListVolumes(arg1 context.Context, arg2 volume.Proper
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeRepository) ListVolumesCallCount() int {
@@ -544,7 +542,7 @@ func (fake *FakeRepository) ListVolumesCallCount() int {
 	return len(fake.listVolumesArgsForCall)
 }
 
-func (fake *FakeRepository) ListVolumesCalls(stub func(context.Context, volume.Properties) (volume.Volumes, []string, error)) {
+func (fake *FakeRepository) ListVolumesCalls(stub func(context.Context, volume.Properties) (volume.Volumes, error)) {
 	fake.listVolumesMutex.Lock()
 	defer fake.listVolumesMutex.Unlock()
 	fake.ListVolumesStub = stub
@@ -557,33 +555,30 @@ func (fake *FakeRepository) ListVolumesArgsForCall(i int) (context.Context, volu
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeRepository) ListVolumesReturns(result1 volume.Volumes, result2 []string, result3 error) {
+func (fake *FakeRepository) ListVolumesReturns(result1 volume.Volumes, result2 error) {
 	fake.listVolumesMutex.Lock()
 	defer fake.listVolumesMutex.Unlock()
 	fake.ListVolumesStub = nil
 	fake.listVolumesReturns = struct {
 		result1 volume.Volumes
-		result2 []string
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeRepository) ListVolumesReturnsOnCall(i int, result1 volume.Volumes, result2 []string, result3 error) {
+func (fake *FakeRepository) ListVolumesReturnsOnCall(i int, result1 volume.Volumes, result2 error) {
 	fake.listVolumesMutex.Lock()
 	defer fake.listVolumesMutex.Unlock()
 	fake.ListVolumesStub = nil
 	if fake.listVolumesReturnsOnCall == nil {
 		fake.listVolumesReturnsOnCall = make(map[int]struct {
 			result1 volume.Volumes
-			result2 []string
-			result3 error
+			result2 error
 		})
 	}
 	fake.listVolumesReturnsOnCall[i] = struct {
 		result1 volume.Volumes
-		result2 []string
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeRepository) SetPrivileged(arg1 context.Context, arg2 string, arg3 bool) error {

--- a/worker/baggageclaim/volume/volumefakes/fake_repository.go
+++ b/worker/baggageclaim/volume/volumefakes/fake_repository.go
@@ -11,6 +11,17 @@ import (
 )
 
 type FakeRepository struct {
+	CleanupOrphanedVolumesStub        func(context.Context) error
+	cleanupOrphanedVolumesMutex       sync.RWMutex
+	cleanupOrphanedVolumesArgsForCall []struct {
+		arg1 context.Context
+	}
+	cleanupOrphanedVolumesReturns struct {
+		result1 error
+	}
+	cleanupOrphanedVolumesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	CreateVolumeStub        func(context.Context, string, volume.Strategy, volume.Properties, bool) (volume.Volume, error)
 	createVolumeMutex       sync.RWMutex
 	createVolumeArgsForCall []struct {
@@ -189,6 +200,67 @@ type FakeRepository struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeRepository) CleanupOrphanedVolumes(arg1 context.Context) error {
+	fake.cleanupOrphanedVolumesMutex.Lock()
+	ret, specificReturn := fake.cleanupOrphanedVolumesReturnsOnCall[len(fake.cleanupOrphanedVolumesArgsForCall)]
+	fake.cleanupOrphanedVolumesArgsForCall = append(fake.cleanupOrphanedVolumesArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.CleanupOrphanedVolumesStub
+	fakeReturns := fake.cleanupOrphanedVolumesReturns
+	fake.recordInvocation("CleanupOrphanedVolumes", []interface{}{arg1})
+	fake.cleanupOrphanedVolumesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRepository) CleanupOrphanedVolumesCallCount() int {
+	fake.cleanupOrphanedVolumesMutex.RLock()
+	defer fake.cleanupOrphanedVolumesMutex.RUnlock()
+	return len(fake.cleanupOrphanedVolumesArgsForCall)
+}
+
+func (fake *FakeRepository) CleanupOrphanedVolumesCalls(stub func(context.Context) error) {
+	fake.cleanupOrphanedVolumesMutex.Lock()
+	defer fake.cleanupOrphanedVolumesMutex.Unlock()
+	fake.CleanupOrphanedVolumesStub = stub
+}
+
+func (fake *FakeRepository) CleanupOrphanedVolumesArgsForCall(i int) context.Context {
+	fake.cleanupOrphanedVolumesMutex.RLock()
+	defer fake.cleanupOrphanedVolumesMutex.RUnlock()
+	argsForCall := fake.cleanupOrphanedVolumesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRepository) CleanupOrphanedVolumesReturns(result1 error) {
+	fake.cleanupOrphanedVolumesMutex.Lock()
+	defer fake.cleanupOrphanedVolumesMutex.Unlock()
+	fake.CleanupOrphanedVolumesStub = nil
+	fake.cleanupOrphanedVolumesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeRepository) CleanupOrphanedVolumesReturnsOnCall(i int, result1 error) {
+	fake.cleanupOrphanedVolumesMutex.Lock()
+	defer fake.cleanupOrphanedVolumesMutex.Unlock()
+	fake.CleanupOrphanedVolumesStub = nil
+	if fake.cleanupOrphanedVolumesReturnsOnCall == nil {
+		fake.cleanupOrphanedVolumesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.cleanupOrphanedVolumesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeRepository) CreateVolume(arg1 context.Context, arg2 string, arg3 volume.Strategy, arg4 volume.Properties, arg5 bool) (volume.Volume, error) {

--- a/worker/volume_sweeper.go
+++ b/worker/volume_sweeper.go
@@ -95,4 +95,9 @@ func (sweeper *volumeSweeper) sweep(logger lager.Logger) {
 		}
 		wg.Wait()
 	}
+
+	err = sweeper.baggageclaimClient.CleanupOrphanedVolumes(ctx)
+	if err != nil {
+		logger.Error("failed-to-cleanup-orphaned-volumes", err)
+	}
 }

--- a/worker/volume_sweeper_test.go
+++ b/worker/volume_sweeper_test.go
@@ -1,0 +1,77 @@
+package worker_test
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
+	"github.com/concourse/concourse/worker"
+	"github.com/concourse/concourse/worker/baggageclaim/baggageclaimfakes"
+	"github.com/concourse/concourse/worker/workerfakes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Volume Sweeper", func() {
+	const (
+		sweepInterval = 1 * time.Second
+		maxInFlight   = uint16(1)
+	)
+
+	var (
+		testLogger = lagertest.NewTestLogger("volume-sweeper")
+
+		fakeTSAClient *workerfakes.FakeTSAClient
+		fakeBcClient  *baggageclaimfakes.FakeClient
+
+		osSignal chan os.Signal
+		exited   chan struct{}
+	)
+
+	BeforeEach(func() {
+		osSignal = make(chan os.Signal)
+		exited = make(chan struct{})
+
+		fakeTSAClient = new(workerfakes.FakeTSAClient)
+		fakeTSAClient.ReportVolumesReturns(nil)
+		fakeTSAClient.VolumesToDestroyReturns([]string{}, nil)
+
+		fakeBcClient = new(baggageclaimfakes.FakeClient)
+		fakeBcClient.ListVolumesReturns(nil, nil)
+	})
+
+	JustBeforeEach(func() {
+		sweeper := worker.NewVolumeSweeper(testLogger, sweepInterval, fakeTSAClient, fakeBcClient, maxInFlight)
+		go func() {
+			_ = sweeper.Run(osSignal, make(chan struct{}))
+			close(exited)
+		}()
+	})
+
+	AfterEach(func() {
+		close(osSignal)
+		<-exited
+	})
+
+	It("calls CleanupOrphanedVolumes on each tick", func() {
+		Eventually(fakeBcClient.CleanupOrphanedVolumesCallCount).Should(BeNumerically(">=", 1))
+	})
+
+	Context("when CleanupOrphanedVolumes returns an error", func() {
+		BeforeEach(func() {
+			fakeBcClient.CleanupOrphanedVolumesReturns(errors.New("cleanup-failed"))
+		})
+
+		It("logs the error but continues sweeping", func() {
+			// Wait for at least 2 ticks to confirm it keeps running
+			Eventually(fakeBcClient.CleanupOrphanedVolumesCallCount).Should(BeNumerically(">=", 2))
+			logs := testLogger.Logs()
+			Expect(len(logs)).To(BeNumerically(">=", 2))
+			Expect(logs[0].LogLevel).To(Equal(lager.ERROR))
+			Expect(logs[0].Data["error"]).To(Equal("cleanup-failed"))
+		})
+	})
+})


### PR DESCRIPTION
## Changes proposed by this PR

closes #9274 

The main logic is in the Filesystem and Driver. Everything else is just
plumbing.

At the Filesystem level, we try calling `volume.Destroy()` on any volumes
we find in the `dead/` directory.

Filesystem then gets all volume handles in the `init/` and `live/`
directories. We pass that list into the Driver's
`RemoveOrphanedResources()` func. It's then up to the driver to remove any
extra resources that it handles.

For btrfs and naive there's no extra work. Overlay has its `overlays/` dir
that lives outside the `volumes/` dir, so it has work to do.

The overlay driver goes through it's `overlays/` and `overlays/work/`
directory and deletes any directories that aren't in the list of
`knownHandles` passed into the func.

I used Claude Opus 4.6 with OpenCode to do most of the work. I
reviewed the code and made some modifications.