### PR TITLE
Make the set_pipeline step respect the CONCOURSE_DISABLE_REDACT_SECRETS setting

### DIFF
--- a/atc/engine/set_pipeline_delegate.go
+++ b/atc/engine/set_pipeline_delegate.go
@@ -19,13 +19,14 @@ func NewSetPipelineStepDelegate(
 ) *setPipelineStepDelegate {
 	return &setPipelineStepDelegate{
 		buildStepDelegate{
-			build:         build,
-			planID:        planID,
-			clock:         clock,
-			state:         state,
-			stdout:        nil,
-			stderr:        nil,
-			policyChecker: policyChecker,
+			build:                build,
+			planID:               planID,
+			clock:                clock,
+			state:                state,
+			stdout:               nil,
+			stderr:               nil,
+			policyChecker:        policyChecker,
+			disableRedactSecrets: atc.DisableRedactSecrets,
 		},
 	}
 }


### PR DESCRIPTION
## Changes proposed by this PR

closes #9496

CONCOURSE_DISABLE_REDACT_SECRETS was not being respected by the `set_pipeline` step