### PR TITLE
return BreakoutError when symlink does not link to a path inside the destination

### DIFF
--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -79,6 +79,12 @@ func ExtractEntry(header *tar.Header, dest string, input io.Reader, chown bool) 
 		}
 
 	case tar.TypeSymlink:
+		targetPath := filepath.Join(dest, header.Linkname)
+
+		if !strings.HasPrefix(targetPath, dest) {
+			return BreakoutError{header.Name, header.Linkname}
+		}
+
 		err := os.Symlink(header.Linkname, filePath)
 		if err != nil {
 			return err

--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -1,11 +1,13 @@
 package tarfs_test
 
 import (
+	"archive/tar"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/concourse/concourse/go-archive/archivetest"
@@ -146,5 +148,55 @@ var _ = Describe("Extract", func() {
 		})
 
 		It("extracts the TGZ's files, generating directories, and honoring file permissions and symlinks", extractionTest)
+	})
+})
+
+var _ = Describe("ExtractEntry", func() {
+	var dest string
+
+	BeforeEach(func() {
+		var err error
+		dest, err = os.MkdirTemp("", "extract-entry")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(dest)
+	})
+
+	It("returns a BreakoutError when a hard link points outside the destination", func() {
+		header := &tar.Header{
+			Typeflag: tar.TypeLink,
+			Name:     "malicious-link",
+			Linkname: "../outside-file",
+		}
+
+		err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
+		Expect(err).To(HaveOccurred())
+
+		var breakoutErr tarfs.BreakoutError
+		Expect(err).To(BeAssignableToTypeOf(breakoutErr))
+
+		breakoutErr = err.(tarfs.BreakoutError)
+		Expect(breakoutErr.HeaderName).To(Equal("malicious-link"))
+		Expect(breakoutErr.LinkName).To(Equal("../outside-file"))
+	})
+
+	It("returns a BreakoutError when a symlink points outside the destination", func() {
+		header := &tar.Header{
+			Typeflag: tar.TypeSymlink,
+			Name:     "malicious-link",
+			Linkname: "../outside-file",
+		}
+
+		err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
+		Expect(err).To(HaveOccurred())
+
+		var breakoutErr tarfs.BreakoutError
+		Expect(err).To(BeAssignableToTypeOf(breakoutErr))
+
+		breakoutErr = err.(tarfs.BreakoutError)
+		Expect(breakoutErr.HeaderName).To(Equal("malicious-link"))
+		Expect(breakoutErr.LinkName).To(Equal("../outside-file"))
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

Issue reported to security@concourse-ci.org by @SnailSploit

Added tests to verify this behaviour for hard links and symlinks.

Thankfully it is not easy to exploit this code path within Concourse. This code gets called in two scenarios:

- When fly downloads outputs from a `fly execute --output` build
- When baggageclaim streams a volume in (Windows/macOS workers only)

Neither case has an easy path to exploit.

In the first case, you'd have to trick the user into running a malicious Task config which would create an output volume with the goal of overwriting a specific file on the users' system. This would require the attacker knowing the directory the user will run `fly execute` in and what file the attacker wants to overwrite. The user also has to include the correct output in `--output` in the `fly execute` command. If the user can be socially engineered to run an arbitrary task on their Concourse system, the attacker could just as easily get the user to execute a simple bash script instead. The external CI system is also potentially a better target than the users' system.

In the second case, you'd have to already have access to run arbitrary workloads on the Concourse worker or some way to craft a volume that will then be streamed to a Windows or macOS worker. This would involve intimiate knowledge of the target pipeline and would likely mean the attacker can modify the pipeline to do whatever they want, which would make this exploit moot to the attacker.
