### PR TITLE
Max timeout global configuration for tasks

### DIFF
--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -223,6 +223,7 @@ var _ = BeforeEach(func() {
 		credsManagers,
 		interceptTimeoutFactory,
 		time.Second,
+		time.Duration(0),
 		dbWall,
 		fakeClock,
 		dbSigningKeyFactory,

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -61,7 +61,7 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	warnings, errorMessages := configvalidate.Validate(config)
+	warnings, errorMessages := configvalidate.Validate(config, s.maxTaskTimeout)
 	if len(errorMessages) > 0 {
 		session.Info("ignoring-invalid-config", lager.Data{"errors": errorMessages})
 		HandleBadRequest(w, errorMessages...)

--- a/atc/api/configserver/server.go
+++ b/atc/api/configserver/server.go
@@ -1,25 +1,30 @@
 package configserver
 
 import (
+	"time"
+
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
 )
 
 type Server struct {
-	logger        lager.Logger
-	teamFactory   db.TeamFactory
-	secretManager creds.Secrets
+	logger         lager.Logger
+	teamFactory    db.TeamFactory
+	secretManager  creds.Secrets
+	maxTaskTimeout time.Duration
 }
 
 func NewServer(
 	logger lager.Logger,
 	teamFactory db.TeamFactory,
 	secretManager creds.Secrets,
+	maxTaskTimeout time.Duration,
 ) *Server {
 	return &Server{
-		logger:        logger,
-		teamFactory:   teamFactory,
-		secretManager: secretManager,
+		logger:         logger,
+		teamFactory:    teamFactory,
+		secretManager:  secretManager,
+		maxTaskTimeout: maxTaskTimeout,
 	}
 }

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -81,6 +81,7 @@ func NewHandler(
 	credsManagers creds.Managers,
 	interceptTimeoutFactory containerserver.InterceptTimeoutFactory,
 	interceptUpdateInterval time.Duration,
+	maxTaskTimeout time.Duration,
 	dbWall db.Wall,
 	clock clock.Clock,
 	dbSigningKeyFactory db.SigningKeyFactory,
@@ -101,7 +102,7 @@ func NewHandler(
 
 	versionServer := versionserver.NewServer(logger, externalURL)
 	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, externalURL)
-	configServer := configserver.NewServer(logger, dbTeamFactory, secretManager)
+	configServer := configserver.NewServer(logger, dbTeamFactory, secretManager, maxTaskTimeout)
 	ccServer := ccserver.NewServer(logger, dbTeamFactory, externalURL)
 	workerServer := workerserver.NewServer(logger, workerTeamFactory, dbWorkerFactory)
 	logLevelServer := loglevelserver.NewServer(logger, sink)

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -278,6 +278,7 @@ type RunCommand struct {
 	DefaultGetTimeout  time.Duration `long:"default-get-timeout" description:"Default timeout of get steps"`
 	DefaultPutTimeout  time.Duration `long:"default-put-timeout" description:"Default timeout of put steps"`
 	DefaultTaskTimeout time.Duration `long:"default-task-timeout" description:"Default timeout of task steps"`
+	MaxTaskTimeout     time.Duration `long:"max-task-timeout" description:"Maximum allowed timeout for task steps"`
 
 	NumGoroutineThreshold int `long:"num-goroutine-threshold" description:"When number of goroutines reaches to this threshold, then slow down current ATC. This helps distribute workloads across ATCs evenly."`
 
@@ -1856,6 +1857,7 @@ func (cmd *RunCommand) constructEngine(
 				cmd.DefaultGetTimeout,
 				cmd.DefaultPutTimeout,
 				cmd.DefaultTaskTimeout,
+				cmd.MaxTaskTimeout,
 			),
 			cmd.ExternalURL.String(),
 			rateLimiter,
@@ -2143,6 +2145,7 @@ func (cmd *RunCommand) constructAPIHandler(
 		credsManagers,
 		containerserver.NewInterceptTimeoutFactory(cmd.InterceptIdleTimeout),
 		time.Minute,
+		cmd.MaxTaskTimeout,
 		dbWall,
 		clock.NewClock(),
 		dbSigningKeyFactory,

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/creds"
@@ -39,7 +40,7 @@ func (l location) Identifier(name string) string {
 	return fmt.Sprintf("%s.%s", l.section, name)
 }
 
-func Validate(c atc.Config) ([]atc.ConfigWarning, []string) {
+func Validate(c atc.Config, maxTaskTimeout time.Duration) ([]atc.ConfigWarning, []string) {
 	warnings := []atc.ConfigWarning{}
 	errorMessages := []string{}
 
@@ -75,7 +76,7 @@ func Validate(c atc.Config) ([]atc.ConfigWarning, []string) {
 	}
 	warnings = append(warnings, varSourcesWarnings...)
 
-	jobWarnings, jobsErr := validateJobs(c)
+	jobWarnings, jobsErr := validateJobs(c, maxTaskTimeout)
 	if jobsErr != nil {
 		errorMessages = append(errorMessages, formatErr("jobs", jobsErr))
 	}
@@ -321,7 +322,7 @@ func usedResources(c atc.Config) map[string]bool {
 	return usedResources
 }
 
-func validateJobs(c atc.Config) ([]atc.ConfigWarning, error) {
+func validateJobs(c atc.Config, maxTaskTimeout time.Duration) ([]atc.ConfigWarning, error) {
 	var errorMessages []string
 	var warnings []atc.ConfigWarning
 
@@ -405,7 +406,7 @@ func validateJobs(c atc.Config) ([]atc.ConfigWarning, error) {
 
 		step := job.Step()
 
-		validator := atc.NewStepValidator(c, []string{identifier, ".plan"})
+		validator := atc.NewStepValidator(c, []string{identifier, ".plan"}, maxTaskTimeout)
 
 		_ = validator.Validate(step)
 

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -3,6 +3,7 @@ package configvalidate_test
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/configvalidate"
@@ -16,9 +17,10 @@ import (
 
 var _ = Describe("ValidateConfig", func() {
 	var (
-		config        atc.Config
-		warnings      []atc.ConfigWarning
-		errorMessages []string
+		config         atc.Config
+		warnings       []atc.ConfigWarning
+		errorMessages  []string
+		maxTaskTimeout time.Duration
 	)
 
 	BeforeEach(func() {
@@ -128,7 +130,11 @@ var _ = Describe("ValidateConfig", func() {
 	})
 
 	JustBeforeEach(func() {
-		warnings, errorMessages = configvalidate.Validate(config)
+		warnings, errorMessages = configvalidate.Validate(config, maxTaskTimeout)
+	})
+
+	BeforeEach(func() {
+		maxTaskTimeout = time.Duration(0)
 	})
 
 	Context("when the config is valid", func() {
@@ -1773,6 +1779,45 @@ var _ = Describe("ValidateConfig", func() {
 				It("throws a validation error", func() {
 					Expect(errorMessages).To(HaveLen(1))
 					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].timeout: invalid duration 'nope'"))
+				})
+			})
+
+			Context("when a task has a timeout that exceeds the max task timeout", func() {
+				BeforeEach(func() {
+					maxTaskTimeout = time.Hour
+					job.PlanSequence = append(job.PlanSequence, atc.Step{
+						Config: &atc.TaskStep{
+							Name:       "some-task",
+							ConfigPath: "some/config/path.yml",
+							Timeout:    "2h",
+						},
+					})
+
+					config.Jobs = append(config.Jobs, job)
+				})
+
+				It("throws a validation error", func() {
+					Expect(errorMessages).To(HaveLen(1))
+					Expect(errorMessages[0]).To(ContainSubstring("timeout '2h' exceeds maximum allowed task timeout '1h0m0s'"))
+				})
+			})
+
+			Context("when a task has a timeout within the max task timeout", func() {
+				BeforeEach(func() {
+					maxTaskTimeout = time.Hour
+					job.PlanSequence = append(job.PlanSequence, atc.Step{
+						Config: &atc.TaskStep{
+							Name:       "some-task",
+							ConfigPath: "some/config/path.yml",
+							Timeout:    "30m",
+						},
+					})
+
+					config.Jobs = append(config.Jobs, job)
+				})
+
+				It("does not return an error", func() {
+					Expect(errorMessages).To(HaveLen(0))
 				})
 			})
 

--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -30,6 +30,7 @@ type coreStepFactory struct {
 	defaultGetTimeout     time.Duration
 	defaultPutTimeout     time.Duration
 	defaultTaskTimeout    time.Duration
+	maxTaskTimeout        time.Duration
 }
 
 func NewCoreStepFactory(
@@ -48,6 +49,7 @@ func NewCoreStepFactory(
 	defaultGetTimeout time.Duration,
 	defaultPutTimeout time.Duration,
 	defaultTaskTimeout time.Duration,
+	maxTaskTimeout time.Duration,
 ) CoreStepFactory {
 	return &coreStepFactory{
 		pool:                  pool,
@@ -65,6 +67,7 @@ func NewCoreStepFactory(
 		defaultGetTimeout:     defaultGetTimeout,
 		defaultPutTimeout:     defaultPutTimeout,
 		defaultTaskTimeout:    defaultTaskTimeout,
+		maxTaskTimeout:        maxTaskTimeout,
 	}
 }
 
@@ -191,6 +194,7 @@ func (factory *coreStepFactory) TaskStep(
 		factory.streamer,
 		delegateFactory,
 		factory.defaultTaskTimeout,
+		factory.maxTaskTimeout,
 	)
 
 	taskStep = exec.LogError(taskStep, delegateFactory)
@@ -213,6 +217,7 @@ func (factory *coreStepFactory) SetPipelineStep(
 		factory.teamFactory,
 		factory.buildFactory,
 		factory.streamer,
+		factory.maxTaskTimeout,
 	)
 
 	spStep = exec.LogError(spStep, delegateFactory)

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -296,7 +296,7 @@ func (step *CheckStep) runCheck(
 		)
 	}()
 
-	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultCheckTimeout)
+	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultCheckTimeout, time.Duration(0))
 	if err != nil {
 		return nil, runtime.ProcessResult{}, err
 	}

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -481,7 +481,7 @@ func (step *GetStep) performGetAndInitCache(
 		}()
 	}
 
-	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultGetTimeout)
+	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultGetTimeout, time.Duration(0))
 	if err != nil {
 		return nil, resource.VersionResult{}, runtime.ProcessResult{}, err
 	}

--- a/atc/exec/maybe_timeout.go
+++ b/atc/exec/maybe_timeout.go
@@ -7,7 +7,7 @@ import (
 )
 
 func MaybeTimeout(ctx context.Context, timeoutStr string, defaultTimeout time.Duration, maxTimeout time.Duration) (context.Context, func(), error) {
-	if timeoutStr == "" && defaultTimeout == 0 {
+	if timeoutStr == "" && defaultTimeout == 0 && maxTimeout == 0 {
 		return ctx, func() {}, nil
 	}
 
@@ -20,8 +20,12 @@ func MaybeTimeout(ctx context.Context, timeoutStr string, defaultTimeout time.Du
 		}
 	}
 
-	if maxTimeout > 0 && timeout > maxTimeout {
+	if maxTimeout > 0 && (timeout == 0 || timeout > maxTimeout) {
 		timeout = maxTimeout
+	}
+
+	if timeout == 0 {
+		return ctx, func() {}, nil
 	}
 
 	processCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/atc/exec/maybe_timeout.go
+++ b/atc/exec/maybe_timeout.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func MaybeTimeout(ctx context.Context, timeoutStr string, defaultTimeout time.Duration) (context.Context, func(), error) {
+func MaybeTimeout(ctx context.Context, timeoutStr string, defaultTimeout time.Duration, maxTimeout time.Duration) (context.Context, func(), error) {
 	if timeoutStr == "" && defaultTimeout == 0 {
 		return ctx, func() {}, nil
 	}
@@ -18,6 +18,10 @@ func MaybeTimeout(ctx context.Context, timeoutStr string, defaultTimeout time.Du
 		if err != nil {
 			return nil, nil, fmt.Errorf("parse timeout: %w", err)
 		}
+	}
+
+	if maxTimeout > 0 && timeout > maxTimeout {
+		timeout = maxTimeout
 	}
 
 	processCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -203,7 +203,7 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 
 	delegate.SelectedWorker(logger, worker.Name())
 
-	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultPutTimeout)
+	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultPutTimeout, time.Duration(0))
 	if err != nil {
 		return false, err
 	}

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"strings"
+	"time"
 
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagerctx"
@@ -33,6 +34,7 @@ type SetPipelineStep struct {
 	teamFactory     db.TeamFactory
 	buildFactory    db.BuildFactory
 	streamer        Streamer
+	maxTaskTimeout  time.Duration
 }
 
 func NewSetPipelineStep(
@@ -43,6 +45,7 @@ func NewSetPipelineStep(
 	teamFactory db.TeamFactory,
 	buildFactory db.BuildFactory,
 	streamer Streamer,
+	maxTaskTimeout time.Duration,
 ) Step {
 	return &SetPipelineStep{
 		planID:          planID,
@@ -52,6 +55,7 @@ func NewSetPipelineStep(
 		teamFactory:     teamFactory,
 		buildFactory:    buildFactory,
 		streamer:        streamer,
+		maxTaskTimeout:  maxTaskTimeout,
 	}
 }
 
@@ -120,7 +124,7 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 		return false, nil
 	}
 
-	warnings, errors := configvalidate.Validate(atcConfig)
+	warnings, errors := configvalidate.Validate(atcConfig, step.maxTaskTimeout)
 	for _, warning := range warnings {
 		fmt.Fprintf(stderr, "WARNING: %s\n", warning.Message)
 	}

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -244,6 +245,7 @@ jobs:
 			fakeTeamFactory,
 			fakeBuildFactory,
 			fakeStreamer,
+			time.Duration(0),
 		)
 
 		stepOk, stepErr = spStep.Run(ctx, state)

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -96,6 +96,7 @@ type TaskStep struct {
 	streamer           Streamer
 	delegateFactory    TaskDelegateFactory
 	defaultTaskTimeout time.Duration
+	maxTaskTimeout     time.Duration
 }
 
 func NewTaskStep(
@@ -109,6 +110,7 @@ func NewTaskStep(
 	streamer Streamer,
 	delegateFactory TaskDelegateFactory,
 	defaultTaskTimeout time.Duration,
+	maxTaskTimeout time.Duration,
 ) Step {
 	return &TaskStep{
 		planID:             planID,
@@ -121,6 +123,7 @@ func NewTaskStep(
 		streamer:           streamer,
 		delegateFactory:    delegateFactory,
 		defaultTaskTimeout: defaultTaskTimeout,
+		maxTaskTimeout:     maxTaskTimeout,
 	}
 }
 
@@ -286,7 +289,7 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 		)
 	}()
 
-	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultTaskTimeout)
+	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultTaskTimeout, step.maxTaskTimeout)
 	if err != nil {
 		return false, err
 	}

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -71,6 +71,7 @@ var _ = Describe("TaskStep", func() {
 		expectedOwner = db.NewBuildStepContainerOwner(stepMetadata.BuildID, planID, stepMetadata.TeamID)
 
 		defaultTaskTimeout time.Duration = 0
+		maxTaskTimeout     time.Duration = 0
 	)
 
 	BeforeEach(func() {
@@ -125,6 +126,7 @@ var _ = Describe("TaskStep", func() {
 			fakeStreamer,
 			fakeDelegateFactory,
 			defaultTaskTimeout,
+			maxTaskTimeout,
 		)
 
 		stepOk, stepErr = taskStep.Run(ctx, state)
@@ -354,6 +356,44 @@ var _ = Describe("TaskStep", func() {
 			})
 		})
 
+		Context("when there is a max task timeout", func() {
+			BeforeEach(func() {
+				maxTaskTimeout = time.Minute * 30
+			})
+
+			It("enforces it on the task", func() {
+				t, ok := chosenContainer.ContextOfRun().Deadline()
+				Expect(ok).To(BeTrue())
+				Expect(t).To(BeTemporally("~", time.Now().Add(time.Minute*30), time.Minute))
+			})
+		})
+
+		Context("when the plan specifies a timeout exceeding the max task timeout", func() {
+			BeforeEach(func() {
+				maxTaskTimeout = time.Minute * 30
+				taskPlan.Timeout = "1h"
+			})
+
+			It("caps the timeout to the max task timeout", func() {
+				t, ok := chosenContainer.ContextOfRun().Deadline()
+				Expect(ok).To(BeTrue())
+				Expect(t).To(BeTemporally("~", time.Now().Add(time.Minute*30), time.Minute))
+			})
+		})
+
+		Context("when the plan specifies a timeout within the max task timeout", func() {
+			BeforeEach(func() {
+				maxTaskTimeout = time.Hour
+				taskPlan.Timeout = "30m"
+			})
+
+			It("enforces the plan's timeout on the task step", func() {
+				t, ok := chosenContainer.ContextOfRun().Deadline()
+				Expect(ok).To(BeTrue())
+				Expect(t).To(BeTemporally("~", time.Now().Add(time.Minute*30), time.Minute))
+			})
+		})
+
 		Context("when rootfs uri is set instead of image resource", func() {
 			BeforeEach(func() {
 				taskPlan.Config.RootfsURI = "some-image"
@@ -370,6 +410,7 @@ var _ = Describe("TaskStep", func() {
 		Context("when tracing is enabled", func() {
 			BeforeEach(func() {
 				defaultTaskTimeout = 0
+				maxTaskTimeout = 0
 				exporter := tracetest.NewInMemoryExporter()
 				tp := trace.NewTracerProvider(trace.WithSyncer(exporter))
 				tracing.ConfigureTraceProvider(tp)

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -23,8 +23,9 @@ type StepValidator struct {
 	// This field will be populated after visiting the step.
 	Errors []string
 
-	config  Config
-	context []string
+	config         Config
+	context        []string
+	maxTaskTimeout time.Duration
 
 	seenGetName    scope
 	localVarScopes []scope
@@ -40,10 +41,11 @@ type scope map[string]bool
 // The context argument contains the initial context used to annotate error and
 // warning messages. For example, []string{"jobs(foo)", ".plan"} will result in
 // errors like 'jobs(foo).plan.task(bar): blah blah'.
-func NewStepValidator(config Config, context []string) *StepValidator {
+func NewStepValidator(config Config, context []string, maxTaskTimeout time.Duration) *StepValidator {
 	return &StepValidator{
 		config:         config,
 		context:        context,
+		maxTaskTimeout: maxTaskTimeout,
 		seenGetName:    scope{},
 		localVarScopes: []scope{{}},
 	}
@@ -93,6 +95,15 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 			Type:    "pipeline",
 			Message: validator.annotate("specifies `hermetic:` only works against worker containerd runtime"),
 		})
+	}
+
+	if plan.Timeout != "" && validator.maxTaskTimeout != 0 {
+		timeout, err := time.ParseDuration(plan.Timeout)
+		if err != nil {
+			validator.recordErrorf("invalid timeout '%s'", plan.Timeout)
+		} else if timeout > validator.maxTaskTimeout {
+			validator.recordErrorf("timeout '%s' exceeds maximum allowed task timeout '%s'", plan.Timeout, validator.maxTaskTimeout)
+		}
 	}
 
 	if plan.Config != nil {

--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -61,7 +62,7 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 		return err
 	}
 
-	configWarnings, _ := configvalidate.Validate(newConfig)
+	configWarnings, _ := configvalidate.Validate(newConfig, time.Duration(0))
 	for _, w := range configWarnings {
 		atcConfig.CommandWarnings = append(atcConfig.CommandWarnings, concourse.ConfigWarning{
 			Type:    w.Type,

--- a/fly/commands/internal/validatepipelinehelpers/validate.go
+++ b/fly/commands/internal/validatepipelinehelpers/validate.go
@@ -3,6 +3,7 @@ package validatepipelinehelpers
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/concourse/concourse/atc"
 
@@ -30,7 +31,7 @@ func Validate(yamlTemplate templatehelpers.YamlTemplateWithParams, strict bool, 
 		return err
 	}
 
-	warnings, errorMessages := configvalidate.Validate(unmarshalledTemplate)
+	warnings, errorMessages := configvalidate.Validate(unmarshalledTemplate, time.Duration(0))
 
 	if len(warnings) > 0 {
 		configWarnings := make([]concourse.ConfigWarning, len(warnings))


### PR DESCRIPTION
## Changes proposed by this PR

closes #9480 

* [x] Introduce a new configuration option - `CONCOURSE_MAX_TASK_TIMEOUT`
* [x] Validation when user sets a pipeline
* [x] Tests

<img width="1075" height="111" alt="max_timeout" src="https://github.com/user-attachments/assets/39c9b6d4-d18c-4205-b44a-1b788a8e46df" />


## Notes to reviewer

- Followed the same code pattern written for `CONCOURSE_DEFAULT_TASK_TIMEOUT`.
- If set to zero, it will be disabled.

## Release Note

Operators now can configure a maximum allowed timeout for tasks. Any pipeline that sets a timeout which exceeds the maximum allowed will be rejected.
