### PR TITLE
Fix missing volumesStreamedViaFallback Prometheus metric

### DIFF
--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -78,7 +78,8 @@ type PrometheusEmitter struct {
 
 	checksEnqueued prometheus.Counter
 
-	volumesStreamed prometheus.Counter
+	volumesStreamed            prometheus.Counter
+	volumesStreamedViaFallback prometheus.Counter
 
 	getStepCacheHits       prometheus.Counter
 	streamedResourceCaches prometheus.Counter
@@ -576,6 +577,17 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 	)
 	prometheus.MustRegister(volumesStreamed)
 
+	volumesStreamedViaFallback := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace:   "concourse",
+			Subsystem:   "volumes",
+			Name:        "volumes_streamed_via_fallback",
+			Help:        "Total number of volumes streamed via fallback (through ATC)",
+			ConstLabels: attributes,
+		},
+	)
+	prometheus.MustRegister(volumesStreamedViaFallback)
+
 	workerOrphanedVolumesToBeCollected := prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace:   "concourse",
@@ -890,7 +902,8 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 		workerUnknownVolumes:               workerUnknownVolumes,
 		workerOrphanedVolumesToBeCollected: workerOrphanedVolumesToBeCollected,
 
-		volumesStreamed: volumesStreamed,
+		volumesStreamed:            volumesStreamed,
+		volumesStreamedViaFallback: volumesStreamedViaFallback,
 
 		getStepCacheHits:       getStepCacheHits,
 		streamedResourceCaches: streamedResourceCaches,
@@ -1033,6 +1046,8 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.checksEnqueued.Add(event.Value)
 	case "volumes streamed":
 		emitter.volumesStreamed.Add(event.Value)
+	case "volumes streamed via fallback":
+		emitter.volumesStreamedViaFallback.Add(event.Value)
 	case "get step cache hits":
 		emitter.getStepCacheHits.Add(event.Value)
 	case "streamed resource caches":


### PR DESCRIPTION
The volumesStreamedViaFallback metric was being tracked internally but not exposed via Prometheus. This metric is incremented when volume streaming falls back to streaming through the ATC instead of direct worker-to-worker streaming. I think this was introduced in: https://github.com/concourse/concourse/pull/9390

The metric is exposed as:
concourse_volumes_volumes_streamed_via_fallback

I was preparing the (next) PR to extend a bit the streaming metrics like:
````
1. Counters
- `concourse_volumes_streaming_p2p_success_total` - Successful P2P streams
- `concourse_volumes_streaming_p2p_failure_total` - Failed P2P streams
- `concourse_volumes_streaming_atc_success_total` - Successful ATC streams
- `concourse_volumes_streaming_atc_failure_total` - Failed ATC streams

2. Histograms
- `concourse_volumes_streaming_duration_seconds{method,status}` - Stream duration by method and status
- `concourse_volumes_streaming_size_bytes` - Volume size distribution

3. Gauges
- `concourse_volumes_streaming_in_progress{method}` - Currently active streams
`````
when I noticed the issue with pre-existing: volumesStreamedViaFallback.


I did some local manual test and checked that metrics increase as expected by the test:
````
$ curl -s http://localhost:9090/metrics | grep -E "concourse_volumes_volumes_streamed|concourse_volumes_volumes_streamed_via_fallback" | grep -v "^#"
concourse_volumes_volumes_streamed 0
concourse_volumes_volumes_streamed_via_fallback 0

$ curl -s http://localhost:9090/metrics | grep -E "concourse_volumes_volumes_streamed|concourse_volumes_volumes_streamed_via_fallback" | grep -v "^#"
concourse_volumes_volumes_streamed 1
concourse_volumes_volumes_streamed_via_fallback 0

$ curl -s http://localhost:9090/metrics | grep -E "concourse_volumes_volumes_streamed|concourse_volumes_volumes_streamed_via_fallback" | grep -v "^#"
concourse_volumes_volumes_streamed 1
concourse_volumes_volumes_streamed_via_fallback 1
````
I know it doesn't show much, but if you wish, I can post the full steps (docker compose with multiple workers in different networks with P2P enabled, + test pipeline.)
