### PR TITLE
Skip Lookup for batch tokens

### DIFF
--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -104,6 +104,12 @@ func (ac *APIClient) loginParams() map[string]any {
 	return loginParams
 }
 
+// isBatchToken checks if a token is a batch token based on its prefix.
+// Batch tokens start with "hvb." (current) or "b." (legacy) and cannot be renewed.
+func isBatchToken(token string) bool {
+	return strings.HasPrefix(token, "hvb.") || strings.HasPrefix(token, "b.")
+}
+
 // setClientToken Create a client with the given token and trigger an immediate renewal.
 func (ac *APIClient) setClientToken(token string, logger lager.Logger) (time.Duration, error) {
 	newClient, err := ac.clientWithToken(token)
@@ -185,26 +191,8 @@ func (ac *APIClient) Renew() (time.Duration, error) {
 
 	client := ac.client()
 
-	// Retrieve token information to determine if it is renewable before attempting renewal.
-	tokenInfo, err := client.Auth().Token().LookupSelf()
-	if err != nil {
-		logger.Error("failed-to-lookup-token", err)
-		return time.Second, err
-	}
-
-	if tokenInfo == nil {
-		err := fmt.Errorf("unexpected nil response from Vault during token lookup")
-		logger.Error("vault-token-info-missing", err)
-		return time.Second, err
-	}
-
-	isRenewable, err := tokenInfo.TokenIsRenewable()
-	if err != nil {
-		logger.Error("token-renewable-check-failed", err)
-		return time.Second, err
-	}
-
-	if !isRenewable {
+	// Check if current token is a batch token - they cannot be renewed
+	if isBatchToken(client.Token()) {
 		ac.renewable = false
 		logger.Info("token-not-renewable")
 		return time.Second, nil
@@ -383,3 +371,4 @@ func (ac *APIClient) health() (*vaultapi.HealthResponse, error) {
 	healthResponse, err := client.Sys().Health()
 	return healthResponse, err
 }
+


### PR DESCRIPTION
## Changes proposed by this PR

_Make sure to follow all [PR requirements](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements)._

* Skip renewal for batch tokens, but instead of look-up determine the token type by inspecting the value of the token

## Notes to reviewer

Currently if token type is batch we do a look-up that fails and we determine the token is not renewable and skip the renew call errors, but cause look-up errors in our case **~620K**, this aims to avoid that by inspecting the token itself, rather than causing server-side issues.
The method I used to check the token is defined in the server side go code of vault, but unfortunately are NOT available in the Vault API client library.

- [ ] - To Be Tested still
