### PR TITLE
Opaque User Data Feature (Issue #8426)

### DIFF
--- a/atc/config.go
+++ b/atc/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Prototypes    Prototypes       `json:"prototypes,omitempty"`
 	Jobs          JobConfigs       `json:"jobs,omitempty"`
 	Display       *DisplayConfig   `json:"display,omitempty"`
+	UserData      any              `json:"user_data,omitempty"`
 }
 
 func UnmarshalConfig(payload []byte, config any) error {
@@ -37,6 +38,7 @@ func UnmarshalConfig(payload []byte, config any) error {
 		Prototypes    any `json:"prototypes,omitempty"`
 		Jobs          any `json:"jobs,omitempty"`
 		Display       any `json:"display,omitempty"`
+		UserData      any `json:"user_data,omitempty"`
 	}
 
 	var stripped skeletonConfig

--- a/atc/config_diff.go
+++ b/atc/config_diff.go
@@ -242,6 +242,40 @@ func diffDisplay(oldDisplay, newDisplay *DisplayConfig) (DisplayDiff, bool) {
 	}, practicallyDifferent(oldDisplay, newDisplay)
 }
 
+type UserDataDiff struct {
+	Before any
+	After  any
+}
+
+func (diff UserDataDiff) Render(to io.Writer) {
+	label := "user_data"
+	if diff.Before != nil && diff.After != nil {
+		fmt.Fprintf(to, ansi.Color("%s has changed:", "yellow")+"\n", label)
+		payloadA, _ := yaml.Marshal(diff.Before)
+		payloadB, _ := yaml.Marshal(diff.After)
+		renderDiff(to, string(payloadA), string(payloadB))
+	} else if diff.Before != nil {
+		fmt.Fprintf(to, ansi.Color("%s has been removed:", "yellow")+"\n", label)
+		payloadA, _ := yaml.Marshal(diff.Before)
+		renderDiff(to, string(payloadA), "")
+	} else {
+		fmt.Fprintf(to, ansi.Color("%s has been added:", "yellow")+"\n", label)
+		payloadB, _ := yaml.Marshal(diff.After)
+		renderDiff(to, "", string(payloadB))
+	}
+}
+
+func diffUserData(oldUserData, newUserData any) (UserDataDiff, bool) {
+	if oldUserData == nil && newUserData == nil {
+		return UserDataDiff{}, false
+	}
+
+	return UserDataDiff{
+		Before: oldUserData,
+		After:  newUserData,
+	}, practicallyDifferent(oldUserData, newUserData)
+}
+
 func renderDiff(to io.Writer, a, b string) {
 	diffs := difflib.Diff(strings.Split(a, "\n"), strings.Split(b, "\n"))
 	indent := gexec.NewPrefixedWriter("\b\b", to)
@@ -337,6 +371,12 @@ func (c Config) Diff(out io.Writer, newConfig Config) bool {
 	if diff {
 		diffExists = true
 		displayDiff.Render(indent)
+	}
+
+	userDataDiff, udDiff := diffUserData(c.UserData, newConfig.UserData)
+	if udDiff {
+		diffExists = true
+		userDataDiff.Render(indent)
 	}
 
 	return diffExists

--- a/atc/config_diff_test.go
+++ b/atc/config_diff_test.go
@@ -216,4 +216,87 @@ var _ = Describe("Config diff", func() {
 			})
 		})
 	})
+
+	Describe("user_data config", func() {
+		var userData any
+		BeforeEach(func() {
+			userData = map[string]any{
+				"organization": "Platform Team",
+				"contact":      "platform@example.com",
+			}
+		})
+
+		Context("when there is no user_data", func() {
+			It("does not print anything about user_data", func() {
+				buffer := NewBuffer()
+				diff := Config{}.Diff(buffer, Config{})
+				Expect(diff).To(BeFalse())
+				Consistently(buffer).ShouldNot(Say("user_data"))
+			})
+		})
+
+		Context("when user_data is added", func() {
+			It("says user_data has been added", func() {
+				buffer := NewBuffer()
+				newConfig := Config{
+					UserData: userData,
+				}
+				diff := Config{}.Diff(buffer, newConfig)
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("user_data has been added:"))
+				Eventually(buffer).Should(Say(`\+.*organization: Platform Team`))
+			})
+		})
+
+		Context("when user_data is removed", func() {
+			It("says user_data has been removed", func() {
+				buffer := NewBuffer()
+				oldConfig := Config{
+					UserData: userData,
+				}
+				diff := oldConfig.Diff(buffer, Config{})
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("user_data has been removed:"))
+				Eventually(buffer).Should(Say(`-.*organization: Platform Team`))
+			})
+		})
+
+		Context("when user_data has not changed", func() {
+			It("reports no changes", func() {
+				oldConfig := Config{
+					UserData: userData,
+				}
+				newConfig := Config{
+					UserData: map[string]any{
+						"organization": "Platform Team",
+						"contact":      "platform@example.com",
+					},
+				}
+
+				diff := oldConfig.Diff(GinkgoWriter, newConfig)
+				Expect(diff).To(BeFalse())
+			})
+		})
+
+		Context("when user_data has changed", func() {
+			It("shows the diff", func() {
+				oldConfig := Config{
+					UserData: userData,
+				}
+				newConfig := Config{
+					UserData: map[string]any{
+						"organization": "New Team",
+						"contact":      "new-team@example.com",
+					},
+				}
+
+				buffer := NewBuffer()
+				diff := oldConfig.Diff(buffer, newConfig)
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("user_data has changed:"))
+				Eventually(buffer).Should(Say(`-.*organization: Platform Team`))
+				Eventually(buffer).Should(Say(`\+.*organization: New Team`))
+			})
+		})
+	})
 })

--- a/atc/config_test.go
+++ b/atc/config_test.go
@@ -223,4 +223,227 @@ var _ = Describe("Config", func() {
 			})
 		})
 	})
+
+	Describe("UnmarshalConfig with UserData", func() {
+		Context("when config has user_data as a map", func() {
+			It("preserves the user_data field", func() {
+				configYAML := []byte(`
+jobs:
+  - name: test-job
+    plan:
+      - task: test
+        config:
+          platform: linux
+          run:
+            path: echo
+user_data:
+  organization: Platform Team
+  contact: platform@example.com
+  labels:
+    - production
+    - critical
+`)
+				var config Config
+				err := UnmarshalConfig(configYAML, &config)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(config.UserData).NotTo(BeNil())
+				userData, ok := config.UserData.(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(userData["organization"]).To(Equal("Platform Team"))
+				Expect(userData["contact"]).To(Equal("platform@example.com"))
+				labels, ok := userData["labels"].([]any)
+				Expect(ok).To(BeTrue())
+				Expect(labels).To(HaveLen(2))
+				Expect(labels[0]).To(Equal("production"))
+				Expect(labels[1]).To(Equal("critical"))
+			})
+		})
+
+		Context("when config has user_data as a string", func() {
+			It("preserves the user_data field", func() {
+				configYAML := []byte(`
+jobs:
+  - name: test-job
+    plan:
+      - task: test
+        config:
+          platform: linux
+          run:
+            path: echo
+user_data: "simple string metadata"
+`)
+				var config Config
+				err := UnmarshalConfig(configYAML, &config)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(config.UserData).To(Equal("simple string metadata"))
+			})
+		})
+
+		Context("when config has user_data as an array", func() {
+			It("preserves the user_data field", func() {
+				configYAML := []byte(`
+jobs:
+  - name: test-job
+    plan:
+      - task: test
+        config:
+          platform: linux
+          run:
+            path: echo
+user_data:
+  - item1
+  - item2
+  - item3
+`)
+				var config Config
+				err := UnmarshalConfig(configYAML, &config)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(config.UserData).NotTo(BeNil())
+				userData, ok := config.UserData.([]any)
+				Expect(ok).To(BeTrue())
+				Expect(userData).To(HaveLen(3))
+				Expect(userData[0]).To(Equal("item1"))
+				Expect(userData[1]).To(Equal("item2"))
+				Expect(userData[2]).To(Equal("item3"))
+			})
+		})
+
+		Context("when config has user_data as a number", func() {
+			It("preserves the user_data field", func() {
+				configYAML := []byte(`
+jobs:
+  - name: test-job
+    plan:
+      - task: test
+        config:
+          platform: linux
+          run:
+            path: echo
+user_data: 12345
+`)
+				var config Config
+				err := UnmarshalConfig(configYAML, &config)
+				Expect(err).NotTo(HaveOccurred())
+
+				// YAML unmarshals numbers as float64
+				Expect(config.UserData).To(Equal(float64(12345)))
+			})
+		})
+
+		Context("when config has nested user_data structures", func() {
+			It("preserves the nested structure", func() {
+				configYAML := []byte(`
+jobs:
+  - name: test-job
+    plan:
+      - task: test
+        config:
+          platform: linux
+          run:
+            path: echo
+user_data:
+  metadata:
+    owner:
+      team: platform
+      contact: user@example.com
+    tags:
+      - key: env
+        value: production
+      - key: region
+        value: us-west-2
+  version: 1.0
+`)
+				var config Config
+				err := UnmarshalConfig(configYAML, &config)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(config.UserData).NotTo(BeNil())
+				userData, ok := config.UserData.(map[string]any)
+				Expect(ok).To(BeTrue())
+
+				metadata, ok := userData["metadata"].(map[string]any)
+				Expect(ok).To(BeTrue())
+
+				owner, ok := metadata["owner"].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(owner["team"]).To(Equal("platform"))
+				Expect(owner["contact"]).To(Equal("user@example.com"))
+
+				tags, ok := metadata["tags"].([]any)
+				Expect(ok).To(BeTrue())
+				Expect(tags).To(HaveLen(2))
+			})
+		})
+
+		Context("when config has no user_data field", func() {
+			It("user_data should be nil", func() {
+				configYAML := []byte(`
+jobs:
+  - name: test-job
+    plan:
+      - task: test
+        config:
+          platform: linux
+          run:
+            path: echo
+`)
+				var config Config
+				err := UnmarshalConfig(configYAML, &config)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(config.UserData).To(BeNil())
+			})
+		})
+
+		Context("when config has user_data as null", func() {
+			It("user_data should be nil", func() {
+				configYAML := []byte(`
+jobs:
+  - name: test-job
+    plan:
+      - task: test
+        config:
+          platform: linux
+          run:
+            path: echo
+user_data: null
+`)
+				var config Config
+				err := UnmarshalConfig(configYAML, &config)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(config.UserData).To(BeNil())
+			})
+		})
+
+		Context("when config has unknown fields along with user_data", func() {
+			It("strips unknown fields but preserves user_data", func() {
+				configYAML := []byte(`
+jobs:
+  - name: test-job
+    plan:
+      - task: test
+        config:
+          platform: linux
+          run:
+            path: echo
+user_data:
+  preserved: data
+unknown_field: should_be_stripped
+another_unknown: also_stripped
+`)
+				var config Config
+				err := UnmarshalConfig(configYAML, &config)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(config.UserData).NotTo(BeNil())
+				userData, ok := config.UserData.(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(userData["preserved"]).To(Equal("data"))
+			})
+		})
+	})
 })

--- a/atc/db/migration/migrations/1773181582_add_user_data_to_pipelines.down.sql
+++ b/atc/db/migration/migrations/1773181582_add_user_data_to_pipelines.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipelines DROP COLUMN user_data;

--- a/atc/db/migration/migrations/1773181582_add_user_data_to_pipelines.up.sql
+++ b/atc/db/migration/migrations/1773181582_add_user_data_to_pipelines.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pipelines ADD COLUMN user_data text;

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -138,6 +138,7 @@ type pipeline struct {
 	groups        atc.GroupConfigs
 	varSources    atc.VarSourceConfigs
 	display       *atc.DisplayConfig
+	userData      any
 	configVersion ConfigVersion
 	paused        bool
 	pausedBy      string
@@ -159,6 +160,7 @@ var pipelinesQuery = psql.Select(`
 		p.groups,
 		p.var_sources,
 		p.display,
+		p.user_data,
 		p.nonce,
 		p.version,
 		p.team_id,
@@ -266,6 +268,7 @@ func (p *pipeline) Config() (atc.Config, error) {
 		Prototypes:    prototypes.Configs(),
 		Jobs:          jobConfigs,
 		Display:       p.Display(),
+		UserData:      p.userData,
 	}
 
 	return config, nil

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -2271,6 +2271,101 @@ var _ = Describe("Pipeline", func() {
 			Expect(pipeline.Config()).To(Equal(pipelineConfig))
 		})
 	})
+
+	Describe("UserData", func() {
+		Context("when pipeline is created with user_data", func() {
+			It("preserves user_data as a map", func() {
+				userData := map[string]any{
+					"organization": "Platform Team",
+					"contact":      "platform@example.com",
+					"labels":       []any{"prod", "critical"},
+				}
+
+				configWithUserData := pipelineConfig
+				configWithUserData.UserData = userData
+
+				pipeline, _, err := team.SavePipeline(atc.PipelineRef{Name: "pipeline-with-userdata"}, configWithUserData, 0, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				config, err := pipeline.Config()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.UserData).NotTo(BeNil())
+
+				retrievedUserData, ok := config.UserData.(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(retrievedUserData["organization"]).To(Equal("Platform Team"))
+				Expect(retrievedUserData["contact"]).To(Equal("platform@example.com"))
+			})
+
+			It("preserves user_data as a string", func() {
+				configWithUserData := pipelineConfig
+				configWithUserData.UserData = "simple metadata"
+
+				pipeline, _, err := team.SavePipeline(atc.PipelineRef{Name: "pipeline-with-string-userdata"}, configWithUserData, 0, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				config, err := pipeline.Config()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.UserData).To(Equal("simple metadata"))
+			})
+
+			It("preserves user_data as an array", func() {
+				configWithUserData := pipelineConfig
+				configWithUserData.UserData = []any{"tag1", "tag2", "tag3"}
+
+				pipeline, _, err := team.SavePipeline(atc.PipelineRef{Name: "pipeline-with-array-userdata"}, configWithUserData, 0, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				config, err := pipeline.Config()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.UserData).NotTo(BeNil())
+
+				retrievedUserData, ok := config.UserData.([]any)
+				Expect(ok).To(BeTrue())
+				Expect(retrievedUserData).To(ConsistOf("tag1", "tag2", "tag3"))
+			})
+		})
+
+		Context("when pipeline is created without user_data", func() {
+			It("returns nil for user_data", func() {
+				pipeline, _, err := team.SavePipeline(atc.PipelineRef{Name: "pipeline-without-userdata"}, pipelineConfig, 0, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				config, err := pipeline.Config()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.UserData).To(BeNil())
+			})
+		})
+
+		Context("when updating pipeline user_data", func() {
+			It("replaces user_data with new value", func() {
+				initialUserData := map[string]any{"version": "1.0"}
+				configWithUserData := pipelineConfig
+				configWithUserData.UserData = initialUserData
+
+				pipeline, _, err := team.SavePipeline(atc.PipelineRef{Name: "pipeline-update-userdata"}, configWithUserData, 0, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Update with new user_data
+				updatedUserData := map[string]any{
+					"version":    "2.0",
+					"updated_by": "test",
+				}
+				configWithUserData.UserData = updatedUserData
+
+				pipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "pipeline-update-userdata"}, configWithUserData, pipeline.ConfigVersion(), false)
+				Expect(err).ToNot(HaveOccurred())
+
+				config, err := pipeline.Config()
+				Expect(err).ToNot(HaveOccurred())
+
+				retrievedUserData, ok := config.UserData.(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(retrievedUserData["version"]).To(Equal("2.0"))
+				Expect(retrievedUserData["updated_by"]).To(Equal("test"))
+			})
+		})
+	})
 })
 
 func intptr(i int) *int {

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -2295,6 +2295,7 @@ var _ = Describe("Pipeline", func() {
 				Expect(ok).To(BeTrue())
 				Expect(retrievedUserData["organization"]).To(Equal("Platform Team"))
 				Expect(retrievedUserData["contact"]).To(Equal("platform@example.com"))
+				Expect(retrievedUserData["labels"]).To(ConsistOf("prod", "critical"))
 			})
 
 			It("preserves user_data as a string", func() {

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -464,6 +464,14 @@ func savePipeline(
 		return 0, false, err
 	}
 
+	var userDataPayload []byte
+	if config.UserData != nil {
+		userDataPayload, err = json.Marshal(config.UserData)
+		if err != nil {
+			return 0, false, err
+		}
+	}
+
 	var pipelineID int
 	if !existingConfig {
 		values := map[string]any{
@@ -471,6 +479,7 @@ func savePipeline(
 			"groups":          groupsPayload,
 			"var_sources":     encryptedVarSourcesPayload,
 			"display":         displayPayload,
+			"user_data":       userDataPayload,
 			"nonce":           nonce,
 			"version":         sq.Expr("nextval('config_version_seq')"),
 			"paused":          initiallyPaused,
@@ -516,6 +525,7 @@ func savePipeline(
 			Set("groups", groupsPayload).
 			Set("var_sources", encryptedVarSourcesPayload).
 			Set("display", displayPayload).
+			Set("user_data", userDataPayload).
 			Set("nonce", nonce).
 			Set("version", sq.Expr("nextval('config_version_seq')")).
 			Set("last_updated", sq.Expr("now()")).
@@ -1334,6 +1344,7 @@ func scanPipeline(p *pipeline, scan scannable) error {
 		groups        sql.NullString
 		varSources    sql.NullString
 		display       sql.NullString
+		userData      sql.NullString
 		nonce         sql.NullString
 		nonceStr      *string
 		lastUpdated   sql.NullTime
@@ -1343,7 +1354,7 @@ func scanPipeline(p *pipeline, scan scannable) error {
 		pausedBy      sql.NullString
 		pausedAt      sql.NullTime
 	)
-	err := scan.Scan(&p.id, &p.name, &groups, &varSources, &display, &nonce, &p.configVersion, &p.teamID, &p.teamName, &p.paused, &p.public, &p.archived, &lastUpdated, &parentJobID, &parentBuildID, &instanceVars, &pausedBy, &pausedAt)
+	err := scan.Scan(&p.id, &p.name, &groups, &varSources, &display, &userData, &nonce, &p.configVersion, &p.teamID, &p.teamName, &p.paused, &p.public, &p.archived, &lastUpdated, &parentJobID, &parentBuildID, &instanceVars, &pausedBy, &pausedAt)
 	if err != nil {
 		return err
 	}
@@ -1374,6 +1385,16 @@ func scanPipeline(p *pipeline, scan scannable) error {
 		}
 
 		p.display = displayConfig
+	}
+
+	if userData.Valid {
+		var userDataObj any
+		err = json.Unmarshal([]byte(userData.String), &userDataObj)
+		if err != nil {
+			return err
+		}
+
+		p.userData = userDataObj
 	}
 
 	if varSources.Valid {

--- a/atc/integration/user_data_test.go
+++ b/atc/integration/user_data_test.go
@@ -1,0 +1,296 @@
+package integration_test
+
+import (
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/go-concourse/concourse"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+)
+
+var _ = Describe("Pipeline user_data", func() {
+	var (
+		pipelineName string
+		team         concourse.Team
+	)
+
+	JustBeforeEach(func() {
+		pipelineName = "pipeline-with-userdata"
+		team = login(atcURL, "test", "test").Team("main")
+	})
+
+	Context("when setting a pipeline with user_data as a map", func() {
+		var userDataMap map[string]any
+
+		JustBeforeEach(func() {
+			userDataMap = map[string]any{
+				"organization": "Platform Team",
+				"contact":      "platform@example.com",
+				"labels": []any{
+					"production",
+					"critical",
+				},
+				"metadata": map[string]any{
+					"cost_center": "CC-1234",
+					"region":      "us-west-2",
+				},
+			}
+
+			config := atc.Config{
+				Jobs: atc.JobConfigs{
+					{
+						Name: "test-job",
+						PlanSequence: []atc.Step{
+							{
+								Config: &atc.TaskStep{
+									Name: "simple-task",
+									Config: &atc.TaskConfig{
+										Platform: "linux",
+										Run: atc.TaskRunConfig{
+											Path: "echo",
+											Args: []string{"hello"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				UserData: userDataMap,
+			}
+
+			payload, err := yaml.Marshal(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, _, err = team.CreateOrUpdatePipelineConfig(atc.PipelineRef{Name: pipelineName}, "0", payload, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			_, err := team.DeletePipeline(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("preserves user_data when retrieving the pipeline config", func() {
+			retrievedConfig, _, _, err := team.PipelineConfig(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(retrievedConfig.UserData).NotTo(BeNil())
+
+			userData, ok := retrievedConfig.UserData.(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(userData["organization"]).To(Equal("Platform Team"))
+			Expect(userData["contact"]).To(Equal("platform@example.com"))
+
+			labels, ok := userData["labels"].([]any)
+			Expect(ok).To(BeTrue())
+			Expect(labels).To(ConsistOf("production", "critical"))
+
+			metadata, ok := userData["metadata"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(metadata["cost_center"]).To(Equal("CC-1234"))
+			Expect(metadata["region"]).To(Equal("us-west-2"))
+		})
+	})
+
+	Context("when setting a pipeline with user_data as a string", func() {
+		JustBeforeEach(func() {
+			config := atc.Config{
+				Jobs: atc.JobConfigs{
+					{
+						Name: "test-job",
+						PlanSequence: []atc.Step{
+							{
+								Config: &atc.TaskStep{
+									Name: "simple-task",
+									Config: &atc.TaskConfig{
+										Platform: "linux",
+										Run: atc.TaskRunConfig{
+											Path: "echo",
+											Args: []string{"hello"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				UserData: "simple string metadata",
+			}
+
+			payload, err := yaml.Marshal(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, _, err = team.CreateOrUpdatePipelineConfig(atc.PipelineRef{Name: pipelineName}, "0", payload, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			_, err := team.DeletePipeline(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("preserves string user_data when retrieving", func() {
+			retrievedConfig, _, _, err := team.PipelineConfig(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(retrievedConfig.UserData).To(Equal("simple string metadata"))
+		})
+	})
+
+	Context("when setting a pipeline with user_data as an array", func() {
+		JustBeforeEach(func() {
+			config := atc.Config{
+				Jobs: atc.JobConfigs{
+					{
+						Name: "test-job",
+						PlanSequence: []atc.Step{
+							{
+								Config: &atc.TaskStep{
+									Name: "simple-task",
+									Config: &atc.TaskConfig{
+										Platform: "linux",
+										Run: atc.TaskRunConfig{
+											Path: "echo",
+											Args: []string{"hello"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				UserData: []any{"tag1", "tag2", "tag3"},
+			}
+
+			payload, err := yaml.Marshal(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, _, err = team.CreateOrUpdatePipelineConfig(atc.PipelineRef{Name: pipelineName}, "0", payload, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			_, err := team.DeletePipeline(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("preserves array user_data when retrieving", func() {
+			retrievedConfig, _, _, err := team.PipelineConfig(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(retrievedConfig.UserData).NotTo(BeNil())
+
+			userData, ok := retrievedConfig.UserData.([]any)
+			Expect(ok).To(BeTrue())
+			Expect(userData).To(ConsistOf("tag1", "tag2", "tag3"))
+		})
+	})
+
+	Context("when setting a pipeline without user_data", func() {
+		JustBeforeEach(func() {
+			config := atc.Config{
+				Jobs: atc.JobConfigs{
+					{
+						Name: "test-job",
+						PlanSequence: []atc.Step{
+							{
+								Config: &atc.TaskStep{
+									Name: "simple-task",
+									Config: &atc.TaskConfig{
+										Platform: "linux",
+										Run: atc.TaskRunConfig{
+											Path: "echo",
+											Args: []string{"hello"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			payload, err := yaml.Marshal(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, _, err = team.CreateOrUpdatePipelineConfig(atc.PipelineRef{Name: pipelineName}, "0", payload, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			_, err := team.DeletePipeline(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns nil for user_data", func() {
+			retrievedConfig, _, _, err := team.PipelineConfig(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(retrievedConfig.UserData).To(BeNil())
+		})
+	})
+
+	Context("when updating a pipeline's user_data", func() {
+		JustBeforeEach(func() {
+			config := atc.Config{
+				Jobs: atc.JobConfigs{
+					{
+						Name: "test-job",
+						PlanSequence: []atc.Step{
+							{
+								Config: &atc.TaskStep{
+									Name: "simple-task",
+									Config: &atc.TaskConfig{
+										Platform: "linux",
+										Run: atc.TaskRunConfig{
+											Path: "echo",
+											Args: []string{"hello"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				UserData: map[string]any{"version": "1.0"},
+			}
+
+			payload, err := yaml.Marshal(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, _, err = team.CreateOrUpdatePipelineConfig(atc.PipelineRef{Name: pipelineName}, "0", payload, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			_, err := team.DeletePipeline(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("replaces user_data with new value", func() {
+			// Retrieve current version
+			currentConfig, version, _, err := team.PipelineConfig(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Update with new user_data
+			currentConfig.UserData = map[string]any{
+				"version":      "2.0",
+				"updated_by":   "test-user",
+				"last_updated": "2026-03-11",
+			}
+
+			payload, err := yaml.Marshal(currentConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, _, err = team.CreateOrUpdatePipelineConfig(atc.PipelineRef{Name: pipelineName}, version, payload, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify updated user_data
+			retrievedConfig, _, _, err := team.PipelineConfig(atc.PipelineRef{Name: pipelineName})
+			Expect(err).NotTo(HaveOccurred())
+
+			userData, ok := retrievedConfig.UserData.(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(userData["version"]).To(Equal("2.0"))
+			Expect(userData["updated_by"]).To(Equal("test-user"))
+			Expect(userData["last_updated"]).To(Equal("2026-03-11"))
+		})
+	})
+})


### PR DESCRIPTION
Support for opaque `user_data` field in pipeline YAML configurations, allowing users to store arbitrary metadata that is preserved through the set-pipeline/get-pipeline cycle.

The feature allows users to store arbitrary metadata in pipeline configurations, addressing the use case described in issue #8426 where teams need to attach organizational information to pipelines for programmatic processing.

**Closes GitHub Issue**: https://github.com/concourse/concourse/issues/8426

## Example Usage

### Pipeline YAML with user_data
```yaml
jobs:
  - name: build
    plan:
      - task: test
        config:
          platform: linux
          run:
            path: echo
            args: ["hello"]

user_data:
  organization: Platform Team
  contact: platform@example.com
  labels:
    - production
    - critical
  metadata:
    cost_center: CC-1234
    region: us-west-2
```

### Workflow
```bash
# Set pipeline with user_data
fly -t target set-pipeline -p my-pipeline -c pipeline.yml

# Get pipeline - user_data is preserved
fly -t target get-pipeline -p my-pipeline
# Output includes the same user_data block
```