### PR TITLE
Implement SearchBar for jobs in pipelines

### DIFF
--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -237,7 +237,8 @@ handleCallback callback model =
 
         GotCurrentTimeZone zone ->
             let
-                session = model.session
+                session =
+                    model.session
             in
             ( { model | session = { session | timeZone = zone } }, [] )
 
@@ -245,10 +246,12 @@ handleCallback callback model =
             let
                 newMsg =
                     let
-                        trimmed = String.trim wall.message
+                        trimmed =
+                            String.trim wall.message
                     in
                     if trimmed == "" then
                         Nothing
+
                     else
                         Just trimmed
             in
@@ -478,12 +481,14 @@ view model =
                 Just msg ->
                     Html.div [ id "wall-banner", style "white-space" "pre-wrap" ] <|
                         wallLinks msg
+
                 Nothing ->
                     Html.text ""
             , Html.div
                 ([ id "page-wrapper", style "height" "100%" ]
                     ++ (if model.session.draggingSideBar then
                             Styles.disableInteraction
+
                         else
                             []
                        )
@@ -540,21 +545,27 @@ routeMatchesModel route model =
 wallLinks : String -> List (Html.Html msg)
 wallLinks msg =
     let
-        tokens = String.split " " msg
+        tokens =
+            String.split " " msg
 
         stripTrailingPunct original =
             let
-                punctuations = [ '.', ',' ]
+                punctuations =
+                    [ '.', ',' ]
 
                 dropWhileEnd s =
                     case String.uncons (String.reverse s) of
                         Just ( c, restRev ) ->
                             if List.member c punctuations then
                                 let
-                                    trimmed = String.reverse restRev
-                                    ( url, trailing ) = dropWhileEnd trimmed
+                                    trimmed =
+                                        String.reverse restRev
+
+                                    ( url, trailing ) =
+                                        dropWhileEnd trimmed
                                 in
                                 ( url, String.fromChar c ++ trailing )
+
                             else
                                 ( s, "" )
 
@@ -566,13 +577,18 @@ wallLinks msg =
         render t =
             if String.startsWith "http://" t || String.startsWith "https://" t then
                 let
-                    ( url, trailing ) = stripTrailingPunct t
-                    anchor = Html.a [ href url, target "_blank", rel "noopener noreferrer", style "text-decoration" "underline", style "margin-right" "0.25em" ] [ Html.text url ]
+                    ( url, trailing ) =
+                        stripTrailingPunct t
+
+                    anchor =
+                        Html.a [ href url, target "_blank", rel "noopener noreferrer", style "text-decoration" "underline", style "margin-right" "0.25em" ] [ Html.text url ]
                 in
                 if trailing == "" then
                     [ anchor ]
+
                 else
                     [ anchor, Html.text trailing ]
+
             else
                 [ Html.text t ]
     in

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -526,9 +526,10 @@ handleDelivery delivery ( model, effects ) =
                     currentBuildInvisible && not model.scrolledToCurrentBuild
             in
             ( if shouldScroll then
-                  { model | scrolledToCurrentBuild = True }
+                { model | scrolledToCurrentBuild = True }
+
               else
-                  model
+                model
             , effects
                 ++ (if shouldScroll then
                         [ Scroll (ToId id) historyId ]

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -1248,24 +1248,27 @@ viewStepHeader step =
             simpleHeader "task:" Nothing name
 
         Concourse.BuildStepSetPipeline name team instanceVars ->
-            headerWithContent "set_pipeline:" (Just "pipeline config changed")
+            headerWithContent "set_pipeline:"
+                (Just "pipeline config changed")
                 (Html.span [] [ Html.text name ]
-                 :: (case team of
-                        Just teamName ->
-                            [ Html.span [ style "color" Colors.pending, style "margin-left" "10px", style "margin-right" "4px" ] [ Html.text "team:" ]
-                            , Html.text teamName
-                            ]
+                    :: (case team of
+                            Just teamName ->
+                                [ Html.span [ style "color" Colors.pending, style "margin-left" "10px", style "margin-right" "4px" ] [ Html.text "team:" ]
+                                , Html.text teamName
+                                ]
 
-                        Nothing ->
+                            Nothing ->
+                                []
+                       )
+                    ++ (if Dict.isEmpty instanceVars then
                             []
-                    )
-                ++ (if Dict.isEmpty instanceVars then
-                    []
-                 else
-                    [ Html.span [ style "margin-left" "10px", style "margin-right" "4px" ] [ Html.text "/" ]
-                    , viewKeyValuePairHeaderLabels (Dict.toList instanceVars)
-                    ]
-                ))
+
+                        else
+                            [ Html.span [ style "margin-left" "10px", style "margin-right" "4px" ] [ Html.text "/" ]
+                            , viewKeyValuePairHeaderLabels (Dict.toList instanceVars)
+                            ]
+                       )
+                )
 
         Concourse.BuildStepLoadVar name ->
             simpleHeader "load_var:" Nothing name

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -34,7 +34,6 @@ import Dashboard.Models as Models
     exposing
         ( DragState(..)
         , DropState(..)
-        , Dropdown(..)
         , FetchError(..)
         , Model
         )
@@ -88,6 +87,7 @@ import StrictEvents exposing (onScroll)
 import Time
 import Tooltip
 import UserState
+import Views.SearchBar exposing (Dropdown(..))
 import Views.Spinner as Spinner
 import Views.Styles
 import Views.Toggle as Toggle

--- a/web/elm/src/Dashboard/Footer.elm
+++ b/web/elm/src/Dashboard/Footer.elm
@@ -4,7 +4,7 @@ import Assets
 import Concourse.PipelineStatus as PipelineStatus exposing (PipelineStatus(..))
 import Dashboard.Filter as Filter
 import Dashboard.Group.Models exposing (Pipeline)
-import Dashboard.Models exposing (Dropdown(..), FooterModel)
+import Dashboard.Models exposing (FooterModel)
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
 import HoverState
@@ -17,6 +17,7 @@ import Message.Subscription exposing (Delivery(..), Interval(..))
 import Routes
 import ScreenSize
 import Views.Icon as Icon
+import Views.SearchBar exposing (Dropdown(..))
 import Views.Toggle as Toggle
 
 

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -1,7 +1,6 @@
 module Dashboard.Models exposing
     ( DragState(..)
     , DropState(..)
-    , Dropdown(..)
     , FetchError(..)
     , FooterModel
     , Model
@@ -17,6 +16,7 @@ import Message.Message exposing (DropTarget)
 import Routes
 import Set exposing (Set)
 import Time
+import Views.SearchBar exposing (Dropdown)
 
 
 type alias Model =
@@ -74,8 +74,3 @@ type alias FooterModel r =
         , dashboardView : Routes.DashboardView
         , query : String
     }
-
-
-type Dropdown
-    = Hidden
-    | Shown (Maybe Int)

--- a/web/elm/src/Dashboard/SearchBar.elm
+++ b/web/elm/src/Dashboard/SearchBar.elm
@@ -6,337 +6,86 @@ module Dashboard.SearchBar exposing
     )
 
 import Application.Models exposing (Session)
-import Concourse.PipelineStatus
-    exposing
-        ( PipelineStatus(..)
-        , StatusDetails(..)
-        )
 import Dashboard.Filter as Filter
-import Dashboard.Models exposing (Dropdown(..), Model)
-import Dashboard.Styles as Styles
+import Dashboard.Models exposing (Model)
 import Dict
 import EffectTransformer exposing (ET)
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, id, placeholder, value)
-import Html.Events exposing (onBlur, onClick, onFocus, onInput, onMouseDown)
-import Keyboard
-import List.Extra
 import Message.Callback exposing (Callback(..))
 import Message.Effects exposing (Effect(..))
 import Message.Message exposing (DomID(..), Message(..))
 import Message.Subscription exposing (Delivery(..))
 import Routes
-import ScreenSize exposing (ScreenSize)
+import Views.SearchBar as SearchBar
 
 
 searchInputId : String
 searchInputId =
-    "search-input-field"
+    SearchBar.searchInputId
 
 
 update : Session -> Message -> ET Model
 update session msg ( model, effects ) =
-    case msg of
-        Click ShowSearchButton ->
-            showSearchInput session ( model, effects )
-
-        Click ClearSearchButton ->
-            ( { model | query = "" }
-            , effects
-                ++ [ Focus searchInputId
-                   , ModifyUrl <|
-                        Routes.toString <|
-                            Routes.Dashboard
-                                { searchType = Routes.Normal ""
-                                , dashboardView = model.dashboardView
-                                }
-                   ]
-            )
-
-        FilterMsg query ->
-            ( { model | query = query }
-            , effects
-                ++ [ Focus searchInputId
-                   , ModifyUrl <|
-                        Routes.toString <|
-                            Routes.Dashboard
-                                { searchType = Routes.Normal query
-                                , dashboardView = model.dashboardView
-                                }
-                   ]
-            )
-
-        FocusMsg ->
-            ( { model | dropdown = Shown Nothing }, effects )
-
-        BlurMsg ->
-            ( { model | dropdown = Hidden }, effects )
-
-        _ ->
-            ( model, effects )
-
-
-showSearchInput : { a | screenSize : ScreenSize } -> ET Model
-showSearchInput session ( model, effects ) =
-    if model.highDensity then
+    SearchBar.update
+        { screenSize = session.screenSize
+        , highDensity = model.highDensity
+        , clearEffects =
+            [ ModifyUrl <|
+                Routes.toString <|
+                    Routes.Dashboard
+                        { searchType = Routes.Normal ""
+                        , dashboardView = model.dashboardView
+                        }
+            ]
+        , changeEffects =
+            \query ->
+                [ ModifyUrl <|
+                    Routes.toString <|
+                        Routes.Dashboard
+                            { searchType = Routes.Normal query
+                            , dashboardView = model.dashboardView
+                            }
+                ]
+        }
+        msg
         ( model, effects )
-
-    else
-        let
-            isDropDownHidden =
-                model.dropdown == Hidden
-
-            isMobile =
-                session.screenSize == ScreenSize.Mobile
-        in
-        if isDropDownHidden && isMobile && model.query == "" then
-            ( { model | dropdown = Shown Nothing }
-            , effects ++ [ Focus searchInputId ]
-            )
-
-        else
-            ( model, effects )
-
-
-screenResize : Float -> Model -> Model
-screenResize width model =
-    let
-        newSize =
-            ScreenSize.fromWindowSize width
-    in
-    case newSize of
-        ScreenSize.Desktop ->
-            { model | dropdown = Hidden }
-
-        ScreenSize.BigDesktop ->
-            { model | dropdown = Hidden }
-
-        ScreenSize.Mobile ->
-            model
 
 
 handleDelivery : Session -> Delivery -> ET Model
 handleDelivery session delivery ( model, effects ) =
-    case delivery of
-        WindowResized width _ ->
-            ( screenResize width model, effects )
-
-        KeyDown keyEvent ->
-            let
-                options =
-                    Filter.suggestions (Filter.filterTeams session model) model.query
-            in
-            case keyEvent.code of
-                Keyboard.ArrowUp ->
-                    ( { model
-                        | dropdown =
-                            arrowUp options model.dropdown
-                      }
-                    , effects
-                    )
-
-                Keyboard.ArrowDown ->
-                    ( { model
-                        | dropdown =
-                            arrowDown options model.dropdown
-                      }
-                    , effects
-                    )
-
-                Keyboard.Enter ->
-                    case model.dropdown of
-                        Shown (Just idx) ->
-                            let
-                                selectedItem =
-                                    options
-                                        |> List.Extra.getAt idx
-                                        |> Maybe.map (\{ prev, cur } -> prev ++ cur)
-                                        |> Maybe.withDefault model.query
-                            in
-                            ( { model
-                                | dropdown = Shown Nothing
-                                , query = selectedItem
-                              }
-                            , [ ModifyUrl <|
-                                    Routes.toString <|
-                                        Routes.Dashboard
-                                            { searchType = Routes.Normal selectedItem
-                                            , dashboardView = model.dashboardView
-                                            }
-                              ]
-                            )
-
-                        Shown Nothing ->
-                            ( model, effects )
-
-                        Hidden ->
-                            ( model, effects )
-
-                Keyboard.Escape ->
-                    ( model, effects ++ [ Blur searchInputId ] )
-
-                Keyboard.Slash ->
-                    ( model
-                    , if keyEvent.shiftKey then
-                        effects
-
-                      else
-                        effects ++ [ Focus searchInputId ]
-                    )
-
-                -- any other keycode
-                _ ->
-                    ( model, effects )
-
-        _ ->
-            ( model, effects )
-
-
-ignoreEmpty : (List a -> b -> b) -> List a -> b -> b
-ignoreEmpty fn l =
-    if List.isEmpty l then
-        identity
-
-    else
-        fn l
-
-
-arrowUp : List a -> Dropdown -> Dropdown
-arrowUp =
-    ignoreEmpty
-        (\options dropdown ->
-            case dropdown of
-                Shown Nothing ->
-                    let
-                        lastItem =
-                            List.length options - 1
-                    in
-                    Shown (Just lastItem)
-
-                Shown (Just idx) ->
-                    let
-                        newSelection =
-                            modBy (List.length options) (idx - 1)
-                    in
-                    Shown (Just newSelection)
-
-                Hidden ->
-                    Hidden
-        )
-
-
-arrowDown : List a -> Dropdown -> Dropdown
-arrowDown =
-    ignoreEmpty
-        (\options dropdown ->
-            case dropdown of
-                Shown Nothing ->
-                    Shown (Just 0)
-
-                Shown (Just idx) ->
-                    let
-                        newSelection =
-                            modBy (List.length options) (idx + 1)
-                    in
-                    Shown (Just newSelection)
-
-                Hidden ->
-                    Hidden
-        )
+    SearchBar.handleDelivery
+        { suggestions =
+            \m ->
+                Filter.suggestions (Filter.filterTeams session m) m.query
+        , selectEffects =
+            \selectedItem ->
+                [ ModifyUrl <|
+                    Routes.toString <|
+                        Routes.Dashboard
+                            { searchType = Routes.Normal selectedItem
+                            , dashboardView = model.dashboardView
+                            }
+                ]
+        }
+        delivery
+        ( model, effects )
 
 
 view : Session -> Model -> Html Message
-view session ({ query, dropdown, pipelines } as params) =
+view session ({ pipelines } as model) =
     let
-        isDropDownHidden =
-            dropdown == Hidden
-
-        isMobile =
-            session.screenSize == ScreenSize.Mobile
-
         noPipelines =
             pipelines
                 |> Maybe.withDefault Dict.empty
                 |> Dict.values
                 |> List.all List.isEmpty
-
-        clearSearchButton =
-            if String.length query > 0 then
-                [ Html.div
-                    ([ id "search-clear"
-                     , onClick <| Click ClearSearchButton
-                     ]
-                        ++ Styles.searchClearButton
-                    )
-                    []
-                ]
-
-            else
-                []
     in
-    if noPipelines then
-        Html.text ""
-
-    else if isDropDownHidden && isMobile && query == "" then
-        Html.div
-            (Styles.showSearchContainer
-                { screenSize = session.screenSize
-                , highDensity = params.highDensity
-                }
-            )
-            [ Html.div
-                ([ id "show-search-button"
-                 , onClick <| Click ShowSearchButton
-                 ]
-                    ++ Styles.searchButton
-                )
-                []
-            ]
-
-    else
-        Html.div
-            (id "search-container" :: Styles.searchContainer session.screenSize)
-            (Html.input
-                ([ id searchInputId
-                 , placeholder "filter pipelines by name, status, or team"
-                 , attribute "autocomplete" "off"
-                 , value query
-                 , onFocus FocusMsg
-                 , onBlur BlurMsg
-                 , onInput FilterMsg
-                 ]
-                    ++ Styles.searchInput
-                        session.screenSize
-                        (String.length query > 0)
-                )
-                []
-                :: clearSearchButton
-                ++ viewDropdownItems session params
-            )
-
-
-viewDropdownItems : Session -> Model -> List (Html Message)
-viewDropdownItems session model =
-    case model.dropdown of
-        Hidden ->
-            []
-
-        Shown selectedIdx ->
-            let
-                dropdownItem : Int -> Filter.Suggestion -> Html Message
-                dropdownItem idx { prev, cur } =
-                    Html.li
-                        (onMouseDown (FilterMsg <| prev ++ cur)
-                            :: Styles.dropdownItem
-                                (Just idx == selectedIdx)
-                                (String.length model.query > 0)
-                        )
-                        [ Html.text cur ]
-
-                filteredTeams =
-                    Filter.filterTeams session model
-            in
-            [ Html.ul
-                (id "search-dropdown" :: Styles.dropdownContainer session.screenSize)
-                (List.indexedMap dropdownItem (Filter.suggestions filteredTeams model.query))
-            ]
+    SearchBar.view
+        { screenSize = session.screenSize
+        , highDensity = model.highDensity
+        , placeholder = "filter pipelines by name, status, or team"
+        , disabled = noPipelines
+        , dropdownAbsolute = False
+        , suggestions = \m -> Filter.suggestions (Filter.filterTeams session m) m.query
+        }
+        model

--- a/web/elm/src/Pipeline/Filter.elm
+++ b/web/elm/src/Pipeline/Filter.elm
@@ -1,0 +1,287 @@
+module Pipeline.Filter exposing (Suggestion, filterJobs, suggestions)
+
+import Concourse
+import Concourse.BuildStatus as BuildStatus exposing (BuildStatus(..))
+import List.Extra
+import Parser
+    exposing
+        ( (|.)
+        , (|=)
+        , Parser
+        , Step(..)
+        , backtrackable
+        , chompUntilEndOr
+        , chompWhile
+        , end
+        , getChompedString
+        , getOffset
+        , getSource
+        , keyword
+        , loop
+        , map
+        , oneOf
+        , run
+        , spaces
+        , succeed
+        , symbol
+        )
+import Simple.Fuzzy
+
+
+type alias Filter =
+    { negate : Bool
+    , jobFilter : JobFilter
+    }
+
+
+filterTypes : List String
+filterTypes =
+    [ "status" ]
+
+
+type JobFilter
+    = Name StringFilter
+    | Status StatusFilter
+
+
+type StringFilter
+    = Fuzzy String
+    | Exact String
+    | StartsWith String
+
+
+type StatusFilter
+    = Paused
+    | JobStatus BuildStatus
+    | JobRunning
+    | IncompleteStatus String
+
+
+filterJobs : String -> List Concourse.Job -> List Concourse.Job
+filterJobs query jobs =
+    parseFilters query
+        |> List.map Tuple.first
+        |> List.foldr runFilter jobs
+
+
+runFilter : Filter -> List Concourse.Job -> List Concourse.Job
+runFilter f =
+    let
+        negater =
+            if f.negate then
+                not
+
+            else
+                identity
+    in
+    List.filter (jobMatches f.jobFilter >> negater)
+
+
+jobMatches : JobFilter -> Concourse.Job -> Bool
+jobMatches jf job =
+    case jf of
+        Name sf ->
+            stringMatches sf job.name
+
+        Status sf ->
+            statusMatches sf job
+
+
+statusMatches : StatusFilter -> Concourse.Job -> Bool
+statusMatches sf job =
+    case sf of
+        Paused ->
+            job.paused
+
+        JobStatus status ->
+            jobBuilds job
+                |> List.any (\b -> b.status == status)
+
+        JobRunning ->
+            jobBuilds job
+                |> List.any (\b -> BuildStatus.isRunning b.status)
+
+        IncompleteStatus _ ->
+            False
+
+
+jobBuilds : Concourse.Job -> List Concourse.Build
+jobBuilds job =
+    [ job.nextBuild
+    , job.finishedBuild
+    , job.transitionBuild
+    ]
+        |> List.filterMap identity
+
+
+stringMatches : StringFilter -> String -> Bool
+stringMatches f =
+    case f of
+        Fuzzy term ->
+            Simple.Fuzzy.match term
+
+        Exact name ->
+            (==) name
+
+        StartsWith prefix ->
+            String.startsWith prefix
+
+
+parseFilters : String -> List ( Filter, String )
+parseFilters =
+    run
+        (loop [] <|
+            \revFilters ->
+                oneOf
+                    [ end |> map (\_ -> Done (List.reverse revFilters))
+                    , filter |> captureChompedString |> map (\f -> Loop (f :: revFilters))
+                    ]
+        )
+        >> Result.withDefault []
+
+
+captureChompedString : Parser a -> Parser ( a, String )
+captureChompedString parser =
+    succeed (\start val end_ source -> ( val, String.slice start end_ source ))
+        |= getOffset
+        |= parser
+        |= getOffset
+        |= getSource
+
+
+filter : Parser Filter
+filter =
+    succeed Filter
+        |. spaces
+        |= oneOf
+            [ symbol "-" |> map (always True)
+            , succeed False
+            ]
+        |= jobFilter
+
+
+jobFilter : Parser JobFilter
+jobFilter =
+    oneOf
+        [ backtrackable statusFilter
+        , succeed Name |= parseString
+        ]
+
+
+parseString : Parser StringFilter
+parseString =
+    oneOf
+        [ parseQuotedString
+        , parseWord |> map Fuzzy
+        ]
+
+
+parseQuotedString : Parser StringFilter
+parseQuotedString =
+    getChompedString
+        (symbol "\""
+            |. chompUntilEndOr "\""
+            |. oneOf [ symbol "\"", end ]
+        )
+        |> map
+            (\s ->
+                if String.endsWith "\"" s && s /= "\"" then
+                    Exact <| String.slice 1 -1 s
+
+                else
+                    StartsWith <| String.dropLeft 1 s
+            )
+
+
+parseWord : Parser String
+parseWord =
+    getChompedString
+        (chompWhile
+            (\c -> c /= ' ' && c /= '\t' && c /= '\n' && c /= '\u{000D}')
+        )
+
+
+statusFilter : Parser JobFilter
+statusFilter =
+    succeed Status
+        |. keyword "status"
+        |. symbol ":"
+        |. spaces
+        |= jobStatus
+
+
+jobStatus : Parser StatusFilter
+jobStatus =
+    oneOf
+        [ keyword "paused" |> map (\_ -> Paused)
+        , keyword "aborted" |> map (\_ -> JobStatus BuildStatusAborted)
+        , keyword "errored" |> map (\_ -> JobStatus BuildStatusErrored)
+        , keyword "failed" |> map (\_ -> JobStatus BuildStatusFailed)
+        , keyword "pending" |> map (\_ -> JobStatus BuildStatusPending)
+        , keyword "succeeded" |> map (\_ -> JobStatus BuildStatusSucceeded)
+        , keyword "running" |> map (\_ -> JobRunning)
+        , parseWord |> map IncompleteStatus
+        ]
+
+
+type alias Suggestion =
+    { prev : String
+    , cur : String
+    }
+
+
+suggestions : String -> List Suggestion
+suggestions query =
+    let
+        parsedFilters =
+            parseFilters query
+
+        ( curFilter, negated ) =
+            parsedFilters
+                |> List.Extra.last
+                |> Maybe.map Tuple.first
+                |> Maybe.map (\f -> ( f.jobFilter, f.negate ))
+                |> Maybe.withDefault ( Name (Fuzzy ""), False )
+
+        prevFilters =
+            parsedFilters
+                |> List.map Tuple.second
+                |> List.reverse
+                |> List.drop 1
+                |> List.reverse
+
+        prev =
+            if List.isEmpty prevFilters then
+                ""
+
+            else
+                String.join "" prevFilters ++ " "
+
+        cur =
+            case curFilter of
+                Name (Fuzzy s) ->
+                    filterTypes
+                        |> List.filter (String.startsWith s)
+                        |> List.map (\v -> v ++ ":")
+
+                Name _ ->
+                    []
+
+                Status sf ->
+                    case sf of
+                        IncompleteStatus status ->
+                            [ "paused", "pending", "failed", "errored", "aborted", "running", "succeeded" ]
+                                |> List.filter (String.startsWith status)
+                                |> List.map (\v -> "status:" ++ v)
+
+                        _ ->
+                            []
+
+        prefix =
+            if negated then
+                List.map (\c -> "-" ++ c)
+
+            else
+                identity
+    in
+    List.map (Suggestion prev) (prefix cur)

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -46,10 +46,13 @@ import Message.Subscription
         , Subscription(..)
         )
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
+import Pipeline.Filter as Filter
 import Pipeline.PinMenu.PinMenu as PinMenu
+import Pipeline.SearchBar as PipelineSearchBar
 import Pipeline.Styles as Styles
 import RemoteData exposing (WebData)
 import Routes
+import ScreenSize exposing (ScreenSize)
 import SideBar.SideBar as SideBar
 import StrictEvents exposing (onShiftLeftClick)
 import Svg
@@ -59,6 +62,7 @@ import Tooltip
 import UpdateMsg exposing (UpdateMsg)
 import Views.FavoritedIcon as FavoritedIcon
 import Views.PauseToggle as PauseToggle
+import Views.SearchBar as SearchBar
 import Views.Styles
 import Views.TopBar as TopBar
 
@@ -78,6 +82,9 @@ type alias Model =
         , hideLegendCounter : Float
         , isToggleLoading : Bool
         , pinMenuExpanded : Bool
+        , query : String
+        , dropdown : SearchBar.Dropdown
+        , screenSize : ScreenSize
         }
 
 
@@ -106,6 +113,9 @@ init flags =
             , selectedGroups = flags.selectedGroups
             , isUserMenuExpanded = False
             , pinMenuExpanded = False
+            , query = ""
+            , dropdown = SearchBar.Hidden
+            , screenSize = ScreenSize.Desktop
             }
     in
     ( model
@@ -286,41 +296,65 @@ handleCallback callback ( model, effects ) =
 
 handleDelivery : Delivery -> ET Model
 handleDelivery delivery ( model, effects ) =
-    case delivery of
-        KeyDown keyEvent ->
-            ( { model | hideLegend = False, hideLegendCounter = 0 }
-            , if keyEvent.code == Keyboard.F then
-                effects ++ [ ResetPipelineFocus ]
+    let
+        ( searchModel, searchEffects ) =
+            PipelineSearchBar.handleDelivery delivery ( model, [] )
 
-              else
-                effects
+        withLegendReset m =
+            { m | hideLegend = False, hideLegendCounter = 0 }
+    in
+    case delivery of
+        WindowResized _ _ ->
+            ( searchModel, effects ++ searchEffects )
+
+        KeyDown keyEvent ->
+            let
+                ( postSearchModel, postSearchEffects ) =
+                    case ( model.dropdown, searchModel.dropdown ) of
+                        ( SearchBar.Shown _, SearchBar.Shown _ ) ->
+                            renderIfNeeded ( searchModel, [] )
+
+                        _ ->
+                            ( searchModel, [] )
+            in
+            ( withLegendReset postSearchModel
+            , effects
+                ++ searchEffects
+                ++ postSearchEffects
+                ++ (if keyEvent.code == Keyboard.F then
+                        [ ResetPipelineFocus ]
+
+                    else
+                        []
+                   )
             )
 
         Moused _ ->
-            ( { model | hideLegend = False, hideLegendCounter = 0 }, effects )
+            ( withLegendReset searchModel, effects ++ searchEffects )
 
         ClockTicked OneSecond _ ->
             if model.hideLegendCounter + timeUntilHiddenCheckInterval > timeUntilHidden then
-                ( { model | hideLegend = True }, effects )
+                ( { searchModel | hideLegend = True }, effects ++ searchEffects )
 
             else
-                ( { model | hideLegendCounter = model.hideLegendCounter + timeUntilHiddenCheckInterval }
-                , effects
+                ( { searchModel | hideLegendCounter = model.hideLegendCounter + timeUntilHiddenCheckInterval }
+                , effects ++ searchEffects
                 )
 
         ClockTicked FiveSeconds _ ->
-            ( model
+            ( searchModel
             , effects
+                ++ searchEffects
                 ++ [ FetchPipeline model.pipelineLocator
                    , FetchAllPipelines
                    ]
             )
 
         ClockTicked OneMinute _ ->
-            ( model, effects ++ [ FetchClusterInfo ] )
+            ( searchModel, effects ++ searchEffects ++ [ FetchClusterInfo ] )
 
         _ ->
-            ( model, effects )
+            ( searchModel, effects ++ searchEffects )
 
 
 update : Message -> ET Model
@@ -350,6 +384,23 @@ update msg ( model, effects ) =
 
                 _ ->
                     ( model, effects )
+
+        Click ShowSearchButton ->
+            PipelineSearchBar.update msg ( model, effects )
+
+        Click ClearSearchButton ->
+            renderIfNeeded <|
+                PipelineSearchBar.update msg ( model, effects )
+
+        FilterMsg _ ->
+            renderIfNeeded <|
+                PipelineSearchBar.update msg ( model, effects )
+
+        FocusMsg ->
+            PipelineSearchBar.update msg ( model, effects )
+
+        BlurMsg ->
+            PipelineSearchBar.update msg ( model, effects )
 
         _ ->
             ( model, effects )
@@ -391,55 +442,69 @@ view session model =
             (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
             [ Html.div
                 (id "top-bar-app" :: Views.Styles.topBar displayPaused)
-                (SideBar.sideBarIcon session
-                    :: TopBar.breadcrumbs session route
-                    ++ [ if isArchived model.pipeline then
-                            Html.text ""
+                [ Html.div
+                    [ style "display" "flex" ]
+                    [ SideBar.sideBarIcon session
+                    , Html.div [ style "display" "flex" ] (TopBar.breadcrumbs session route)
+                    ]
+                , Html.div
+                    [ style "flex-grow" "1"
+                    , style "display" "flex"
+                    , style "justify-content" "center"
+                    , style "align-items" "center"
+                    ]
+                    [ PipelineSearchBar.view session model ]
+                , Html.div
+                    [ style "display" "flex"
+                    , style "align-items" "center"
+                    ]
+                    [ if isArchived model.pipeline then
+                        Html.text ""
 
-                         else
-                            TopBar.paused
-                                { paused = displayPaused
-                                , pausedBy = pausedBy model.pipeline
-                                , pausedAt = pausedAt model.pipeline
-                                , timeZone = session.timeZone
+                      else
+                        TopBar.paused
+                            { paused = displayPaused
+                            , pausedBy = pausedBy model.pipeline
+                            , pausedAt = pausedAt model.pipeline
+                            , timeZone = session.timeZone
+                            }
+                    , PinMenu.viewPinMenu session model
+                    , Html.div
+                        Styles.favoritedIcon
+                        [ FavoritedIcon.view
+                            { isHovered = HoverState.isHovered (TopBarFavoritedIcon <| getPipelineId model.pipeline) session.hovered
+                            , isFavorited =
+                                model.pipeline
+                                    |> RemoteData.map (Favorites.isPipelineFavorited session)
+                                    |> RemoteData.withDefault False
+                            , isSideBar = False
+                            , domID = TopBarFavoritedIcon <| getPipelineId model.pipeline
+                            }
+                            [ style "margin" "17px" ]
+                        ]
+                    , if isArchived model.pipeline then
+                        Html.text ""
+
+                      else
+                        Html.div
+                            Styles.pauseToggle
+                            [ PauseToggle.view
+                                { pipeline = model.pipelineLocator
+                                , isPaused = isPaused model.pipeline
+                                , isToggleHovered =
+                                    HoverState.isHovered
+                                        (TopBarPauseToggle model.pipelineLocator)
+                                        session.hovered
+                                , isToggleLoading = model.isToggleLoading
+                                , tooltipPosition = Views.Styles.Below
+                                , margin = "17px"
+                                , userState = session.userState
+                                , domID = TopBarPauseToggle model.pipelineLocator
                                 }
-                       , PinMenu.viewPinMenu session model
-                       , Html.div
-                            Styles.favoritedIcon
-                            [ FavoritedIcon.view
-                                { isHovered = HoverState.isHovered (TopBarFavoritedIcon <| getPipelineId model.pipeline) session.hovered
-                                , isFavorited =
-                                    model.pipeline
-                                        |> RemoteData.map (Favorites.isPipelineFavorited session)
-                                        |> RemoteData.withDefault False
-                                , isSideBar = False
-                                , domID = TopBarFavoritedIcon <| getPipelineId model.pipeline
-                                }
-                                [ style "margin" "17px" ]
                             ]
-                       , if isArchived model.pipeline then
-                            Html.text ""
-
-                         else
-                            Html.div
-                                Styles.pauseToggle
-                                [ PauseToggle.view
-                                    { pipeline = model.pipelineLocator
-                                    , isPaused = isPaused model.pipeline
-                                    , isToggleHovered =
-                                        HoverState.isHovered
-                                            (TopBarPauseToggle model.pipelineLocator)
-                                            session.hovered
-                                    , isToggleLoading = model.isToggleLoading
-                                    , tooltipPosition = Views.Styles.Below
-                                    , margin = "17px"
-                                    , userState = session.userState
-                                    , domID = TopBarPauseToggle model.pipelineLocator
-                                    }
-                                ]
-                       , Login.view session.userState model
-                       ]
-                )
+                    , Login.view session.userState model
+                    ]
+                ]
             , Html.div
                 (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
               <|
@@ -573,7 +638,7 @@ backgroundImage pipeline =
 
 
 viewSubPage :
-    { a | hovered : HoverState.HoverState, version : String }
+    { a | hovered : HoverState.HoverState, version : String, screenSize : ScreenSize }
     -> Model
     -> Html Message
 viewSubPage session model =
@@ -801,18 +866,21 @@ renderIfNeeded ( model, effects ) =
 
                     else
                         filterJobs model fetchedJobs
+
+                queryFilteredJobs =
+                    Filter.filterJobs model.query filteredFetchedJobs
             in
             case ( model.renderedResources, model.renderedJobs ) of
                 ( Just renderedResources, Just renderedJobs ) ->
                     if
-                        (renderedJobs /= filteredFetchedJobs)
+                        (renderedJobs /= queryFilteredJobs)
                             || (renderedResources /= fetchedResources)
                     then
                         ( { model
-                            | renderedJobs = Just filteredFetchedJobs
+                            | renderedJobs = Just queryFilteredJobs
                             , renderedResources = Just fetchedResources
                           }
-                        , effects ++ [ RenderPipeline filteredFetchedJobs fetchedResources ]
+                        , effects ++ [ RenderPipeline queryFilteredJobs fetchedResources ]
                         )
 
                     else
@@ -820,10 +888,10 @@ renderIfNeeded ( model, effects ) =
 
                 _ ->
                     ( { model
-                        | renderedJobs = Just filteredFetchedJobs
+                        | renderedJobs = Just queryFilteredJobs
                         , renderedResources = Just fetchedResources
                       }
-                    , effects ++ [ RenderPipeline filteredFetchedJobs fetchedResources ]
+                    , effects ++ [ RenderPipeline queryFilteredJobs fetchedResources ]
                     )
 
         _ ->

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -183,6 +183,11 @@ handleCallback callback ( model, effects ) =
                 []
     in
     case callback of
+        ScreenResized viewport ->
+            ( { model | screenSize = ScreenSize.fromWindowSize viewport.viewport.width }
+            , effects
+            )
+
         PipelineFetched (Ok pipeline) ->
             let
                 locator =

--- a/web/elm/src/Pipeline/SearchBar.elm
+++ b/web/elm/src/Pipeline/SearchBar.elm
@@ -1,0 +1,63 @@
+module Pipeline.SearchBar exposing
+    ( handleDelivery
+    , searchInputId
+    , update
+    , view
+    )
+
+import EffectTransformer exposing (ET)
+import Html exposing (Html)
+import Message.Message exposing (Message)
+import Message.Subscription exposing (Delivery(..))
+import Pipeline.Filter as Filter
+import ScreenSize exposing (ScreenSize)
+import Views.SearchBar as SearchBar
+
+
+searchInputId : String
+searchInputId =
+    SearchBar.searchInputId
+
+
+update : Message -> ET { a | query : String, dropdown : SearchBar.Dropdown, screenSize : ScreenSize }
+update msg ( model, effects ) =
+    SearchBar.update
+        { screenSize = model.screenSize
+        , highDensity = False
+        , clearEffects = []
+        , changeEffects = \_ -> []
+        }
+        msg
+        ( model, effects )
+
+
+handleDelivery : Delivery -> ET { a | query : String, dropdown : SearchBar.Dropdown, screenSize : ScreenSize }
+handleDelivery delivery ( model, effects ) =
+    let
+        updatedModel =
+            case delivery of
+                WindowResized width _ ->
+                    { model | screenSize = ScreenSize.fromWindowSize width }
+
+                _ ->
+                    model
+    in
+    SearchBar.handleDelivery
+        { suggestions = \m -> Filter.suggestions m.query
+        , selectEffects = \_ -> []
+        }
+        delivery
+        ( updatedModel, effects )
+
+
+view : { a | screenSize : ScreenSize } -> { b | query : String, dropdown : SearchBar.Dropdown } -> Html Message
+view session model =
+    SearchBar.view
+        { screenSize = session.screenSize
+        , highDensity = False
+        , placeholder = "filter jobs by name or status"
+        , disabled = False
+        , dropdownAbsolute = True
+        , suggestions = \m -> Filter.suggestions m.query
+        }
+        model

--- a/web/elm/src/Views/SearchBar.elm
+++ b/web/elm/src/Views/SearchBar.elm
@@ -1,0 +1,352 @@
+module Views.SearchBar exposing
+    ( Dropdown(..)
+    , HandleDeliveryConfig
+    , Suggestion
+    , UpdateConfig
+    , ViewConfig
+    , handleDelivery
+    , searchInputId
+    , update
+    , view
+    )
+
+import Dashboard.Styles as Styles
+import EffectTransformer exposing (ET)
+import Html exposing (Html)
+import Html.Attributes exposing (attribute, id, placeholder, style, value)
+import Html.Events exposing (onBlur, onClick, onFocus, onInput, onMouseDown)
+import Keyboard
+import List.Extra
+import Message.Effects exposing (Effect(..))
+import Message.Message exposing (DomID(..), Message(..))
+import Message.Subscription exposing (Delivery(..))
+import ScreenSize exposing (ScreenSize(..))
+
+
+searchInputId : String
+searchInputId =
+    "search-input-field"
+
+
+type Dropdown
+    = Hidden
+    | Shown (Maybe Int)
+
+
+type alias UpdateConfig =
+    { screenSize : ScreenSize
+    , highDensity : Bool
+    , clearEffects : List Effect
+    , changeEffects : String -> List Effect
+    }
+
+
+update : UpdateConfig -> Message -> ET { a | query : String, dropdown : Dropdown }
+update config msg ( model, effects ) =
+    case msg of
+        Click ShowSearchButton ->
+            showSearchInput config ( model, effects )
+
+        Click ClearSearchButton ->
+            ( { model | query = "" }
+            , effects
+                ++ (Focus searchInputId :: config.clearEffects)
+            )
+
+        FilterMsg query ->
+            ( { model | query = query }
+            , effects
+                ++ (Focus searchInputId :: config.changeEffects query)
+            )
+
+        FocusMsg ->
+            ( { model | dropdown = Shown Nothing }, effects )
+
+        BlurMsg ->
+            ( { model | dropdown = Hidden }, effects )
+
+        _ ->
+            ( model, effects )
+
+
+showSearchInput : UpdateConfig -> ET { a | query : String, dropdown : Dropdown }
+showSearchInput config ( model, effects ) =
+    if config.highDensity then
+        ( model, effects )
+
+    else
+        let
+            isDropDownHidden =
+                model.dropdown == Hidden
+
+            isMobile =
+                config.screenSize == Mobile
+        in
+        if isDropDownHidden && isMobile && model.query == "" then
+            ( { model | dropdown = Shown Nothing }
+            , effects ++ [ Focus searchInputId ]
+            )
+
+        else
+            ( model, effects )
+
+
+type alias Suggestion =
+    { prev : String
+    , cur : String
+    }
+
+
+type alias HandleDeliveryConfig model =
+    { suggestions : model -> List Suggestion
+    , selectEffects : String -> List Effect
+    }
+
+
+handleDelivery : HandleDeliveryConfig { a | query : String, dropdown : Dropdown } -> Delivery -> ET { a | query : String, dropdown : Dropdown }
+handleDelivery config delivery ( model, effects ) =
+    case delivery of
+        WindowResized width _ ->
+            ( screenResize width model, effects )
+
+        KeyDown keyEvent ->
+            let
+                options =
+                    config.suggestions model
+            in
+            case keyEvent.code of
+                Keyboard.ArrowUp ->
+                    ( { model
+                        | dropdown =
+                            arrowUp options model.dropdown
+                      }
+                    , effects
+                    )
+
+                Keyboard.ArrowDown ->
+                    ( { model
+                        | dropdown =
+                            arrowDown options model.dropdown
+                      }
+                    , effects
+                    )
+
+                Keyboard.Enter ->
+                    case model.dropdown of
+                        Shown (Just idx) ->
+                            let
+                                selectedItem =
+                                    options
+                                        |> List.Extra.getAt idx
+                                        |> Maybe.map (\{ prev, cur } -> prev ++ cur)
+                                        |> Maybe.withDefault model.query
+                            in
+                            ( { model
+                                | dropdown = Shown Nothing
+                                , query = selectedItem
+                              }
+                            , config.selectEffects selectedItem
+                            )
+
+                        Shown Nothing ->
+                            ( model, effects )
+
+                        Hidden ->
+                            ( model, effects )
+
+                Keyboard.Escape ->
+                    ( model, effects ++ [ Blur searchInputId ] )
+
+                Keyboard.Slash ->
+                    ( model
+                    , if keyEvent.shiftKey then
+                        effects
+
+                      else
+                        effects ++ [ Focus searchInputId ]
+                    )
+
+                _ ->
+                    ( model, effects )
+
+        _ ->
+            ( model, effects )
+
+
+screenResize : Float -> { a | dropdown : Dropdown } -> { a | dropdown : Dropdown }
+screenResize width model =
+    let
+        newSize =
+            ScreenSize.fromWindowSize width
+    in
+    case newSize of
+        Desktop ->
+            { model | dropdown = Hidden }
+
+        BigDesktop ->
+            { model | dropdown = Hidden }
+
+        Mobile ->
+            model
+
+
+ignoreEmpty : (List a -> b -> b) -> List a -> b -> b
+ignoreEmpty fn l =
+    if List.isEmpty l then
+        identity
+
+    else
+        fn l
+
+
+arrowUp : List a -> Dropdown -> Dropdown
+arrowUp =
+    ignoreEmpty
+        (\options dropdown ->
+            case dropdown of
+                Shown Nothing ->
+                    let
+                        lastItem =
+                            List.length options - 1
+                    in
+                    Shown (Just lastItem)
+
+                Shown (Just idx) ->
+                    let
+                        newSelection =
+                            modBy (List.length options) (idx - 1)
+                    in
+                    Shown (Just newSelection)
+
+                Hidden ->
+                    Hidden
+        )
+
+
+arrowDown : List a -> Dropdown -> Dropdown
+arrowDown =
+    ignoreEmpty
+        (\options dropdown ->
+            case dropdown of
+                Shown Nothing ->
+                    Shown (Just 0)
+
+                Shown (Just idx) ->
+                    let
+                        newSelection =
+                            modBy (List.length options) (idx + 1)
+                    in
+                    Shown (Just newSelection)
+
+                Hidden ->
+                    Hidden
+        )
+
+
+type alias ViewConfig model =
+    { screenSize : ScreenSize
+    , highDensity : Bool
+    , placeholder : String
+    , disabled : Bool
+    , dropdownAbsolute : Bool
+    , suggestions : model -> List Suggestion
+    }
+
+
+view : ViewConfig { a | query : String, dropdown : Dropdown } -> { a | query : String, dropdown : Dropdown } -> Html Message
+view config ({ query, dropdown } as model) =
+    let
+        isDropDownHidden =
+            dropdown == Hidden
+
+        isMobile =
+            config.screenSize == Mobile
+
+        clearSearchButton =
+            if String.length query > 0 then
+                [ Html.div
+                    ([ id "search-clear"
+                     , onClick <| Click ClearSearchButton
+                     ]
+                        ++ Styles.searchClearButton
+                    )
+                    []
+                ]
+
+            else
+                []
+    in
+    if config.disabled then
+        Html.text ""
+
+    else if isDropDownHidden && isMobile && query == "" then
+        Html.div
+            (Styles.showSearchContainer
+                { screenSize = config.screenSize
+                , highDensity = config.highDensity
+                }
+            )
+            [ Html.div
+                ([ id "show-search-button"
+                 , onClick <| Click ShowSearchButton
+                 ]
+                    ++ Styles.searchButton
+                )
+                []
+            ]
+
+    else
+        Html.div
+            (id "search-container" :: Styles.searchContainer config.screenSize)
+            (Html.input
+                ([ id searchInputId
+                 , placeholder config.placeholder
+                 , attribute "autocomplete" "off"
+                 , value query
+                 , onFocus FocusMsg
+                 , onBlur BlurMsg
+                 , onInput FilterMsg
+                 ]
+                    ++ Styles.searchInput
+                        config.screenSize
+                        (String.length query > 0)
+                )
+                []
+                :: clearSearchButton
+                ++ viewDropdownItems config model
+            )
+
+
+viewDropdownItems : ViewConfig { a | query : String, dropdown : Dropdown } -> { a | query : String, dropdown : Dropdown } -> List (Html Message)
+viewDropdownItems config model =
+    case model.dropdown of
+        Hidden ->
+            []
+
+        Shown selectedIdx ->
+            let
+                dropdownItem : Int -> Suggestion -> Html Message
+                dropdownItem idx { prev, cur } =
+                    Html.li
+                        (onMouseDown (FilterMsg <| prev ++ cur)
+                            :: Styles.dropdownItem
+                                (Just idx == selectedIdx)
+                                (String.length model.query > 0)
+                        )
+                        [ Html.text cur ]
+            in
+            [ Html.ul
+                ((id "search-dropdown"
+                    :: (if config.dropdownAbsolute then
+                            [ style "position" "absolute"
+                            , style "z-index" "1000"
+                            ]
+
+                        else
+                            []
+                       )
+                 )
+                    ++ Styles.dropdownContainer config.screenSize
+                )
+                (List.indexedMap dropdownItem (config.suggestions model))
+            ]

--- a/web/elm/tests/PipelineSearchBarTests.elm
+++ b/web/elm/tests/PipelineSearchBarTests.elm
@@ -1,0 +1,215 @@
+module PipelineSearchBarTests exposing (all)
+
+import Application.Application as Application
+import Common
+    exposing
+        ( queryView
+        , whenOnDesktop
+        , whenOnMobile
+        )
+import Concourse.BuildStatus exposing (BuildStatus(..))
+import Data
+import Expect
+import Html.Attributes as Attr
+import Message.Message exposing (DomID(..), Message(..))
+import Message.TopLevelMessage as Msgs
+import Pipeline.Filter as Filter
+import Pipeline.SearchBar as SearchBar
+import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+    exposing
+        ( attribute
+        , containing
+        , id
+        , style
+        , text
+        )
+
+
+all : Test
+all =
+    describe "pipeline search & filter" <|
+        [ describe "Pipeline.Filter" <|
+            [ describe "filterJobs" <|
+                let
+                    jobNamed name =
+                        let
+                            base =
+                                Data.job 0
+                        in
+                        { base | name = name }
+
+                    jobWithFinishedStatus name status =
+                        Data.job 0
+                            |> (\j -> { j | name = name })
+                            |> Data.withFinishedBuild (Just (Data.jobBuild status))
+
+                    pausedJob name =
+                        Data.job 0
+                            |> (\j -> { j | name = name, paused = True })
+
+                    jobs =
+                        [ jobNamed "alpha"
+                        , pausedJob "paused-job"
+                        , jobWithFinishedStatus "failed-job" BuildStatusFailed
+                        , jobWithFinishedStatus "running-job" BuildStatusStarted
+                        ]
+                in
+                [ test "empty query keeps all jobs" <|
+                    \_ ->
+                        Filter.filterJobs "" jobs
+                            |> List.map .name
+                            |> Expect.equal [ "alpha", "paused-job", "failed-job", "running-job" ]
+                , test "filters by fuzzy name" <|
+                    \_ ->
+                        Filter.filterJobs "paus" jobs
+                            |> List.map .name
+                            |> Expect.equal [ "paused-job" ]
+                , test "filters by exact quoted name" <|
+                    \_ ->
+                        Filter.filterJobs "\"paused-job\"" jobs
+                            |> List.map .name
+                            |> Expect.equal [ "paused-job" ]
+                , test "filters by starts-with when quote is not closed" <|
+                    \_ ->
+                        Filter.filterJobs "\"pa" jobs
+                            |> List.map .name
+                            |> Expect.equal [ "paused-job" ]
+                , test "filters by status:paused" <|
+                    \_ ->
+                        Filter.filterJobs "status:paused" jobs
+                            |> List.map .name
+                            |> Expect.equal [ "paused-job" ]
+                , test "filters by status:failed" <|
+                    \_ ->
+                        Filter.filterJobs "status:failed" jobs
+                            |> List.map .name
+                            |> Expect.equal [ "failed-job" ]
+                , test "filters by status:running" <|
+                    \_ ->
+                        Filter.filterJobs "status:running" jobs
+                            |> List.map .name
+                            |> Expect.equal [ "running-job" ]
+                , test "negation works (-status:failed)" <|
+                    \_ ->
+                        Filter.filterJobs "-status:failed" jobs
+                            |> List.map .name
+                            |> Expect.equal [ "alpha", "paused-job", "running-job" ]
+                ]
+            , describe "suggestions" <|
+                [ test "suggests status: when typing filter type" <|
+                    \_ ->
+                        Filter.suggestions "sta"
+                            |> List.map .cur
+                            |> Expect.equal [ "status:" ]
+                , test "suggests paused and pending status values" <|
+                    \_ ->
+                        Filter.suggestions "status:p"
+                            |> List.map .cur
+                            |> Expect.equal [ "status:paused", "status:pending" ]
+                ]
+            ]
+        , describe "pipeline search bar" <|
+            [ describe "on desktop" <|
+                [ test "displays input field in the top bar" <|
+                    \_ ->
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> whenOnDesktop
+                            |> queryView
+                            |> Query.find [ id "top-bar-app" ]
+                            |> Query.has [ id SearchBar.searchInputId ]
+                , test "typing a query updates the value" <|
+                    \_ ->
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> whenOnDesktop
+                            |> Expect.all
+                                [ queryView
+                                    >> Query.find [ id SearchBar.searchInputId ]
+                                    >> Event.simulate (Event.input "status:paused")
+                                    >> Event.expect (Msgs.Update <| FilterMsg "status:paused")
+                                , Application.update (Msgs.Update (FilterMsg "status:paused"))
+                                    >> Tuple.first
+                                    >> queryView
+                                    >> Query.find [ id SearchBar.searchInputId ]
+                                    >> Query.has [ value "status:paused" ]
+                                ]
+                , test "dropdown appears when focused" <|
+                    \_ ->
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> whenOnDesktop
+                            |> Application.update (Msgs.Update FocusMsg)
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.has [ id "search-dropdown" ]
+                , test "dropdown is absolutely positioned" <|
+                    \_ ->
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> whenOnDesktop
+                            |> Application.update (Msgs.Update FocusMsg)
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.find [ id "search-dropdown" ]
+                            |> Query.has
+                                [ style "position" "absolute"
+                                , style "z-index" "1000"
+                                ]
+                , test "dropdown shows status filter option" <|
+                    \_ ->
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> whenOnDesktop
+                            |> Application.update (Msgs.Update FocusMsg)
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.find [ id "search-dropdown" ]
+                            |> Query.findAll [ text "status:" ]
+                            |> Query.count (Expect.equal 1)
+                , test "dropdown suggests status values" <|
+                    \_ ->
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> whenOnDesktop
+                            |> Application.update (Msgs.Update (FilterMsg "status:p"))
+                            |> Tuple.first
+                            |> Application.update (Msgs.Update FocusMsg)
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.find [ id "search-dropdown" ]
+                            |> Expect.all
+                                [ Query.has [ containing [ text "status:paused" ] ]
+                                , Query.has [ containing [ text "status:pending" ] ]
+                                ]
+                ]
+            , describe "on mobile" <|
+                [ test "shows expand button and hides the input by default" <|
+                    \_ ->
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> whenOnMobile
+                            |> queryView
+                            |> Query.find [ id "top-bar-app" ]
+                            |> Expect.all
+                                [ Query.has [ id "show-search-button" ]
+                                , Query.hasNot [ id SearchBar.searchInputId ]
+                                ]
+                , test "clicking expand button shows the input" <|
+                    \_ ->
+                        Common.init "/teams/team/pipelines/pipeline"
+                            |> whenOnMobile
+                            |> Expect.all
+                                [ queryView
+                                    >> Query.find [ id "show-search-button" ]
+                                    >> Event.simulate Event.click
+                                    >> Event.expect (Msgs.Update (Click ShowSearchButton))
+                                , Application.update (Msgs.Update (Click ShowSearchButton))
+                                    >> Tuple.first
+                                    >> queryView
+                                    >> Query.has [ id SearchBar.searchInputId ]
+                                ]
+                ]
+            ]
+        ]
+
+
+value : String -> Selector.Selector
+value v =
+    attribute (Attr.value v)

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -605,8 +605,11 @@ all =
                 , it "top bar has a square concourse logo on the left" <|
                     Common.queryView
                         >> Query.find [ id "top-bar-app" ]
-                        >> Query.children []
-                        >> Query.index 1
+                        >> Query.find
+                            [ style "background-image" <|
+                                Assets.backgroundImage <|
+                                    Just Assets.ConcourseLogoWhite
+                            ]
                         >> Query.has
                             [ style "background-image" <|
                                 Assets.backgroundImage <|


### PR DESCRIPTION
## Changes proposed by this PR

closes #9369 

* [x] Adds filter/search bar to the pipeline page to filter jobs by: name and status.
* [x] Create SearchBar module to be used as reusable module.
* [x] Tests

<img width="1914" height="601" alt="filter-jobs-in-pipeline" src="https://github.com/user-attachments/assets/2e78aa92-6b07-4d1e-b5cc-4cdaea9ee277" />

## Notes to reviewer

* New shared SearchBar module which is central for state transitions, view and keyboard handling.
* Dashbord refactor - delegates to SearchBar.elm.
* Models, Dashboard and Footer are updated to use the shared Dropdown type.
* Use the same query style as the dashboard filter.
* Wired search state into the model which updates via messages/subscriptions and applies the filter before `RenderPipeline`.
* I haven’t added tests yet—I’d like to get approval on the code before proceeding with them.

## Release Note

By using the SearchBar users can easily filter and find the job they want.

