### PR TITLE
Add --containerd-allowed-device flag for cgroup device rules

### DIFF
--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -50,6 +50,7 @@ type GardenBackend struct {
 	requestTimeout time.Duration
 	createLock     TimeoutWithByPassLock
 	privilegedMode bespec.PrivilegedMode
+	allowedDevices []specs.LinuxDeviceCgroup
 }
 
 //counterfeiter:generate . UserNamespace
@@ -133,6 +134,12 @@ func WithPrivilegedMode(privilegedMode bespec.PrivilegedMode) GardenBackendOpt {
 func WithIOManager(ioManager IOManager) GardenBackendOpt {
 	return func(b *GardenBackend) {
 		b.ioManager = ioManager
+	}
+}
+
+func WithAllowedDevices(devices []specs.LinuxDeviceCgroup) GardenBackendOpt {
+	return func(b *GardenBackend) {
+		b.allowedDevices = devices
 	}
 }
 
@@ -346,7 +353,7 @@ func (b *GardenBackend) createContainer(ctx context.Context, gdnSpec garden.Cont
 		return nil, fmt.Errorf("getting uid and gid maps: %w", err)
 	}
 
-	oci, err := bespec.OciSpec(b.initBinPath, b.seccompProfile, b.seccompProfileFuse, b.ociHooks, b.privilegedMode, gdnSpec, maxUid, maxGid)
+	oci, err := bespec.OciSpec(b.initBinPath, b.seccompProfile, b.seccompProfileFuse, b.ociHooks, b.privilegedMode, gdnSpec, maxUid, maxGid, b.allowedDevices)
 	if err != nil {
 		return nil, fmt.Errorf("garden spec to oci spec: %w", err)
 	}

--- a/worker/runtime/spec/devices_test.go
+++ b/worker/runtime/spec/devices_test.go
@@ -1,0 +1,108 @@
+package spec_test
+
+import (
+	"testing"
+
+	"github.com/concourse/concourse/worker/runtime/spec"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DevicesSuite struct {
+	suite.Suite
+	*require.Assertions
+}
+
+func (s *DevicesSuite) TestParseDeviceRule() {
+	for _, tc := range []struct {
+		desc     string
+		input    string
+		expected specs.LinuxDeviceCgroup
+		succeeds bool
+	}{
+		{
+			desc:  "block device with wildcard minor",
+			input: "b 7:* rwm",
+			expected: specs.LinuxDeviceCgroup{
+				Allow: true, Type: "b", Major: int64Ptr(7), Minor: nil, Access: "rwm",
+			},
+			succeeds: true,
+		},
+		{
+			desc:  "char device with specific major and minor",
+			input: "c 10:237 rwm",
+			expected: specs.LinuxDeviceCgroup{
+				Allow: true, Type: "c", Major: int64Ptr(10), Minor: int64Ptr(237), Access: "rwm",
+			},
+			succeeds: true,
+		},
+		{
+			desc:  "wildcard type with wildcard major and minor",
+			input: "a *:* rwm",
+			expected: specs.LinuxDeviceCgroup{
+				Allow: true, Type: "a", Major: nil, Minor: nil, Access: "rwm",
+			},
+			succeeds: true,
+		},
+		{
+			desc:  "read-only access",
+			input: "c 1:3 r",
+			expected: specs.LinuxDeviceCgroup{
+				Allow: true, Type: "c", Major: int64Ptr(1), Minor: int64Ptr(3), Access: "r",
+			},
+			succeeds: true,
+		},
+		{
+			desc:     "invalid format - missing parts",
+			input:    "b 7:*",
+			succeeds: false,
+		},
+		{
+			desc:     "invalid device type",
+			input:    "x 7:* rwm",
+			succeeds: false,
+		},
+		{
+			desc:     "invalid major number",
+			input:    "b abc:* rwm",
+			succeeds: false,
+		},
+		{
+			desc:     "invalid minor number",
+			input:    "b 7:abc rwm",
+			succeeds: false,
+		},
+		{
+			desc:     "invalid access character",
+			input:    "b 7:* xyz",
+			succeeds: false,
+		},
+		{
+			desc:     "missing colon in major:minor",
+			input:    "b 7 rwm",
+			succeeds: false,
+		},
+	} {
+		s.T().Run(tc.desc, func(t *testing.T) {
+			actual, err := spec.ParseDeviceRule(tc.input)
+			if !tc.succeeds {
+				s.Error(err)
+				return
+			}
+			s.NoError(err)
+			s.Equal(tc.expected, actual)
+		})
+	}
+}
+
+func (s *DevicesSuite) TestParseAllowedDevices() {
+	devices, err := spec.ParseAllowedDevices([]string{"b 7:* rwm", "c 10:237 rwm"})
+	s.NoError(err)
+	s.Len(devices, 2)
+	s.Equal("b", devices[0].Type)
+	s.Equal("c", devices[1].Type)
+
+	_, err = spec.ParseAllowedDevices([]string{"b 7:* rwm", "invalid"})
+	s.Error(err)
+}

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -44,6 +44,7 @@ type ContainerdRuntime struct {
 	RequestTimeout     time.Duration         `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 	MaxContainers      int                   `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
 	PrivilegedMode     bespec.PrivilegedMode `long:"privileged-mode" default:"full" choice:"full" choice:"fuse-only" choice:"ignore" description:"How many privileges privileged containers get. full is equivalent to root on host. ignore means no extra privileges. fuse-only means enough to use fuse-overlayfs."`
+	AllowedDevices     []string              `long:"allowed-device" description:"Device cgroup rule to allow in containers, in the format 'type major:minor access' (e.g. 'b 7:* rwm' for loop devices). Can be specified multiple times."`
 
 	Network struct {
 		ExternalIP flag.IP `long:"external-ip" description:"IP address to use to reach container's mapped ports. Autodetected if not specified."`


### PR DESCRIPTION
## Changes proposed by this PR

The list of cgroup device rules allowed in containers was previously hardcoded. This makes it configurable via a repeatable CLI flag
(--containerd-allowed-device / CONCOURSE_CONTAINERD_ALLOWED_DEVICE) so operators can grant containers access to additional devices like loop devices.

Device rules use the format "type major:minor access", e.g.:
  --containerd-allowed-device "b 7:* rwm"
  --containerd-allowed-device "c 10:237 rwm"

## Release Note

Add --containerd-allowed-device to configure cgroup device rules
