### PR TITLE
Enable hot-reloading of ATC HTTPS listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ tags
 web/public/elm.js
 web/public/elm.min.js
 web/public/bundle.js
-web/public/*.bundle.js
+web/public/*.bundle.js*
 web/public/main.css
 docker-compose.override.yml
 *.coverprofile

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -2199,11 +2199,7 @@ func (cmd *RunCommand) isMTLSEnabled() bool {
 
 func (cmd *RunCommand) reloadTLSEnv(logger lager.Logger, dbConn db.DbConn) atctls.ConfigReloader {
 	return func() (*tls.Config, error) {
-		if cmd.isTLSEnabled() && !cmd.LetsEncrypt.Enable {
-			return cmd.tlsConfig(logger, dbConn)
-		}
-
-		return nil, nil
+		return cmd.tlsConfig(logger, dbConn)
 	}
 }
 

--- a/atc/tls/runner.go
+++ b/atc/tls/runner.go
@@ -1,0 +1,120 @@
+package tls
+
+import (
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"code.cloudfoundry.org/lager/v3"
+	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/http_server"
+)
+
+type ConfigReloader func() (*tls.Config, error)
+
+type ReloadableHTTPSListener struct {
+	address     string
+	handler     http.Handler
+	tlsConfig   *tls.Config
+	active      ifrit.Process
+	reloader    ConfigReloader
+	Interrupter chan os.Signal
+	logger      lager.Logger
+	activeMu    *sync.Mutex
+}
+
+func (r *ReloadableHTTPSListener) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+	r.logger.Info("start", lager.Data{"listen-addr": r.address})
+	if err := r.Start(); err != nil {
+		return err
+	}
+
+	close(ready)
+
+	for {
+		select {
+		case <-r.Interrupter:
+			r.logger.Info("reload-requested")
+			if err := r.Restart(); err != nil {
+				return err
+			}
+
+			continue
+		case <-signals:
+			r.Stop()
+			return nil
+		}
+	}
+}
+
+func (r *ReloadableHTTPSListener) Start() error {
+	if r.isStarted() {
+		return errors.New("tls listener already started")
+	}
+
+	r.activeMu.Lock()
+	defer r.activeMu.Unlock()
+	r.active = ifrit.Invoke(http_server.NewTLSServer(r.address, r.handler, r.tlsConfig))
+
+	select {
+	case <-r.active.Ready():
+		return nil
+	case err := <-r.active.Wait():
+		return err
+	}
+}
+
+func (r *ReloadableHTTPSListener) Stop() error {
+	var err error
+	r.activeMu.Lock()
+	defer r.activeMu.Unlock()
+	if r.active != nil {
+		r.active.Signal(os.Interrupt)
+		err = <-r.active.Wait()
+	}
+
+	r.active = nil
+	return err
+}
+
+func (r *ReloadableHTTPSListener) Restart() error {
+	var err error
+
+	r.Stop()
+	r.tlsConfig, err = r.reloader()
+	if err != nil {
+		return err
+	}
+
+	return r.Start()
+}
+
+func (r *ReloadableHTTPSListener) isStarted() bool {
+	r.activeMu.Lock()
+	defer r.activeMu.Unlock()
+
+	return r.active != nil
+}
+
+func NewReloadableListener(
+	address string, handler http.Handler, config *tls.Config,
+	reloader ConfigReloader, logger lager.Logger,
+) *ReloadableHTTPSListener {
+	r := &ReloadableHTTPSListener{
+		address:     address,
+		handler:     handler,
+		tlsConfig:   config,
+		reloader:    reloader,
+		logger:      logger,
+		Interrupter: make(chan os.Signal, 1),
+		activeMu:    new(sync.Mutex),
+	}
+
+	signal.Notify(r.Interrupter, syscall.SIGHUP)
+
+	return r
+}

--- a/atc/tls/runner.go
+++ b/atc/tls/runner.go
@@ -68,17 +68,15 @@ func (r *ReloadableHTTPSListener) Start() error {
 	}
 }
 
-func (r *ReloadableHTTPSListener) Stop() error {
-	var err error
+func (r *ReloadableHTTPSListener) Stop() {
 	r.activeMu.Lock()
 	defer r.activeMu.Unlock()
 	if r.active != nil {
 		r.active.Signal(os.Interrupt)
-		err = <-r.active.Wait()
+		<-r.active.Wait()
 	}
 
 	r.active = nil
-	return err
 }
 
 func (r *ReloadableHTTPSListener) Restart() error {

--- a/atc/tls/runner_test.go
+++ b/atc/tls/runner_test.go
@@ -1,0 +1,79 @@
+package tls_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"code.cloudfoundry.org/lager/v3/lagertest"
+	"github.com/concourse/concourse/atc"
+	. "github.com/concourse/concourse/atc/tls"
+	"github.com/madflojo/testcerts"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tedsuo/ifrit"
+)
+
+var _ = Describe("Runner", func() {
+	It("Can reload", func() {
+		reloaded := new(atomic.Bool)
+
+		tmpDir, err := os.MkdirTemp("", "")
+		Expect(err).ShouldNot(HaveOccurred())
+		defer func() {
+			os.RemoveAll(tmpDir)
+		}()
+
+		certFile, keyFile, err := testcerts.GenerateCertsToTempFile(tmpDir)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		initialConfig := atc.DefaultTLSConfig()
+
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		Expect(err).ShouldNot(HaveOccurred())
+		initialConfig.Certificates = []tls.Certificate{cert}
+
+		runner := NewReloadableListener("127.0.0.1:58008", testHandler(), initialConfig, reloader(certFile, keyFile, reloaded), lagertest.NewTestLogger("tls-reload"))
+		defer func() { runner.Stop() }()
+
+		process := ifrit.Invoke(runner)
+		<-process.Ready()
+
+		runner.Interrupter <- syscall.SIGHUP
+
+		// to let the reload actually happen
+		time.Sleep(time.Second)
+		Expect(reloaded.Load()).Should(BeTrue())
+	})
+})
+
+func reloader(oldCert, oldKey string, reloaded *atomic.Bool) ConfigReloader {
+	return func() (*tls.Config, error) {
+		GinkgoHelper()
+
+		reloaded.Store(true)
+
+		newCert, newKey, err := testcerts.GenerateCertsToTempFile("")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(newCert).ShouldNot(BeEquivalentTo(oldCert))
+		Expect(newKey).ShouldNot(BeEquivalentTo(oldKey))
+
+		newConfig := atc.DefaultTLSConfig()
+
+		cert, err := tls.LoadX509KeyPair(newCert, newKey)
+		Expect(err).ShouldNot(HaveOccurred())
+		newConfig.Certificates = []tls.Certificate{cert}
+
+		return newConfig, nil
+	}
+}
+
+func testHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Hello")
+	})
+}

--- a/atc/tls/tls_suite_test.go
+++ b/atc/tls/tls_suite_test.go
@@ -1,0 +1,13 @@
+package tls_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTls(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tls Suite")
+}

--- a/go.mod
+++ b/go.mod
@@ -259,6 +259,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/lib/pq v1.11.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
+	github.com/madflojo/testcerts v1.5.0 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/jackpal/gateway v1.1.1
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/klauspost/compress v1.18.4
+	github.com/madflojo/testcerts v1.5.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.12.1
@@ -259,7 +260,6 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/lib/pq v1.11.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/madflojo/testcerts v1.5.0 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1216,6 +1216,8 @@ github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
+github.com/madflojo/testcerts v1.5.0 h1:GhQllyAiGzXVZU+i8O/cQkPTHzN59RxMGtm3uETgXnU=
+github.com/madflojo/testcerts v1.5.0/go.mod h1:MW8sh39gLnkKh4K0Nc55AyHEDl9l/FBLDUsQhpmkuo0=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=


### PR DESCRIPTION
## Changes proposed by this PR

closes #9468 

_Make sure to follow all [PR requirements](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements)._

- Wraps `*github.com/tedsuo/ifrit/http_server.httpServer` for TLS calls with new `ifrit.Runner` -- `*github.com/concourse/concourse/atc/tls.ReloadableHTTPSListener` that can react to `syscall.SIGHUP` signals, reload the `*tls.Config`, and restart the https listener
- Adds tests for same
- Updates `atccmd.RunCommand` to use `tls.ReloadableHTTPSListener` instead of `http_server.NewTLSListener` and adds a method to reload the TLS config when the signal is received


## Notes to reviewer

Like the TSA hot-reloading, this doesn't make a ton of sense to use in the BOSH or K8s deployment model 

## Release Note

When running ATC in a self-managed way (like `systemd` or `docker`), sending a `SIGHUP` to the running process will now reload TLS configuration data for the web listener as well as the authorized keys for the TSA.
