### PR TITLE
Add --team flag to fly pipelines command

### DIFF
--- a/fly/commands/pipelines.go
+++ b/fly/commands/pipelines.go
@@ -1,14 +1,17 @@
 package commands
 
 import (
+	"errors"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
+	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/fatih/color"
 )
 
@@ -16,6 +19,7 @@ type PipelinesCommand struct {
 	All             bool `short:"a"  long:"all" description:"Show pipelines across all teams"`
 	IncludeArchived bool `long:"include-archived" description:"Show archived pipelines"`
 	Json            bool `long:"json" description:"Print command result as JSON"`
+	Team            flaghelpers.TeamFlag `long:"team" description:"Name of the team to which the pipelines belong, if different from the target default"`
 }
 
 func (command *PipelinesCommand) Execute([]string) error {
@@ -29,12 +33,21 @@ func (command *PipelinesCommand) Execute([]string) error {
 		return err
 	}
 
+	if command.All && command.Team.Name() != "" {
+		return errors.New("Cannot specify both --all and --team")
+	}
+
 	var unfilteredPipelines []atc.Pipeline
 
 	if command.All {
 		unfilteredPipelines, err = target.Client().ListPipelines()
 	} else {
-		unfilteredPipelines, err = target.Team().ListPipelines()
+		var team concourse.Team
+		team, err = command.Team.LoadTeam(target)
+		if err != nil {
+			return err
+		}
+		unfilteredPipelines, err = team.ListPipelines()
 	}
 	if err != nil {
 		return err

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -156,6 +156,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-j", "pipeline/job", "-s", "some-task-step", "--team", nonExistentTeam)),
 			Entry("rename-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", "brandNew", "--team", nonExistentTeam)),
+			Entry("pipelines command returns an error",
+				exec.Command(flyPath, "-t", targetName, "pipelines", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -222,6 +224,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-j", "pipeline/job", "-s", "some-task-step", "--team", otherTeam)),
 			Entry("rename-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", "brandNew", "--team", otherTeam)),
+			Entry("pipelines command returns an error",
+				exec.Command(flyPath, "-t", targetName, "pipelines", "--team", otherTeam)),
 		)
 	})
 })

--- a/fly/integration/pipelines_test.go
+++ b/fly/integration/pipelines_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"net/http"
 	"os"
 	"os/exec"
 	"time"
@@ -114,7 +115,31 @@ var _ = Describe("pipelines", func() {
 				Expect(sess.Out).ToNot(gbytes.Say("archived-pipeline"))
 			})
 		})
+		Context("when --team is specified", func() {
+			BeforeEach(func() {
+				flyCmd.Args = append(flyCmd.Args, "--team", "other-team")
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{Name: "other-team"}),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/other-team/pipelines"),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, []atc.Pipeline{
+							{ID: 10, Name: "other-team-pipeline", Paused: false, Public: false, LastUpdated: 2},
+						}),
+					),
+				)
+			})
 
+			It("prints the pipelines for the specified team", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(sess).Should(gexec.Exit(0))
+
+				Expect(sess.Out).To(gbytes.Say("other-team-pipeline"))
+			})
+		})
 		Context("when --all is specified", func() {
 			BeforeEach(func() {
 				flyCmd.Args = append(flyCmd.Args, "--all")


### PR DESCRIPTION
## Changes proposed by this PR

Part of #5215

- Adds `--team` flag to `fly pipelines` to list pipelines for a team other than the target default
- Rejects --all and --team when used together