### PR TITLE
Run go fix on the project

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -174,12 +174,7 @@ func (a *access) TeamNames() []string {
 }
 
 func (a *access) hasPermission(roles []string) bool {
-	for _, role := range roles {
-		if a.hasRequiredRole(role) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(roles, a.hasRequiredRole)
 }
 
 func (a *access) hasRequiredRole(role string) bool {
@@ -267,10 +262,8 @@ func (a *access) IsAdmin() bool {
 
 func (a *access) IsSystem() bool {
 	if claim := a.claim(a.systemClaimKey); claim != "" {
-		for _, value := range a.systemClaimValues {
-			if value == claim {
-				return true
-			}
+		if slices.Contains(a.systemClaimValues, claim) {
+			return true
 		}
 	}
 	return false

--- a/atc/api/accessor/claims_cacher_test.go
+++ b/atc/api/accessor/claims_cacher_test.go
@@ -119,7 +119,7 @@ var _ = Describe("ClaimsCacher", func() {
 
 func stringWithLen(l int) string {
 	b := make([]byte, l)
-	for i := 0; i < l; i++ {
+	for i := range l {
 		b[i] = 'a'
 	}
 	return string(b)

--- a/atc/api/accessor/verifier.go
+++ b/atc/api/accessor/verifier.go
@@ -3,6 +3,7 @@ package accessor
 import (
 	"errors"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -67,10 +68,8 @@ func (v *verifier) verify(rawToken string) (map[string]any, error) {
 		return nil, ErrVerificationTokenExpired
 	}
 
-	for _, aud := range v.audience {
-		if claims.Audience.Contains(aud) {
-			return claims.RawClaims, nil
-		}
+	if slices.ContainsFunc(v.audience, claims.Audience.Contains) {
+		return claims.RawClaims, nil
 	}
 
 	return nil, ErrVerificationInvalidAudience

--- a/atc/api/auth/check_build_read_access_handler.go
+++ b/atc/api/auth/check_build_read_access_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"slices"
 	"strconv"
 
 	"github.com/concourse/concourse/atc/api/accessor"
@@ -106,10 +107,8 @@ var errDisappeared = errors.New("internal: build parent disappeared")
 func (h checkBuildReadAccessHandler) allow(build db.BuildForAPI, acc accessor.Access) (bool, error) {
 	if acc.IsAuthenticated() {
 		allTeams := build.AllAssociatedTeamNames()
-		for _, team := range allTeams {
-			if acc.IsAuthorized(team) {
-				return true, nil
-			}
+		if slices.ContainsFunc(allTeams, acc.IsAuthorized) {
+			return true, nil
 		}
 	}
 

--- a/atc/api/auth/check_build_write_access_handler.go
+++ b/atc/api/auth/check_build_write_access_handler.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strconv"
 
 	"github.com/concourse/concourse/atc/api/accessor"
@@ -68,13 +69,7 @@ func (h checkBuildWriteAccessHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 	}
 
 	allTeams := build.AllAssociatedTeamNames()
-	authorized := false
-	for _, team := range allTeams {
-		if acc.IsAuthorized(team) {
-			authorized = true
-			break
-		}
-	}
+	authorized := slices.ContainsFunc(allTeams, acc.IsAuthorized)
 	if !authorized {
 		h.rejector.Forbidden(w, r)
 		return

--- a/atc/api/containerserver/list.go
+++ b/atc/api/containerserver/list.go
@@ -41,8 +41,7 @@ func (s *Server) ListContainers(team db.Team) http.Handler {
 		hLog.Debug("listed", lager.Data{"container-count": len(containers)})
 
 		presentedContainers := make([]atc.Container, len(containers))
-		for i := 0; i < len(containers); i++ {
-			container := containers[i]
+		for i, container := range containers {
 			presentedContainers[i] = present.Container(container, checkContainersExpiresAt[container.ID()])
 		}
 

--- a/atc/api/volumeserver/list.go
+++ b/atc/api/volumeserver/list.go
@@ -26,8 +26,7 @@ func (s *Server) ListVolumes(team db.Team) http.Handler {
 		hLog.Debug("listed", lager.Data{"volume-count": len(volumes)})
 
 		presentedVolumes := []atc.Volume{}
-		for i := 0; i < len(volumes); i++ {
-			volume := volumes[i]
+		for _, volume := range volumes {
 			if vol, err := present.Volume(volume); err != nil {
 				hLog.Error("failed-to-present-volume", err)
 			} else {

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -91,7 +91,6 @@ var _ = Describe("ValidateIdentifier", func() {
 			warning:     false,
 		},
 	} {
-		test := test
 
 		Context("when an identifier "+test.description, func() {
 			var it string

--- a/atc/creds/idtoken/idtoken.go
+++ b/atc/creds/idtoken/idtoken.go
@@ -16,7 +16,7 @@ func (secrets *IDToken) NewSecretLookupPathsWithParams(params creds.SecretLookup
 	return []creds.SecretLookupPath{}
 }
 
-func (secrets *IDToken) GetWithParams(secretPath string, params creds.SecretLookupParams) (interface{}, *time.Time, bool, error) {
+func (secrets *IDToken) GetWithParams(secretPath string, params creds.SecretLookupParams) (any, *time.Time, bool, error) {
 	if secretPath != "token" {
 		return nil, nil, false, fmt.Errorf("idtoken credential provider only supports the field 'token'")
 	}
@@ -37,6 +37,6 @@ func (secrets *IDToken) NewSecretLookupPaths(teamName string, pipelineName strin
 	return nil
 }
 
-func (secrets *IDToken) Get(secretPath string) (interface{}, *time.Time, bool, error) {
+func (secrets *IDToken) Get(secretPath string) (any, *time.Time, bool, error) {
 	return nil, nil, false, fmt.Errorf("IDToken provider can only be used with params")
 }

--- a/atc/creds/idtoken/manager_factory.go
+++ b/atc/creds/idtoken/manager_factory.go
@@ -34,8 +34,8 @@ func (factory *ManagerFactory) SetSigningKeyFactory(signingKeyFactory db.Signing
 	factory.signingKeyFactory = signingKeyFactory
 }
 
-func (factory *ManagerFactory) NewInstance(config interface{}) (creds.Manager, error) {
-	configMap, ok := config.(map[string]interface{})
+func (factory *ManagerFactory) NewInstance(config any) (creds.Manager, error) {
+	configMap, ok := config.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("invalid idtoken provider config: %T", config)
 	}

--- a/atc/creds/idtoken/manager_factory_test.go
+++ b/atc/creds/idtoken/manager_factory_test.go
@@ -10,15 +10,15 @@ import (
 var _ = Describe("ManagerFactory", func() {
 	var factory *idtoken.ManagerFactory
 	var signingKeyFactory *dbfakes.FakeSigningKeyFactory
-	var config map[string]interface{}
+	var config map[string]any
 
 	BeforeEach(func() {
 		factory = idtoken.NewManagerFactory().(*idtoken.ManagerFactory)
 		signingKeyFactory = &dbfakes.FakeSigningKeyFactory{}
 		factory.SetSigningKeyFactory(signingKeyFactory)
 
-		config = map[string]interface{}{
-			"audience": []interface{}{"sts.amazonaws.com"},
+		config = map[string]any{
+			"audience": []any{"sts.amazonaws.com"},
 		}
 	})
 

--- a/atc/creds/vault/reauther_test.go
+++ b/atc/creds/vault/reauther_test.go
@@ -119,7 +119,7 @@ func testExponentialBackoff(t *testing.T) {
 
 	// Make enough login attempts to reach maxRetryInterval
 	var lastRetryInterval time.Duration
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		start := time.Now()
 		select {
 		case li := <-ma.LoginAttempt:

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"strconv"
 	"strings"
@@ -2087,9 +2088,7 @@ func createStartedBuild(tx Tx, build *build, args startedBuildArgs) error {
 	buildVals["schema"] = schema
 	buildVals["needs_v6_migration"] = false
 
-	for name, value := range args.ExtraValues {
-		buildVals[name] = value
-	}
+	maps.Copy(buildVals, args.ExtraValues)
 
 	err = createBuild(tx, build, buildVals)
 	if err != nil {

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -830,7 +830,7 @@ var _ = Describe("Build", func() {
 						childPipelines := []db.Pipeline{childPipeline}
 
 						By("creating a chain of pipelines, previous pipeline setting the next pipeline")
-						for i := 0; i < 5; i++ {
+						for i := range 5 {
 							job, _, _ := childPipeline.Job("some-job")
 							build, _ := job.CreateBuild(defaultBuildCreatedBy)
 							childPipeline, _, _ = build.SavePipeline(atc.PipelineRef{Name: "child-pipeline-" + strconv.Itoa(i)}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false)

--- a/atc/db/check_lifecycle_test.go
+++ b/atc/db/check_lifecycle_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Check Lifecycle", func() {
 
 		It("runs check-deletion query in batches", func() {
 			db.CheckDeleteBatchSize = 10
-			for i := 0; i < 51; i++ {
+			for range 51 {
 				build := createFinishedCheck(defaultResource, scopeOfDefaultResource, plan)
 				scopeOfDefaultResourceType.UpdateLastCheckStartTime(build.ID(), nil)
 			}

--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -116,7 +116,7 @@ var _ = BeforeEach(func() {
 	db.CleanupBaseResourceTypesCache()
 
 	var lockConns [lock.FactoryCount]*sql.DB
-	for i := 0; i < lock.FactoryCount; i++ {
+	for i := range lock.FactoryCount {
 		lockConns[i] = postgresRunner.OpenSingleton()
 	}
 	lockFactory = lock.NewLockFactory(lockConns, metric.LogLockAcquired, metric.LogLockReleased)

--- a/atc/db/input_mapping.go
+++ b/atc/db/input_mapping.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/concourse/concourse/atc"
 )
@@ -19,11 +20,11 @@ type PinnedVersionNotFound struct {
 }
 
 func (p PinnedVersionNotFound) String() ResolutionFailure {
-	var text string
+	var text strings.Builder
 	for k, v := range p.PinnedVersion {
-		text += fmt.Sprintf(" %s:%s", k, v)
+		text.WriteString(fmt.Sprintf(" %s:%s", k, v))
 	}
-	return ResolutionFailure(fmt.Sprintf("pinned version%s not found", text))
+	return ResolutionFailure(fmt.Sprintf("pinned version%s not found", text.String()))
 }
 
 type JobSet map[int]bool

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -426,7 +426,7 @@ var _ = Describe("Job", func() {
 		)
 
 		BeforeEach(func() {
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				var found bool
 				var err error
 				someJob, found, err = pipeline.Job("some-job")

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -131,7 +131,7 @@ func NewLockFactory(
 ) LockFactory {
 	factories := lockFactories{}
 
-	for i := 0; i < FactoryCount; i++ {
+	for i := range FactoryCount {
 		factories[i] = &lockFactory{
 			db: &lockDB{
 				conn:  conns[i],

--- a/atc/db/lock/lock_test.go
+++ b/atc/db/lock/lock_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Locks", func() {
 
 		logger = lagertest.NewTestLogger("test")
 
-		for i := 0; i < lock.FactoryCount; i++ {
+		for i := range lock.FactoryCount {
 			lockConns[i] = postgresRunner.OpenSingleton()
 		}
 
@@ -91,7 +91,7 @@ var _ = Describe("Locks", func() {
 				var wg sync.WaitGroup
 				wg.Add(connCount)
 
-				for i := 0; i < connCount; i++ {
+				for range connCount {
 					go func() {
 						defer wg.Done()
 
@@ -122,7 +122,7 @@ var _ = Describe("Locks", func() {
 			var lockConns2 [lock.FactoryCount]*sql.DB
 
 			BeforeEach(func() {
-				for i := 0; i < lock.FactoryCount; i++ {
+				for i := range lock.FactoryCount {
 					lockConns2[i] = postgresRunner.OpenSingleton()
 				}
 				lockFactory2 = lock.NewLockFactory(lockConns2, fakeLogFunc, fakeLogFunc)

--- a/atc/db/notifications_bus.go
+++ b/atc/db/notifications_bus.go
@@ -185,10 +185,8 @@ func (bus *notificationsBus) cacheNotify() {
 
 func (bus *notificationsBus) asyncNotify() {
 	ticker := time.NewTicker(500 * time.Millisecond)
-	bus.wg.Add(1)
 
-	go func() {
-		defer bus.wg.Done()
+	bus.wg.Go(func() {
 
 		for {
 			select {
@@ -215,7 +213,7 @@ func (bus *notificationsBus) asyncNotify() {
 				return
 			}
 		}
-	}()
+	})
 }
 
 func (bus *notificationsBus) handleNotification(notification *pgconn.Notification) {

--- a/atc/db/notifications_bus_test.go
+++ b/atc/db/notifications_bus_test.go
@@ -286,7 +286,7 @@ var _ = Describe("NotificationBus", func() {
 
 			Context("when it receives many upstream notifications", func() {
 				BeforeEach(func() {
-					for i := 0; i < 100; i++ {
+					for range 100 {
 						c <- &pgconn.Notification{Channel: "some-channel"}
 					}
 					Eventually(c).Should(BeEmpty())
@@ -316,19 +316,19 @@ var _ = Describe("NotificationBus", func() {
 
 			Context("when it receives many upstream notifications", func() {
 				BeforeEach(func() {
-					for i := 0; i < 100; i++ {
+					for range 100 {
 						c <- &pgconn.Notification{Channel: "some-channel"}
 					}
 				})
 
 				It("sends a message to the Go channel for every notification", func() {
-					for i := 0; i < 100; i++ {
+					for range 100 {
 						Eventually(a).Should(Receive())
 					}
 				})
 
 				It("should still work after the channel is drained", func() {
-					for i := 0; i < 100; i++ {
+					for range 100 {
 						<-a
 					}
 
@@ -339,7 +339,7 @@ var _ = Describe("NotificationBus", func() {
 
 			Context("when it receives more upstream notifications than fit in the queue", func() {
 				BeforeEach(func() {
-					for i := 0; i < 200; i++ {
+					for range 200 {
 						c <- &pgconn.Notification{Channel: "some-channel"}
 					}
 					// TODO: this is awful, but we need to guarantee the last event has been processed
@@ -347,7 +347,7 @@ var _ = Describe("NotificationBus", func() {
 				})
 
 				It("ignores the overflowing notifications", func() {
-					for i := 0; i < 100; i++ {
+					for range 100 {
 						<-a
 					}
 					Consistently(a).ShouldNot(Receive())

--- a/atc/db/resource_cache_factory_test.go
+++ b/atc/db/resource_cache_factory_test.go
@@ -226,7 +226,7 @@ var _ = Describe("ResourceCacheFactory", func() {
 				done := make(chan struct{})
 
 				wg := new(sync.WaitGroup)
-				for i := 0; i < 5; i++ {
+				for range 5 {
 					wg.Add(1)
 					go func() {
 						defer GinkgoRecover()
@@ -251,7 +251,7 @@ var _ = Describe("ResourceCacheFactory", func() {
 					defer close(done)
 					defer wg.Done()
 
-					for i := 0; i < 100; i++ {
+					for range 100 {
 						_, err := resourceCacheFactory.FindOrCreateResourceCache(
 							db.ForBuild(build.ID()),
 							"some-base-resource-type",

--- a/atc/db/resource_check_rate_limiter_test.go
+++ b/atc/db/resource_check_rate_limiter_test.go
@@ -120,7 +120,7 @@ var _ = Describe("ResourceCheckRateLimiter", func() {
 			Expect(<-done).To(Succeed())
 
 			By("creating more checkables")
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				createCheckable()
 			}
 
@@ -197,7 +197,7 @@ var _ = Describe("ResourceCheckRateLimiter", func() {
 			Expect(limiter.Limit()).To(Equal(rate.Limit(rate.Inf)))
 
 			By("creating a few (ignored) checkables")
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				createCheckable()
 			}
 

--- a/atc/db/resource_config_factory_test.go
+++ b/atc/db/resource_config_factory_test.go
@@ -125,7 +125,7 @@ var _ = Describe("ResourceConfigFactory", func() {
 				defer close(done)
 				defer wg.Done()
 
-				for i := 0; i < 100; i++ {
+				for range 100 {
 					_, err := resourceConfigFactory.FindOrCreateResourceConfig("some-base-resource-type", atc.Source{"some": "unique-source"}, nil)
 					Expect(err).ToNot(HaveOccurred())
 				}
@@ -170,7 +170,7 @@ var _ = Describe("ResourceConfigFactory", func() {
 				defer close(done)
 				defer wg.Done()
 
-				for i := 0; i < 100; i++ {
+				for range 100 {
 					_, err := resourceConfigFactory.FindOrCreateResourceConfig("some-base-resource-type", atc.Source{"some": "unique-source"}, nil)
 					Expect(err).ToNot(HaveOccurred())
 				}

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -853,7 +853,7 @@ var _ = Describe("Resource", func() {
 
 				resourceVersions = make([]atc.ResourceVersion, 0)
 
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					rcv := scenario.ResourceVersion("some-resource", atc.Version{
 						"ref":    "v" + strconv.Itoa(i),
 						"commit": "v" + strconv.Itoa(i),
@@ -962,7 +962,7 @@ var _ = Describe("Resource", func() {
 
 				resourceVersions = make([]atc.ResourceVersion, 0)
 
-				for i := 0; i < 10; i++ {
+				for i := range 10 {
 					rcv := scenario.ResourceVersion("some-resource", atc.Version{"ref": "v" + strconv.Itoa(i)})
 
 					var metadata atc.Metadata

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -1419,7 +1419,7 @@ var _ = Describe("Team", func() {
 			var pipelineBuilds [2]db.Build
 
 			BeforeEach(func() {
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					build, err := team.CreateOneOffBuild()
 					Expect(err).ToNot(HaveOccurred())
 					allBuilds[i] = build
@@ -1512,7 +1512,7 @@ var _ = Describe("Team", func() {
 					Expect(found).To(BeTrue())
 					Expect(err).ToNot(HaveOccurred())
 
-					for i := 0; i < 3; i++ {
+					for i := range 3 {
 						teamABuilds[i], err = caseInsensitiveTeamA.CreateOneOffBuild()
 						Expect(err).ToNot(HaveOccurred())
 
@@ -1784,7 +1784,7 @@ var _ = Describe("Team", func() {
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					teamABuilds[i], err = caseInsensitiveTeamA.CreateOneOffBuild()
 					Expect(err).ToNot(HaveOccurred())
 

--- a/atc/db/volume_repository.go
+++ b/atc/db/volume_repository.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"maps"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -723,9 +724,7 @@ func (repository *volumeRepository) createVolumeWithHandle(
 		"worker_name": workerName,
 		"handle":      handle,
 	}
-	for name, value := range columns {
-		values[name] = value
-	}
+	maps.Copy(values, columns)
 
 	if teamID != 0 {
 		values["team_id"] = teamID
@@ -762,9 +761,7 @@ func (repository *volumeRepository) findVolume(teamID int, workerName string, co
 		whereClause["v.worker_name"] = workerName
 	}
 
-	for name, value := range columns {
-		whereClause[name] = value
-	}
+	maps.Copy(whereClause, columns)
 
 	return getVolume(repository.conn, whereClause)
 }

--- a/atc/db/worker_factory.go
+++ b/atc/db/worker_factory.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -85,13 +86,7 @@ func (f *workerFactory) VisibleWorkers(teamNames []string) ([]Worker, error) {
 			return true
 		}
 
-		for _, team := range teamNames {
-			if worker.TeamName() == team {
-				return true
-			}
-		}
-
-		return false
+		return slices.Contains(teamNames, worker.TeamName())
 	}
 
 	visibleWorkers := []Worker{}

--- a/atc/engine/build_step_delegate_test.go
+++ b/atc/engine/build_step_delegate_test.go
@@ -585,7 +585,7 @@ var _ = Describe("BuildStepDelegate", func() {
 				}
 			}
 
-			planIDType := reflect.TypeOf(atc.PlanID(""))
+			planIDType := reflect.TypeFor[atc.PlanID]()
 
 			seen := map[reflect.Type]bool{}
 			var walk func([]string, reflect.Type)
@@ -616,7 +616,7 @@ var _ = Describe("BuildStepDelegate", func() {
 				}
 			}
 
-			walk(nil, reflect.TypeOf(atc.Plan{}))
+			walk(nil, reflect.TypeFor[atc.Plan]())
 		})
 	})
 

--- a/atc/event/deprecated_events.go
+++ b/atc/event/deprecated_events.go
@@ -119,7 +119,7 @@ type OriginV30 struct {
 	Name     string            `json:"name"`
 	Type     OriginV30Type     `json:"type"`
 	Source   OriginV30Source   `json:"source"`
-	Location OriginV30Location `json:"location,omitempty"`
+	Location OriginV30Location `json:"location,omitzero"`
 	Hook     string            `json:"hook"`
 }
 
@@ -313,7 +313,7 @@ type OutputV20OutputPlan struct {
 
 type ErrorV10 struct {
 	Message string    `json:"message"`
-	Origin  OriginV20 `json:"origin,omitempty"`
+	Origin  OriginV20 `json:"origin,omitzero"`
 }
 
 func (ErrorV10) EventType() atc.EventType  { return "error" }
@@ -321,7 +321,7 @@ func (ErrorV10) Version() atc.EventVersion { return "1.0" }
 
 type ErrorV20 struct {
 	Message string    `json:"message"`
-	Origin  OriginV30 `json:"origin,omitempty"`
+	Origin  OriginV30 `json:"origin,omitzero"`
 }
 
 func (ErrorV20) EventType() atc.EventType  { return "error" }
@@ -331,7 +331,7 @@ func (ErrorV20) Version() atc.EventVersion { return "2.0" }
 
 type ErrorV30 struct {
 	Message string    `json:"message"`
-	Origin  OriginV40 `json:"origin,omitempty"`
+	Origin  OriginV40 `json:"origin,omitzero"`
 }
 
 func (ErrorV30) EventType() atc.EventType  { return "error" }
@@ -374,7 +374,7 @@ type OriginV40 struct {
 	Name     string            `json:"name"`
 	Type     OriginV40Type     `json:"type"`
 	Source   OriginSource      `json:"source"`
-	Location OriginV40Location `json:"location,omitempty"`
+	Location OriginV40Location `json:"location,omitzero"`
 }
 
 type OriginV40Type string

--- a/atc/exec/across_step_test.go
+++ b/atc/exec/across_step_test.go
@@ -171,7 +171,6 @@ var _ = Describe("AcrossStep", func() {
 		plans := make([]atc.VarScopedPlan, len(allVals))
 		for i, vals := range allVals {
 			// capture the array from the range
-			vals := vals
 			plans[i] = atc.VarScopedPlan{Values: vals[:]}
 		}
 		fakeDelegate.ConstructAcrossSubstepsReturns(plans, nil)
@@ -270,7 +269,7 @@ var _ = Describe("AcrossStep", func() {
 
 			By("running the first stage")
 			var receivedVals []vals
-			for i := 0; i < 6; i++ {
+			for range 6 {
 				receivedVals = append(receivedVals, <-started)
 			}
 			Expect(receivedVals).To(ConsistOf(
@@ -290,7 +289,7 @@ var _ = Describe("AcrossStep", func() {
 
 			By("running the second stage")
 			receivedVals = []vals{}
-			for i := 0; i < 6; i++ {
+			for range 6 {
 				receivedVals = append(receivedVals, <-started)
 			}
 			Expect(receivedVals).To(ConsistOf(
@@ -310,7 +309,7 @@ var _ = Describe("AcrossStep", func() {
 
 			By("running the third stage")
 			receivedVals = []vals{}
-			for i := 0; i < 6; i++ {
+			for range 6 {
 				receivedVals = append(receivedVals, <-started)
 			}
 			Expect(receivedVals).To(ConsistOf(
@@ -330,7 +329,7 @@ var _ = Describe("AcrossStep", func() {
 
 			By("running the forth stage")
 			receivedVals = []vals{}
-			for i := 0; i < 6; i++ {
+			for range 6 {
 				receivedVals = append(receivedVals, <-started)
 			}
 			Expect(receivedVals).To(ConsistOf(

--- a/atc/gc/gc_suite_test.go
+++ b/atc/gc/gc_suite_test.go
@@ -69,7 +69,7 @@ var _ = BeforeEach(func() {
 	db.CleanupBaseResourceTypesCache()
 
 	var lockConns [lock.FactoryCount]*sql.DB
-	for i := 0; i < lock.FactoryCount; i++ {
+	for i := range lock.FactoryCount {
 		lockConns[i] = postgresRunner.OpenSingleton()
 	}
 	lockFactory = lock.NewLockFactory(lockConns, fakeLogFunc, fakeLogFunc)

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -75,9 +75,7 @@ func (s *scanner) scanResources(ctx context.Context, resources []db.Resource, re
 	}()
 
 	for range maxConcurrency {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
+		waitGroup.Go(func() {
 			for {
 				select {
 				case rs, open := <-resourcesChan:
@@ -105,7 +103,7 @@ func (s *scanner) scanResources(ctx context.Context, resources []db.Resource, re
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	done := make(chan struct{})

--- a/atc/metric/emitter/influxdb_test.go
+++ b/atc/metric/emitter/influxdb_test.go
@@ -53,14 +53,14 @@ var _ = Describe("InfluxDBEmitter", func() {
 			})
 
 			It("should write 1 batch to InfluxDB", func() {
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					influxDBEmitter.Emit(testLogger, metric.Event{})
 				}
 				Eventually(influxDBClient.WriteCallCount).Should(BeNumerically("==", 1))
 			})
 
 			It("should write 2 batches to InfluxDB", func() {
-				for i := 0; i < 4; i++ {
+				for range 4 {
 					influxDBEmitter.Emit(testLogger, metric.Event{})
 				}
 				Eventually(influxDBClient.WriteCallCount).Should(BeNumerically("==", 2))
@@ -127,7 +127,7 @@ var _ = Describe("InfluxDBEmitter", func() {
 			})
 
 			It("should write 2 batches to InfluxDB", func() {
-				for i := 0; i < 2; i++ {
+				for range 2 {
 					influxDBEmitter.Emit(testLogger, metric.Event{})
 					time.Sleep(2 * time.Nanosecond)
 				}

--- a/atc/metric/gauge_test.go
+++ b/atc/metric/gauge_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Gauge", func() {
 		wg := new(sync.WaitGroup)
 		wg.Add(totalIncs)
 
-		for i := 0; i < totalIncs; i++ {
+		for range totalIncs {
 			go func() {
 				gauge.Inc()
 				wg.Done()

--- a/atc/pipeline_test.go
+++ b/atc/pipeline_test.go
@@ -74,7 +74,6 @@ var _ = Describe("PipelineRef", func() {
 				out: `some-pipeline/bool:true,float:123.456,int:123,nil:null`,
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				Expect(tt.ref.String()).To(Equal(tt.out))
 			})
@@ -108,7 +107,6 @@ var _ = Describe("PipelineRef", func() {
 				out:  url.Values{`vars."hello.1"."foo:bar"`: []string{`"baz"`}},
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				Expect(tt.ref.QueryParams()).To(Equal(tt.out))
 			})
@@ -206,7 +204,6 @@ var _ = Describe("PipelineRef", func() {
 				err: "unexpected end of JSON input",
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				vars, err := atc.InstanceVarsFromQueryParams(tt.query)
 				if tt.err != "" {

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -286,7 +286,7 @@ type CheckPlan struct {
 	// was last checked, and the build has not been manually triggered, the check
 	// will be skipped. It will also be set as Never if the user has specified
 	// for it to not be checked periodically.
-	Interval CheckEvery `json:"interval,omitempty"`
+	Interval CheckEvery `json:"interval,omitzero"`
 
 	// If set, the check interval will not be respected, (i.e. a new check will
 	// be run even if the interval has not elapsed).

--- a/atc/policy/checker.go
+++ b/atc/policy/checker.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -177,13 +178,7 @@ func (c *AgentChecker) ShouldSkipAction(action string) bool {
 }
 
 func inArray(array []string, target string) bool {
-	found := false
-	for _, ele := range array {
-		if ele == target {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(array, target)
 	return found
 }
 

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -164,7 +164,7 @@ func (plan AcrossPlan) Public() *json.RawMessage {
 func (plan DoPlan) Public() *json.RawMessage {
 	public := make([]*json.RawMessage, len(plan))
 
-	for i := 0; i < len(plan); i++ {
+	for i := range plan {
 		public[i] = plan[i].Public()
 	}
 
@@ -346,7 +346,7 @@ func (plan TryPlan) Public() *json.RawMessage {
 func (plan RetryPlan) Public() *json.RawMessage {
 	public := make([]*json.RawMessage, len(plan))
 
-	for i := 0; i < len(plan); i++ {
+	for i := range plan {
 		public[i] = plan[i].Public()
 	}
 

--- a/atc/scheduler/algorithm/suite_test.go
+++ b/atc/scheduler/algorithm/suite_test.go
@@ -60,7 +60,7 @@ var _ = BeforeEach(func() {
 	db.CleanupBaseResourceTypesCache()
 
 	var lockConns [lock.FactoryCount]*sql.DB
-	for i := 0; i < lock.FactoryCount; i++ {
+	for i := range lock.FactoryCount {
 		lockConns[i] = postgresRunner.OpenSingleton()
 	}
 	lockFactory = lock.NewLockFactory(lockConns, metric.LogLockAcquired, metric.LogLockReleased)

--- a/atc/task.go
+++ b/atc/task.go
@@ -26,7 +26,7 @@ type TaskConfig struct {
 	Params TaskEnv `json:"params,omitempty"`
 
 	// Script to execute.
-	Run TaskRunConfig `json:"run,omitempty"`
+	Run TaskRunConfig `json:"run,omitzero"`
 
 	// The set of (logical, name-only) inputs required by the task.
 	Inputs []TaskInputConfig `json:"inputs,omitempty"`

--- a/atc/worker/gardenruntime/gardenruntime_suite_test.go
+++ b/atc/worker/gardenruntime/gardenruntime_suite_test.go
@@ -29,7 +29,7 @@ var _ = BeforeEach(func() {
 
 	ignore := func(logger lager.Logger, id lock.LockID) {}
 	var lockConns [lock.FactoryCount]*sql.DB
-	for i := 0; i < lock.FactoryCount; i++ {
+	for i := range lock.FactoryCount {
 		lockConns[i] = postgresRunner.OpenSingleton()
 	}
 	lockFactory = lock.NewLockFactory(lockConns, ignore, ignore)

--- a/atc/worker/gardenruntime/gardenruntimetest/worker.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/worker.go
@@ -182,7 +182,7 @@ func (w Worker) WithJobBuildContainerCreatedInDBAndGarden() *Worker {
 func (w Worker) WithActiveTasks(activeTasks int) *Worker {
 	return w.WithSetup(func(s *workertest.Scenario) {
 		worker := s.DB.Worker(w.Name())
-		for i := 0; i < activeTasks; i++ {
+		for range activeTasks {
 			_, err := worker.IncreaseActiveTasks(activeTasks)
 			Expect(err).ToNot(HaveOccurred())
 		}

--- a/atc/worker/gardenruntime/gclient/client.go
+++ b/atc/worker/gardenruntime/gclient/client.go
@@ -1,6 +1,8 @@
 package gclient
 
 import (
+	"slices"
+
 	"code.cloudfoundry.org/garden"
 	"github.com/concourse/concourse/atc/worker/gardenruntime/gclient/connection"
 )
@@ -124,10 +126,8 @@ func (client *client) Lookup(handle string) (Container, error) {
 		return nil, err
 	}
 
-	for _, h := range handles {
-		if h == handle {
-			return newContainer(handle, client.connection), nil
-		}
+	if slices.Contains(handles, handle) {
+		return newContainer(handle, client.connection), nil
 	}
 
 	return nil, garden.ContainerNotFoundError{Handle: handle}

--- a/atc/worker/gardenruntime/gclient/connection/connection_test.go
+++ b/atc/worker/gardenruntime/gclient/connection/connection_test.go
@@ -1011,7 +1011,7 @@ var _ = Describe("Connection", func() {
 					),
 					stdoutStream("foo-handle", "process-handle", 123, func(conn net.Conn) {
 						conn.Write([]byte("stdout data"))
-						conn.Write([]byte(fmt.Sprintf("roundtripped %s", <-stdInContent)))
+						conn.Write(fmt.Appendf(nil, "roundtripped %s", <-stdInContent))
 					}),
 					stderrStream("foo-handle", "process-handle", 123, func(conn net.Conn) {
 						conn.Write([]byte("stderr data"))
@@ -1134,7 +1134,7 @@ var _ = Describe("Connection", func() {
 					),
 					stdoutStream("foo-handle", "process-handle", 123, func(conn net.Conn) {
 						conn.Write([]byte("stdout data"))
-						conn.Write([]byte(fmt.Sprintf("roundtripped %s", <-stdInContent)))
+						conn.Write(fmt.Appendf(nil, "roundtripped %s", <-stdInContent))
 					}),
 					emptyStderrStream("foo-handle", "process-handle", 123),
 				)
@@ -1485,7 +1485,7 @@ var _ = Describe("Connection", func() {
 					),
 					stdoutStream("foo-handle", "process-handle", 123, func(conn net.Conn) {
 						conn.Write([]byte("stdout data"))
-						conn.Write([]byte(fmt.Sprintf("roundtripped %s", <-expectedRoundtrip)))
+						conn.Write(fmt.Appendf(nil, "roundtripped %s", <-expectedRoundtrip))
 					}),
 					stderrStream("foo-handle", "process-handle", 123, func(conn net.Conn) {
 						conn.Write([]byte("stderr data"))

--- a/atc/worker/gardenruntime/gclient/connection/stream_handler.go
+++ b/atc/worker/gardenruntime/gclient/connection/stream_handler.go
@@ -37,11 +37,9 @@ func (sh *streamHandler) streamIn(processWriter io.WriteCloser, stdin io.Reader)
 }
 
 func (sh *streamHandler) streamOut(streamWriter io.Writer, streamReader io.Reader) {
-	sh.wg.Add(1)
-	go func() {
+	sh.wg.Go(func() {
 		io.Copy(streamWriter, streamReader)
-		sh.wg.Done()
-	}()
+	})
 }
 
 type waitReturn struct {

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -637,7 +637,7 @@ var _ = Describe("Garden Worker", func() {
 
 				By("validating 2 streaming-volume events are emitted", func() {
 					Expect(delegate.StreamingVolumeCallCount()).To(Equal(2))
-					for i := 0; i < 2; i++ {
+					for i := range 2 {
 						_, volume, src, dest := delegate.StreamingVolumeArgsForCall(i)
 						Expect(volume).To(Equal("for image"))
 						Expect(src).To(Equal("worker2"))
@@ -884,7 +884,7 @@ var _ = Describe("Garden Worker", func() {
 
 				By("validating 2 streaming-volume events are emitted", func() {
 					Expect(delegate.StreamingVolumeCallCount()).To(Equal(2))
-					for i := 0; i < 2; i++ {
+					for i := range 2 {
 						_, volume, src, dest := delegate.StreamingVolumeArgsForCall(i)
 						Expect(volume).To(Equal("remote-input"))
 						Expect(src).To(Equal("worker2"))

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -1,6 +1,8 @@
 package worker_test
 
 import (
+	"slices"
+
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/runtime"
 	"github.com/concourse/concourse/atc/runtime/runtimetest"
@@ -802,12 +804,7 @@ func workerNames(workers []db.Worker) []string {
 
 func filterWorkers(allWorkers []db.Worker, namesToKeep ...string) []db.Worker {
 	keep := func(name string) bool {
-		for _, otherName := range namesToKeep {
-			if name == otherName {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(namesToKeep, name)
 	}
 
 	var workers []db.Worker

--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -471,12 +472,7 @@ func tagsMatch(worker db.Worker, tags []string) bool {
 	}
 
 	hasTag := func(tag string) bool {
-		for _, wtag := range worker.Tags() {
-			if wtag == tag {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(worker.Tags(), tag)
 	}
 
 	for _, tag := range tags {

--- a/atc/worker/worker_suite_test.go
+++ b/atc/worker/worker_suite_test.go
@@ -34,7 +34,7 @@ var _ = BeforeEach(func() {
 
 	ignore := func(logger lager.Logger, id lock.LockID) {}
 	var lockConns [lock.FactoryCount]*sql.DB
-	for i := 0; i < lock.FactoryCount; i++ {
+	for i := range lock.FactoryCount {
 		lockConns[i] = postgresRunner.OpenSingleton()
 	}
 	lockFactory = lock.NewLockFactory(lockConns, ignore, ignore)

--- a/atc/wrappa/pool_test.go
+++ b/atc/wrappa/pool_test.go
@@ -64,7 +64,7 @@ func pool(size int) wrappa.Pool {
 func doInParallel(numGoroutines int, thingToDo func()) {
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines)
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			thingToDo()
 			wg.Done()

--- a/fly/commands/completion.go
+++ b/fly/commands/completion.go
@@ -74,7 +74,7 @@ func fishCompletionSnippetHelper(snippet string, prefix string, commandType refl
 			}
 
 			// Handle pointer types
-			if fieldType.Kind() == reflect.Ptr {
+			if fieldType.Kind() == reflect.Pointer {
 				fieldType = fieldType.Elem()
 			}
 
@@ -88,7 +88,7 @@ func fishCompletionSnippetHelper(snippet string, prefix string, commandType refl
 	return snippet
 }
 
-var fishCompletionSnippet = fishCompletionSnippetHelper("", "", reflect.TypeOf(Fly))
+var fishCompletionSnippet = fishCompletionSnippetHelper("", "", reflect.TypeFor[FlyCommand]())
 
 // Initial implementation just using bashcompinit
 const zshCompletionSnippet = `autoload -Uz compinit && compinit

--- a/fly/commands/internal/flaghelpers/instance_vars_flag_test.go
+++ b/fly/commands/internal/flaghelpers/instance_vars_flag_test.go
@@ -139,7 +139,6 @@ var _ = Describe("InstanceVarsFlag", func() {
 				err:  `invalid value for key 'hello': error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}'`,
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				err := instanceVarsFlag.UnmarshalFlag(tt.flag)
 				if tt.err == "" {

--- a/fly/commands/internal/flaghelpers/job_flag_test.go
+++ b/fly/commands/internal/flaghelpers/job_flag_test.go
@@ -77,7 +77,6 @@ var _ = Describe("JobFlag", func() {
 				err:  "instance vars should be formatted as <key1:value1>(,<key2:value2>)",
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				err := flag.UnmarshalFlag(tt.flag)
 				if tt.err == "" {

--- a/fly/commands/internal/flaghelpers/pipeline_flag_test.go
+++ b/fly/commands/internal/flaghelpers/pipeline_flag_test.go
@@ -35,7 +35,6 @@ var _ = Describe("PipelineFlag", func() {
 				instanceVars: atc.InstanceVars{"branch": "master"},
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				err := pipelineFlag.UnmarshalFlag(tt.flag)
 				Expect(err).ToNot(HaveOccurred())

--- a/fly/commands/internal/flaghelpers/resource_flag_test.go
+++ b/fly/commands/internal/flaghelpers/resource_flag_test.go
@@ -75,7 +75,6 @@ var _ = Describe("ResourceFlag", func() {
 			err:  "instance vars should be formatted as <key1:value1>(,<key2:value2>)",
 		},
 	} {
-		tt := tt
 		It(tt.desc, func() {
 			err := flag.UnmarshalFlag(tt.flag)
 			if tt.err == "" {

--- a/fly/commands/internal/flaghelpers/yaml_variable_pair_flag_test.go
+++ b/fly/commands/internal/flaghelpers/yaml_variable_pair_flag_test.go
@@ -49,7 +49,6 @@ var _ = Describe("YAMLVariablePair", func() {
 				err:  `error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}'`,
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				err := variable.UnmarshalFlag(tt.flag)
 				if tt.err == "" {

--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -186,7 +186,7 @@ func diff(existingConfig atc.Config, newConfig atc.Config) bool {
 func indent(text, indent string) string {
 	text = strings.TrimRight(text, "\n")
 	var result strings.Builder
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		result.WriteString(indent + line + "\n")
 	}
 	return result.String()[:result.Len()-1]

--- a/fly/commands/resource_versions.go
+++ b/fly/commands/resource_versions.go
@@ -19,7 +19,7 @@ type ResourceVersionsCommand struct {
 	Count    int                      `short:"c" long:"count" default:"50" description:"Number of versions you want to limit the return to"`
 	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to get versions for"`
 	Json     bool                     `long:"json" description:"Print command result as JSON"`
-	Team  flaghelpers.TeamFlag  `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Team     flaghelpers.TeamFlag     `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *ResourceVersionsCommand) Execute([]string) error {
@@ -40,7 +40,6 @@ func (command *ResourceVersionsCommand) Execute([]string) error {
 	}
 
 	page := concourse.Page{Limit: command.Count}
-
 
 	versions, _, _, err := team.ResourceVersions(command.Resource.PipelineRef, command.Resource.ResourceName, page, atc.Version{})
 	if err != nil {
@@ -64,11 +63,7 @@ func (command *ResourceVersionsCommand) Execute([]string) error {
 	}
 
 	var rangeUntil int
-	if command.Count < len(versions) {
-		rangeUntil = command.Count
-	} else {
-		rangeUntil = len(versions)
-	}
+	rangeUntil = min(command.Count, len(versions))
 
 	for _, version := range versions[:rangeUntil] {
 		var enabledCell ui.TableCell

--- a/fly/pty/open_raw_term_unix.go
+++ b/fly/pty/open_raw_term_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package pty
 

--- a/fly/pty/open_raw_term_windows.go
+++ b/fly/pty/open_raw_term_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package pty
 

--- a/fly/pty/pty_unix.go
+++ b/fly/pty/pty_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package pty
 

--- a/fly/pty/pty_windows.go
+++ b/fly/pty/pty_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package pty
 

--- a/fly/pty/resize_notifier.go
+++ b/fly/pty/resize_notifier.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package pty
 

--- a/fly/pty/resize_notifier_windows.go
+++ b/fly/pty/resize_notifier_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package pty
 

--- a/go-concourse/concourse/internal/connection.go
+++ b/go-concourse/concourse/internal/connection.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -228,9 +229,7 @@ func (connection *connection) populateResponse(response *http.Response, returnRe
 	}
 
 	if passedResponse.Headers != nil {
-		for k, v := range response.Header {
-			(*passedResponse.Headers)[k] = v
-		}
+		maps.Copy((*passedResponse.Headers), response.Header)
 	}
 
 	if returnResponseBody {

--- a/go-concourse/concourse/internal/policy_warn.go
+++ b/go-concourse/concourse/internal/policy_warn.go
@@ -14,10 +14,11 @@ func showPolicyCheckWarningIfHas(response *http.Response) {
 	}
 
 	parts := strings.Split(warn, " * ")
-	warnText := fmt.Sprintf("\x1b[1;33m%s\x1b[0m\n", parts[0])
+	var warnText strings.Builder
+	warnText.WriteString(fmt.Sprintf("\x1b[1;33m%s\x1b[0m\n", parts[0]))
 	for i := 1; i < len(parts); i++ {
-		warnText += fmt.Sprintf("\x1b[1;33m * %s\x1b[0m\n", parts[i])
+		warnText.WriteString(fmt.Sprintf("\x1b[1;33m * %s\x1b[0m\n", parts[i]))
 	}
-	warnText += fmt.Sprintln("\x1b[33mWARNING: unblocking from the policy check failure for soft enforcement\x1b[0m")
-	fmt.Fprintln(os.Stderr, warnText)
+	warnText.WriteString(fmt.Sprintln("\x1b[33mWARNING: unblocking from the policy check failure for soft enforcement\x1b[0m"))
+	fmt.Fprintln(os.Stderr, warnText.String())
 }

--- a/skymarshal/skycmd/flags.go
+++ b/skymarshal/skycmd/flags.go
@@ -226,12 +226,12 @@ func (con *Connector) Serialize(redirectURI string) ([]byte, error) {
 func (con *Connector) newTeamConfig() (TeamConfig, error) {
 
 	typeof := reflect.TypeOf(con.teamConfig)
-	if typeof.Kind() == reflect.Ptr {
+	if typeof.Kind() == reflect.Pointer {
 		typeof = typeof.Elem()
 	}
 
 	valueof := reflect.ValueOf(con.teamConfig)
-	if valueof.Kind() == reflect.Ptr {
+	if valueof.Kind() == reflect.Pointer {
 		valueof = valueof.Elem()
 	}
 

--- a/skymarshal/skyserver/skyserver_test.go
+++ b/skymarshal/skyserver/skyserver_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Sky Server API", func() {
 						data, err := base64.RawURLEncoding.DecodeString(stateParam)
 						Expect(err).NotTo(HaveOccurred())
 
-						var state map[string]interface{}
+						var state map[string]any
 						json.Unmarshal(data, &state)
 						Expect(state["redirect_uri"]).To(Equal("/redirect"))
 						Expect(state["sig"]).NotTo(BeEmpty())
@@ -116,7 +116,7 @@ var _ = Describe("Sky Server API", func() {
 						data, err := base64.RawURLEncoding.DecodeString(stateParam)
 						Expect(err).NotTo(HaveOccurred())
 
-						var state map[string]interface{}
+						var state map[string]any
 						json.Unmarshal(data, &state)
 						Expect(state["redirect_uri"]).To(Equal("/"))
 					})

--- a/skymarshal/token/access_token_test.go
+++ b/skymarshal/token/access_token_test.go
@@ -133,7 +133,6 @@ var _ = Describe("Access Tokens", func() {
 				expectStatusCode: 500,
 			},
 		} {
-			t := t
 
 			It(t.it, func() {
 				baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/testflight/idtoken_test.go
+++ b/testflight/idtoken_test.go
@@ -94,14 +94,14 @@ func extractIDtokenFromBuffer(buffer []byte, whichToken string) string {
 	return string(tokenMatches[1])
 }
 
-func getOpenIDConfiguration(atcURL string) (map[string]interface{}, error) {
+func getOpenIDConfiguration(atcURL string) (map[string]any, error) {
 	resp, err := http.Get(atcURL + "/.well-known/openid-configuration")
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	var config map[string]interface{}
+	var config map[string]any
 	err = json.NewDecoder(resp.Body).Decode(&config)
 	return config, err
 }

--- a/tools.go
+++ b/tools.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package tools
 

--- a/topgun/both/build_container_gc_test.go
+++ b/topgun/both/build_container_gc_test.go
@@ -2,6 +2,7 @@ package topgun_test
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -163,13 +164,7 @@ var _ = Describe("Garbage collecting build containers", func() {
 
 				var secondBuildContainerHandles []string
 				for _, handle := range allBuildContainerHandles {
-					alreadyExisted := false
-					for _, preHandle := range firstBuildContainerHandles {
-						if preHandle == handle {
-							alreadyExisted = true
-							break
-						}
-					}
+					alreadyExisted := slices.Contains(firstBuildContainerHandles, handle)
 
 					if !alreadyExisted {
 						secondBuildContainerHandles = append(secondBuildContainerHandles, handle)
@@ -238,13 +233,7 @@ var _ = Describe("Garbage collecting build containers", func() {
 
 				var secondBuildContainerHandles []string
 				for _, handle := range allBuildContainerHandles {
-					alreadyExisted := false
-					for _, preHandle := range firstBuildContainerHandles {
-						if preHandle == handle {
-							alreadyExisted = true
-							break
-						}
-					}
+					alreadyExisted := slices.Contains(firstBuildContainerHandles, handle)
 
 					if !alreadyExisted {
 						secondBuildContainerHandles = append(secondBuildContainerHandles, handle)

--- a/topgun/both/resource_containers_gc_test.go
+++ b/topgun/both/resource_containers_gc_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Garbage collecting resource containers", func() {
 				Fly.Run("unpause-pipeline", "-p", "resource-gc-test")
 
 				By("checking resource excessively")
-				for i := 0; i < 20; i++ {
+				for range 20 {
 					Fly.Run("check-resource", "-r", "resource-gc-test/tick-tock")
 				}
 
@@ -130,7 +130,7 @@ var _ = Describe("Garbage collecting resource containers", func() {
 
 				By("checking resource excessively")
 				Fly.Run("login", "-c", AtcExternalURL, "-n", "main", "-u", AtcUsername, "-p", AtcPassword)
-				for i := 0; i < 20; i++ {
+				for range 20 {
 					Fly.Run("check-resource", "-r", "resource-gc-test/tick-tock")
 				}
 

--- a/topgun/both/worker_landing_test.go
+++ b/topgun/both/worker_landing_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Worker landing", func() {
 
 			Context("while in landing or landed state", func() {
 				It("is not used for new workloads", func() {
-					for i := 0; i < 10; i++ {
+					for range 10 {
 						Fly.Run("execute", "-c", "tasks/tiny.yml")
 						usedWorkers := WorkersWithContainers()
 						Expect(usedWorkers).To(HaveLen(1))

--- a/topgun/both/worker_stalling_test.go
+++ b/topgun/both/worker_stalling_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Worker stalling", func() {
 			})
 
 			It("enters 'stalled' state and is no longer used for new containers", func() {
-				for i := 0; i < 10; i++ {
+				for range 10 {
 					Fly.Run("execute", "-c", "tasks/tiny.yml")
 					usedWorkers := WorkersWithContainers()
 					Expect(usedWorkers).To(HaveLen(1))

--- a/topgun/core/vault_test.go
+++ b/topgun/core/vault_test.go
@@ -102,9 +102,7 @@ var _ = XDescribe("Vault", func() {
 				}()
 
 				renewTicker := time.NewTicker(5 * time.Second)
-				renewing.Add(1)
-				go func() {
-					defer renewing.Done()
+				renewing.Go(func() {
 					defer GinkgoRecover()
 
 					for {
@@ -115,7 +113,7 @@ var _ = XDescribe("Vault", func() {
 							return
 						}
 					}
-				}()
+				})
 
 				By("deploying concourse with the token")
 				Deploy(

--- a/tsa/tsacmd/remote_cli.go
+++ b/tsa/tsacmd/remote_cli.go
@@ -42,7 +42,7 @@ func (req forwardWorkerRequest) Handle(ctx context.Context, state ConnState, cha
 	}
 
 	forwards := map[string]ForwardedTCPIP{}
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case forwarded := <-state.ForwardedTCPIPs:
 			logger.Info("forwarded-tcpip", lager.Data{

--- a/tsa/tsacmd/server.go
+++ b/tsa/tsacmd/server.go
@@ -397,10 +397,7 @@ func (server *server) forwardTCPIP(
 			break
 		}
 
-		connsWg.Add(1)
-
-		go func() {
-			defer connsWg.Done()
+		connsWg.Go(func() {
 
 			forwardLocalConn(
 				lagerctx.NewContext(ctx, logger.Session("forward-conn")),
@@ -409,7 +406,7 @@ func (server *server) forwardTCPIP(
 				forwardIP,
 				forwardPort,
 			)
-		}()
+		})
 	}
 }
 

--- a/vars/reference_test.go
+++ b/vars/reference_test.go
@@ -39,7 +39,6 @@ var _ = Describe("Reference", func() {
 				result: "source:hello",
 			},
 		} {
-			tt := tt
 
 			It(tt.desc, func() {
 				Expect(tt.ref.String()).To(Equal(tt.result))
@@ -115,7 +114,6 @@ var _ = Describe("Reference", func() {
 				ref:  vars.Reference{Path: " hello ", Fields: []string{"world "}},
 			},
 		} {
-			tt := tt
 
 			It(tt.desc, func() {
 				ref, err := vars.ParseReference(tt.raw)

--- a/vars/static_vars_test.go
+++ b/vars/static_vars_test.go
@@ -125,7 +125,6 @@ var _ = Describe("StaticVariables", func() {
 				},
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				Expect(tt.expanded.Flatten()).To(ConsistOf(tt.kvPairs))
 			})
@@ -182,7 +181,6 @@ var _ = Describe("StaticVariables", func() {
 				},
 			},
 		} {
-			tt := tt
 			It(tt.desc, func() {
 				Expect(tt.kvPairs.Expand()).To(Equal(tt.expanded))
 			})

--- a/worker/baggageclaim/api/volume_server_linux_test.go
+++ b/worker/baggageclaim/api/volume_server_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package api_test
 

--- a/worker/baggageclaim/baggageclaimcmd/driver_nonlinux.go
+++ b/worker/baggageclaim/baggageclaimcmd/driver_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package baggageclaimcmd
 

--- a/worker/baggageclaim/integration/baggageclaim/overlay_mounts_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/overlay_mounts_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package integration_test
 

--- a/worker/baggageclaim/integration/baggageclaim/privileges_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/privileges_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package integration_test
 

--- a/worker/baggageclaim/kernel/kernel.go
+++ b/worker/baggageclaim/kernel/kernel.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Package kernel provides helper function to get, parse and compare kernel
 // versions for different platforms.

--- a/worker/baggageclaim/kernel/kernel_unix.go
+++ b/worker/baggageclaim/kernel/kernel_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd || solaris || openbsd
-// +build linux freebsd solaris openbsd
 
 // Package kernel provides helper function to get, parse and compare kernel
 // versions for different platforms.

--- a/worker/baggageclaim/kernel/uname_unsupported.go
+++ b/worker/baggageclaim/kernel/uname_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !solaris
-// +build !linux,!solaris
 
 package kernel
 

--- a/worker/baggageclaim/uidgid/mapper_nonlinux.go
+++ b/worker/baggageclaim/uidgid/mapper_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package uidgid
 

--- a/worker/baggageclaim/uidgid/uidgid.go
+++ b/worker/baggageclaim/uidgid/uidgid.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package uidgid
 

--- a/worker/baggageclaim/volume/copy/copy_unix.go
+++ b/worker/baggageclaim/volume/copy/copy_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package copy
 

--- a/worker/baggageclaim/volume/driver/is_subvolume_stub.go
+++ b/worker/baggageclaim/volume/driver/is_subvolume_stub.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package driver
 

--- a/worker/baggageclaim/volume/stream_in_out_nonlinux.go
+++ b/worker/baggageclaim/volume/stream_in_out_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package volume
 

--- a/worker/runtime/backend_test.go
+++ b/worker/runtime/backend_test.go
@@ -239,7 +239,7 @@ func (s *BackendSuite) TestCreateMaxContainersReachedConcurrent() {
 	wg := sync.WaitGroup{}
 	wg.Add(numberOfRequests)
 
-	for i := 0; i < numberOfRequests; i++ {
+	for range numberOfRequests {
 		go func() {
 			_, err := backend.Create(minimumValidGdnSpec)
 			if err != nil {
@@ -286,7 +286,7 @@ func (s *BackendSuite) TestCreateContainerLockTimeout() {
 	wg := sync.WaitGroup{}
 	wg.Add(numberOfRequests)
 
-	for i := 0; i < numberOfRequests; i++ {
+	for range numberOfRequests {
 		go func() {
 			_, err := backend.Create(minimumValidGdnSpec)
 			if err != nil {

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -332,7 +332,7 @@ func (s *CNINetworkSuite) TestSetupHostNetwork() {
 		if testCase.expectedRuleSpec == nil {
 			// Test cases to check if correct chain is created
 			numOfCalls := s.iptables.CreateChainOrFlushIfExistsCallCount()
-			for i := 0; i < numOfCalls; i++ {
+			for i := range numOfCalls {
 				tablename, chainName := s.iptables.CreateChainOrFlushIfExistsArgsForCall(i)
 				if tablename == testCase.expectedTableName && chainName == testCase.expectedChainName {
 					foundExpected = true
@@ -342,7 +342,7 @@ func (s *CNINetworkSuite) TestSetupHostNetwork() {
 		} else {
 			// Test cases to check if correct rule is appended
 			numOfCalls := s.iptables.AppendRuleCallCount()
-			for i := 0; i < numOfCalls; i++ {
+			for i := range numOfCalls {
 				tablename, chainName, rulespec := s.iptables.AppendRuleArgsForCall(i)
 				if tablename == testCase.expectedTableName && chainName == testCase.expectedChainName && reflect.DeepEqual(rulespec, testCase.expectedRuleSpec) {
 					foundExpected = true

--- a/worker/runtime/container_test.go
+++ b/worker/runtime/container_test.go
@@ -5,6 +5,7 @@ package runtime_test
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"unicode/utf8"
 
 	"code.cloudfoundry.org/garden"
@@ -219,11 +220,8 @@ func (s *ContainerSuite) TestRunWithUserLookupSucceeds() {
 	userEnvVarSet := false
 	expectedEnvVar := "USER=some_user"
 
-	for _, envVar := range procSpec.Env {
-		if envVar == expectedEnvVar {
-			userEnvVarSet = true
-			break
-		}
+	if slices.Contains(procSpec.Env, expectedEnvVar) {
+		userEnvVarSet = true
 	}
 	s.True(userEnvVarSet)
 }
@@ -253,14 +251,7 @@ func (s *ContainerSuite) TestDoesNotOverwriteExistingPathInImage() {
 	_, _, procSpec, _ := s.containerdTask.ExecArgsForCall(0)
 	s.Equal(expectedUser, procSpec.User)
 
-	userEnvVarSet := false
-
-	for _, envVar := range procSpec.Env {
-		if envVar == expectedImagePath {
-			userEnvVarSet = true
-			break
-		}
-	}
+	userEnvVarSet := slices.Contains(procSpec.Env, expectedImagePath)
 	s.True(userEnvVarSet)
 }
 
@@ -285,11 +276,8 @@ func (s *ContainerSuite) TestRunWithRootUserHasSuperUserPath() {
 	userEnvVarSet := false
 	expectedEnvVar := runtime.SuperuserPath
 
-	for _, envVar := range procSpec.Env {
-		if envVar == expectedEnvVar {
-			userEnvVarSet = true
-			break
-		}
+	if slices.Contains(procSpec.Env, expectedEnvVar) {
+		userEnvVarSet = true
 	}
 	s.True(userEnvVarSet)
 }
@@ -315,11 +303,8 @@ func (s *ContainerSuite) TestRunWithNonRootUserHasUserPath() {
 	userEnvVarSet := false
 	expectedEnvVar := runtime.Path
 
-	for _, envVar := range procSpec.Env {
-		if envVar == expectedEnvVar {
-			userEnvVarSet = true
-			break
-		}
+	if slices.Contains(procSpec.Env, expectedEnvVar) {
+		userEnvVarSet = true
 	}
 	s.True(userEnvVarSet)
 }

--- a/worker/runtime/integration/sample/main.go
+++ b/worker/runtime/integration/sample/main.go
@@ -63,7 +63,7 @@ func httpGet(url string) {
 }
 
 func writeTenTimes(content string) {
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		fmt.Println(content)
 		time.Sleep(300 * time.Millisecond)
 	}

--- a/worker/runtime/resolvconf_parser.go
+++ b/worker/runtime/resolvconf_parser.go
@@ -38,7 +38,7 @@ func ParseHostResolveConf(path string) ([]string, error) {
 
 	var entries []string
 
-	for _, resolvEntry := range strings.Split(strings.TrimSpace(resolvContents), "\n") {
+	for resolvEntry := range strings.SplitSeq(strings.TrimSpace(resolvContents), "\n") {
 		if resolvEntry == "" {
 			continue
 		}

--- a/worker/signals_unix.go
+++ b/worker/signals_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package worker
 

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -179,9 +179,9 @@ func getGdnFlagsFromEnv(logger lager.Logger) []string {
 			"flag": flag,
 		})
 
-		vals := strings.Split(val, ",")
+		vals := strings.SplitSeq(val, ",")
 
-		for _, v := range vals {
+		for v := range vals {
 			flags = append(flags, "--"+flag, v)
 		}
 

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package workercmd
 

--- a/worker/workercmd/worker_nonlinux.go
+++ b/worker/workercmd/worker_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package workercmd
 


### PR DESCRIPTION
I ran `go fix` using the latest `go1.26` binary on the entire project. I broke things down into individual commits per package (mostly). I ran unit tests locally as I ran `go fix` to ensure things didn't suddenly break. Will also make it easier if we need to `git bisect` in the future.

This PR should have no functional impact. It's modernizing the codebase to use the latest go conventions. Most obvious is using `for range {}` instead of classic C-style incrementing for loops and replacing `interface{}` with `any`.