### PR TITLE
Finish wiring up the `concourse_builds_check_finished_total` metric

### DIFF
--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -324,6 +324,10 @@ func (b *engineBuild) trackFinished(logger lager.Logger) {
 			metric.BuildFinished{
 				Build: b.build,
 			}.Emit(logger)
+		} else {
+			metric.CheckBuildFinished{
+				Build: b.build,
+			}.Emit(logger)
 		}
 	}
 }

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -99,6 +99,7 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	// These are the simple ones that only need a small name transformation
 	case "build started",
 		"build finished",
+		"check build finished",
 		"checks finished",
 		"checks started",
 		"checks enqueued",

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -963,6 +963,8 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 			).Observe(event.Value)
 	case "build finished":
 		emitter.buildFinishedMetrics(logger, event)
+	case "check build finished":
+		emitter.checkBuildFinishedMetrics(logger, event)
 	case "worker containers":
 		// update last seen counters, used to gc stale timeseries
 		emitter.updateLastSeen(event)

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -502,6 +502,24 @@ func (event BuildFinished) Emit(logger lager.Logger) {
 	)
 }
 
+type CheckBuildFinished struct {
+	Build db.Build
+}
+
+func (event CheckBuildFinished) Emit(logger lager.Logger) {
+	attrs := event.Build.TracingAttrs()
+	attrs["build_status"] = event.Build.Status().String()
+
+	Metrics.emit(
+		logger.Session("check-build-finished"),
+		Event{
+			Name:       "check build finished",
+			Value:      ms(event.Build.EndTime().Sub(event.Build.StartTime())),
+			Attributes: attrs,
+		},
+	)
+}
+
 func ms(duration time.Duration) float64 {
 	return float64(duration) / 1000000
 }


### PR DESCRIPTION
## Changes proposed by this PR

Related to #1445 and #9492

I noticed that the `concourse_builds_check_finished_total` metric wasn't wired up. It's value stayed at zero on an active cluster. This PR wires it up.