### PR TITLE
Add UserData field to pipeline API responses

### DIFF
--- a/atc/api/present/pipeline.go
+++ b/atc/api/present/pipeline.go
@@ -17,6 +17,7 @@ func Pipeline(savedPipeline db.Pipeline) atc.Pipeline {
 		Archived:      savedPipeline.Archived(),
 		Groups:        savedPipeline.Groups(),
 		Display:       savedPipeline.Display(),
+		UserData:      savedPipeline.UserData(),
 		ParentBuildID: savedPipeline.ParentBuildID(),
 		ParentJobID:   savedPipeline.ParentJobID(),
 		LastUpdated:   savedPipeline.LastUpdated().Unix(),

--- a/atc/db/dbfakes/fake_pipeline.go
+++ b/atc/db/dbfakes/fake_pipeline.go
@@ -589,6 +589,16 @@ type FakePipeline struct {
 	unpauseReturnsOnCall map[int]struct {
 		result1 error
 	}
+	UserDataStub        func() any
+	userDataMutex       sync.RWMutex
+	userDataArgsForCall []struct {
+	}
+	userDataReturns struct {
+		result1 any
+	}
+	userDataReturnsOnCall map[int]struct {
+		result1 any
+	}
 	VarSourcesStub        func() atc.VarSourceConfigs
 	varSourcesMutex       sync.RWMutex
 	varSourcesArgsForCall []struct {
@@ -3461,6 +3471,59 @@ func (fake *FakePipeline) UnpauseReturnsOnCall(i int, result1 error) {
 	}
 	fake.unpauseReturnsOnCall[i] = struct {
 		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) UserData() any {
+	fake.userDataMutex.Lock()
+	ret, specificReturn := fake.userDataReturnsOnCall[len(fake.userDataArgsForCall)]
+	fake.userDataArgsForCall = append(fake.userDataArgsForCall, struct {
+	}{})
+	stub := fake.UserDataStub
+	fakeReturns := fake.userDataReturns
+	fake.recordInvocation("UserData", []interface{}{})
+	fake.userDataMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePipeline) UserDataCallCount() int {
+	fake.userDataMutex.RLock()
+	defer fake.userDataMutex.RUnlock()
+	return len(fake.userDataArgsForCall)
+}
+
+func (fake *FakePipeline) UserDataCalls(stub func() any) {
+	fake.userDataMutex.Lock()
+	defer fake.userDataMutex.Unlock()
+	fake.UserDataStub = stub
+}
+
+func (fake *FakePipeline) UserDataReturns(result1 any) {
+	fake.userDataMutex.Lock()
+	defer fake.userDataMutex.Unlock()
+	fake.UserDataStub = nil
+	fake.userDataReturns = struct {
+		result1 any
+	}{result1}
+}
+
+func (fake *FakePipeline) UserDataReturnsOnCall(i int, result1 any) {
+	fake.userDataMutex.Lock()
+	defer fake.userDataMutex.Unlock()
+	fake.UserDataStub = nil
+	if fake.userDataReturnsOnCall == nil {
+		fake.userDataReturnsOnCall = make(map[int]struct {
+			result1 any
+		})
+	}
+	fake.userDataReturnsOnCall[i] = struct {
+		result1 any
 	}{result1}
 }
 

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -62,6 +62,7 @@ type Pipeline interface {
 	Groups() atc.GroupConfigs
 	VarSources() atc.VarSourceConfigs
 	Display() *atc.DisplayConfig
+	UserData() any
 	ConfigVersion() ConfigVersion
 	Config() (atc.Config, error)
 	Public() bool
@@ -194,6 +195,7 @@ func (p *pipeline) InstanceVars() atc.InstanceVars   { return p.instanceVars }
 func (p *pipeline) Groups() atc.GroupConfigs         { return p.groups }
 func (p *pipeline) VarSources() atc.VarSourceConfigs { return p.varSources }
 func (p *pipeline) Display() *atc.DisplayConfig      { return p.display }
+func (p *pipeline) UserData() any                    { return p.userData }
 func (p *pipeline) ConfigVersion() ConfigVersion     { return p.configVersion }
 func (p *pipeline) Public() bool                     { return p.public }
 func (p *pipeline) Paused() bool                     { return p.paused }

--- a/atc/pipeline.go
+++ b/atc/pipeline.go
@@ -23,6 +23,7 @@ type Pipeline struct {
 	Groups        GroupConfigs   `json:"groups,omitempty"`
 	TeamName      string         `json:"team_name"`
 	Display       *DisplayConfig `json:"display,omitempty"`
+	UserData      any            `json:"user_data,omitempty"`
 	ParentBuildID int            `json:"parent_build_id,omitempty"`
 	ParentJobID   int            `json:"parent_job_id,omitempty"`
 	LastUpdated   int64          `json:"last_updated,omitempty"`


### PR DESCRIPTION
Follow up to: https://github.com/concourse/concourse/pull/9489

Ensure that user_data is included when accessing the pipelines API endpoint or using the fly pipelines command. Enables you to get user data for ALL pipelines in a single API request towards `/api/v1/pipelines` vs X request towards `/api/v1/teams/:team_name/pipelines/:pipeline_name/config`. In large deployments with 300-400 pipelines, this results in significant gains. I am basically reusing the same approach used to display groups top level key.

The UserData field is now exposed in:
- GET /api/v1/pipelines (all pipelines)
- GET /api/v1/teams/{team}/pipelines (team pipelines)
- fly pipelines --json (JSON output includes user_data)

This allows pipeline metadata defined in user_data to be retrieved via the API and CLI, enabling better pipeline management and automation workflows.

```bash
# Table format (default) - user_data is NOT displayed in table
fly -t test pipelines

# JSON format - user_data IS included
fly -t test pipelines --json | jq '.'

# Show only pipelines with user_data
fly -t test pipelines --json | jq '.[] | select(.user_data != null) | {name, user_data}'

# Pretty print specific pipeline's user_data
fly -t test pipelines --json | jq '.[] | select(.name == "pipeline-with-userdata") | .user_data'
```

## Expected Results

### Pipeline WITHOUT user_data
```json
{
  "name": "pipeline-no-userdata",
  "user_data": null
}
```

### Pipeline WITH user_data
```json
{
  "name": "pipeline-with-userdata",
  "user_data": {
    "team": "Platform Engineering",
    "owner": "devops@example.com",
    "environment": "production",
  }
}
```