### PR TITLE
nit: TSA cleanup

### DIFF
--- a/tsa/keepalive.go
+++ b/tsa/keepalive.go
@@ -13,6 +13,7 @@ import (
 func KeepAlive(ctx context.Context, sshClient *ssh.Client, tcpConn *net.TCPConn, interval time.Duration, timeout time.Duration) {
 	logger := lagerctx.WithSession(ctx, "keepalive")
 	keepAliveTicker := time.NewTicker(interval)
+	defer keepAliveTicker.Stop()
 
 	for {
 

--- a/tsa/tsacmd/server.go
+++ b/tsa/tsacmd/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -374,12 +375,12 @@ func (server *server) forwardTCPIP(
 	done := make(chan struct{})
 	defer close(done)
 
-	interrupted := false
+	interrupted := atomic.Bool{}
 	go func() {
 		select {
 		case <-drain:
 			logger.Debug("draining")
-			interrupted = true
+			interrupted.Store(true)
 			listener.Close()
 		case <-done:
 			logger.Debug("done")
@@ -389,7 +390,7 @@ func (server *server) forwardTCPIP(
 	for {
 		localConn, err := listener.Accept()
 		if err != nil {
-			if !interrupted {
+			if !interrupted.Load() {
 				logger.Error("failed-to-accept", err)
 			}
 

--- a/tsa/tsacmd/server.go
+++ b/tsa/tsacmd/server.go
@@ -44,15 +44,6 @@ func (s *sessionTeam) AuthorizeTeam(sessionID, team string) {
 	s.sessionTeams[sessionID] = team
 }
 
-func (s *sessionTeam) IsNotAuthorized(sessionID, team string) bool {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-
-	t, found := s.sessionTeams[sessionID]
-
-	return found && t != team
-}
-
 func (s *sessionTeam) AuthorizedTeamFor(sessionID string) string {
 	s.lock.RLock()
 	defer s.lock.RUnlock()

--- a/tsa/tsacmd/server.go
+++ b/tsa/tsacmd/server.go
@@ -51,6 +51,13 @@ func (s *sessionTeam) AuthorizedTeamFor(sessionID string) string {
 	return s.sessionTeams[sessionID]
 }
 
+func (s *sessionTeam) RemoveSession(sessionID string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	delete(s.sessionTeams, sessionID)
+}
+
 type ConnState struct {
 	Team string
 
@@ -106,6 +113,7 @@ func (server *server) handshake(logger lager.Logger, netConn net.Conn) {
 	defer cancel()
 
 	sessionID := string(conn.SessionID())
+	defer server.sessionTeam.RemoveSession(sessionID)
 
 	forwardedTCPIPs := make(chan ForwardedTCPIP, maxForwards)
 	go server.handleForwardRequests(ctx, conn, reqs, forwardedTCPIPs)


### PR DESCRIPTION
## Changes proposed by this PR

I pointed Claude at the TSA package, asking it to find any memory leaks or performance issues. I went through its analysis and resolved the legitimate issues.

1. The `sessionTeams` map is never cleaned up and grows forever
2. The var `interrupted` was in a data race

Claude kept stating there were issues with `time.NewTicker()` and `time.After()` calls in a few other places, but I ignored those after reading: https://pkg.go.dev/time#NewTicker

> Before Go 1.23, the garbage collector did not recover tickers that had not yet expired or been stopped, so code often immediately deferred t.Stop after calling NewTicker, to make the ticker recoverable when it was no longer needed. As of Go 1.23, the garbage collector can recover unreferenced tickers, even if they haven't been stopped. The Stop method is no longer necessary to help the garbage collector. (Code may of course still want to call Stop to stop the ticker for other reasons.)


