### PR TITLE
worker/runtime: wrap containers from NewContainer and Containers with request timeout

### DIFF
--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -1223,3 +1223,80 @@ func (s *IntegrationSuite) TestNetworkMountsAreRemoved() {
 	s.NoError(err)
 	s.Len(networkFiles, 0)
 }
+
+// TestNewContainerEnforcesTimeoutOnTask is a regression test verifying that
+// containers returned by client.NewContainer enforce the requestTimeout on
+// follow-on operations (Task, NewTask, Spec).
+
+// How this test works:
+//  1. Create a libcontainerd client with a 1s requestTimeout
+//  2. Create a container directly via client.NewContainer with a minimal
+//     OCI runtime spec (no init binary or running task needed)
+//  3. Freeze containerd with SIGSTOP (making all gRPC calls hang)
+//  4. Call Task() on the container from NewContainer with context.Background()
+//     (no deadline from the caller — the wrapper must add it)
+//  5. Expect a "deadline exceeded" error within ~1s
+//  6. Also verify GetContainer returns a container that behaves identically
+//  7. Unfreeze containerd and verify recovery
+//
+// Step 4 will blocks indefinitely and the test times out without the fix
+func (s *IntegrationSuite) TestNewContainerEnforcesTimeoutOnTask() {
+	requestTimeout := 1 * time.Second
+
+	client := libcontainerd.New(
+		s.containerdSocket(),
+		"test-timeout-enforcement",
+		requestTimeout,
+	)
+	err := client.Init()
+	s.NoError(err)
+	defer client.Stop()
+
+	handle := uuid()
+	minimalSpec := &specs.Spec{
+		Version: specs.Version,
+		Process: &specs.Process{
+			Args: []string{"/bin/sh"},
+		},
+		Root: &specs.Root{
+			Path: s.rootfs,
+		},
+	}
+
+	contViaNew, err := client.NewContainer(
+		context.Background(), handle, map[string]string{}, minimalSpec,
+	)
+	s.NoError(err, "NewContainer should succeed")
+	defer func() {
+		_ = s.containerdProcess.Process.Signal(syscall.SIGCONT)
+		contViaNew.Delete(context.Background())
+	}()
+
+	_, err = contViaNew.Task(context.Background(), nil)
+	s.Error(err, "Task should return 'not found' error (no task started)")
+
+	contViaGet, err := client.GetContainer(context.Background(), handle)
+	s.NoError(err, "GetContainer should succeed while containerd is responsive")
+
+	_, err = contViaGet.Task(context.Background(), nil)
+	s.Error(err, "Task via GetContainer should also return 'not found'")
+
+	s.NoError(s.containerdProcess.Process.Signal(syscall.SIGSTOP))
+
+	start := time.Now()
+	_, err = contViaNew.Task(context.Background(), nil)
+	elapsed := time.Since(start)
+
+	s.Error(err, "Task must fail when containerd is frozen")
+	s.Contains(err.Error(), "deadline exceeded",
+		"Expected 'context deadline exceeded', got: %v", err)
+	s.Less(elapsed.Seconds(), 3.0,
+		"Task should timeout in ~1s (requestTimeout), but took %v", elapsed)
+
+	s.NoError(s.containerdProcess.Process.Signal(syscall.SIGCONT))
+
+	_, err = contViaNew.Task(context.Background(), nil)
+	s.Error(err)
+	s.NotContains(err.Error(), "deadline exceeded",
+		"After unfreeze, Task should not timeout")
+}

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/concourse/concourse/worker/workercmd"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/jackpal/gateway"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )

--- a/worker/runtime/libcontainerd/client.go
+++ b/worker/runtime/libcontainerd/client.go
@@ -121,10 +121,18 @@ func (c *client) NewContainer(
 	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
-	return c.containerd.NewContainer(ctx, id,
+	cont, err := c.containerd.NewContainer(ctx, id,
 		containerd.WithSpec(oci),
 		containerd.WithContainerLabels(labels),
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &container{
+		requestTimeout: c.requestTimeout,
+		container:      cont,
+	}, nil
 }
 
 func (c *client) Containers(
@@ -135,7 +143,20 @@ func (c *client) Containers(
 	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
-	return c.containerd.Containers(ctx, labels...)
+	containers, err := c.containerd.Containers(ctx, labels...)
+	if err != nil {
+		return nil, err
+	}
+
+	wrapped := make([]containerd.Container, len(containers))
+	for i, cont := range containers {
+		wrapped[i] = &container{
+			requestTimeout: c.requestTimeout,
+			container:      cont,
+		}
+	}
+
+	return wrapped, nil
 }
 
 func (c *client) GetContainer(ctx context.Context, handle string) (containerd.Container, error) {


### PR DESCRIPTION
### Description
`NewContainer` and `Containers` were returning raw `containerd.Container` values,
bypassing the `requestTimeout` wrapper applied in `GetContainer`. This meant
downstream calls to `Spec`, `Task`, and `NewTask` during `container.Run` could block
indefinitely with a background context, even when --containerd-request-timeout
was configured.

This caused intermittent hangs where `gdn-init` was alive but the user process
was never exec'd - a userspace handshake deadlock that would only resolve when
the outer step timeout was reached, leaking a lidar check in the process.

closes:
#9398 
#9511

### What I changed?
* Updated `client.go` so `NewContainer` now returns the timeout-wrapped container type instead of the raw containerd container.
* Updated `client.go` so `Containers` also returns timeout-wrapped container objects for every listed container.

### Why this targets the hang?
* The stuck path is consistent with unbounded `containerd` calls during early process startup.
* Before this change, containers from create/list paths could bypass the wrapper and run calls like `Spec`, `Task`, and `NewTask` with effectively unbounded contexts.
* After this change, those calls consistently honor the configured worker --containerd-request-timeout, so deadlocked handshakes should fail fast instead of leaking long-running checks/tasks.

### Validation
* docker compose && run a pipeline

### Notes to reviewer
trade-off to be aware of: When unit tests use `FakeClient.NewContainerReturns(fakeContainer, nil)`, the backend gets back a raw `FakeContainer` without the timeout wrapper. So `container_test.go` and `backend_test.go` don't exercise the timeout wrapping. That's intentional for unit tests as the interfaces (`Client-FakeClient` and `Container-FakeContainer`) remain unchanged.

The wrapping is exercised in the integration tests under `integration_test.go` which uses the real `libcontainerd.New(...)` with a real `containerd` client that now returns wrapped containers from both `NewContainer` and `Containers`.

### Steps to reproduce
Still not actually 100% sure as it is quite intermittent, but I assume heavier load, IO on the machine might cause the leak 

### Possible verification:
As explained in the discussion on a problematic web, we see:
1. Attaching to the webs of an impacted instance
2. Checking the lidar metrics with curl http://localhost:9090 | grep concourse_lidar
3. Doing the math STARTED − (SUCCESS + ERROR) should eventauly equal 0
4. That was true for all web hosts, except for a single one which came out to 1

So I expect this works if eventually we see that the STARTED − (SUCCESS + ERROR) is always 0