### PR TITLE
nit: API cleanup

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -99,13 +99,13 @@ func (a *access) rolesForTeam(auth atc.TeamAuth) []string {
 	if userName != "" {
 		userName = fmt.Sprintf("%v:%v", connectorID, userName)
 	}
-	var groups []string
+	groups := make([]string, 0, len(a.groups()))
 	for _, group := range a.groups() {
 		if group != "" {
 			groups = append(groups, fmt.Sprintf("%v:%v", connectorID, group))
 		}
 	}
-	var roles []string
+	roles := make([]string, 0, len(auth))
 	for role, roleAuth := range auth {
 		if roleOnTeam(userID, userName, groups, roleAuth) {
 			roles = append(roles, role)
@@ -163,7 +163,7 @@ func (a *access) IsAuthorized(teamName string) bool {
 }
 
 func (a *access) TeamNames() []string {
-	teamNames := []string{}
+	teamNames := make([]string, 0, len(a.teams))
 	for _, team := range a.teams {
 		if a.isAdmin || a.hasPermission(a.teamRoles[team.Name()]) {
 			teamNames = append(teamNames, team.Name())
@@ -243,9 +243,10 @@ func (a *access) connectorID() string {
 }
 
 func (a *access) groups() []string {
-	groups := []string{}
+	var groups []string
 	if raw, ok := a.claims()["groups"]; ok {
 		if rawGroups, ok := raw.([]any); ok {
+			groups = make([]string, 0, len(rawGroups))
 			for _, rawGroup := range rawGroups {
 				if group, ok := rawGroup.(string); ok {
 					groups = append(groups, group)

--- a/atc/api/accessor/verifier.go
+++ b/atc/api/accessor/verifier.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/concourse/concourse/atc/db"
@@ -33,7 +32,6 @@ func NewVerifier(accessTokenFetcher AccessTokenFetcher, audience []string) *veri
 }
 
 type verifier struct {
-	sync.Mutex
 	accessTokenFetcher AccessTokenFetcher
 	audience           []string
 }

--- a/atc/api/helpers/helpers.go
+++ b/atc/api/helpers/helpers.go
@@ -17,16 +17,10 @@ func HandleBadRequest(w http.ResponseWriter, errorMessages ...string) {
 }
 
 func WriteSaveConfigResponse(w http.ResponseWriter, saveConfigResponse atc.SaveConfigResponse) {
-	responseJSON, err := json.Marshal(saveConfigResponse)
+	err := json.NewEncoder(w).Encode(saveConfigResponse)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "failed to generate error response: %s", err)
-		return
-	}
-
-	_, err = w.Write(responseJSON)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 }

--- a/atc/api/jobserver/clear_task_cache.go
+++ b/atc/api/jobserver/clear_task_cache.go
@@ -63,19 +63,11 @@ func (s *Server) writeJSONResponse(w http.ResponseWriter, obj any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	responseJSON, err := json.Marshal(obj)
+	err := json.NewEncoder(w).Encode(obj)
 	if err != nil {
 		s.logger.Error("failed-to-marshal-response", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "failed to generate error response: %s", err)
 		return
 	}
-
-	_, err = w.Write(responseJSON)
-	if err != nil {
-		s.logger.Error("failed-to-write-response", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 }

--- a/atc/api/present/job.go
+++ b/atc/api/present/job.go
@@ -32,8 +32,7 @@ func Job(
 		presented := Build(transitionBuild, job, access)
 		presentedTransitionBuild = &presented
 	}
-
-	sanitizedInputs := []atc.JobInput{}
+	sanitizedInputs := make([]atc.JobInput, 0, len(inputs))
 	for _, input := range inputs {
 		sanitizedInputs = append(sanitizedInputs, atc.JobInput{
 			Name:     input.Name,
@@ -43,7 +42,7 @@ func Job(
 		})
 	}
 
-	sanitizedOutputs := []atc.JobOutput{}
+	sanitizedOutputs := make([]atc.JobOutput, 0, len(outputs))
 	for _, output := range outputs {
 		sanitizedOutputs = append(sanitizedOutputs, atc.JobOutput{
 			Name:     output.Name,

--- a/atc/api/present/resource_version.go
+++ b/atc/api/present/resource_version.go
@@ -5,7 +5,7 @@ import (
 )
 
 func ResourceVersions(hideMetadata bool, resourceVersions []atc.ResourceVersion) []atc.ResourceVersion {
-	presented := []atc.ResourceVersion{}
+	presented := make([]atc.ResourceVersion, 0, len(resourceVersions))
 
 	for _, resourceVersion := range resourceVersions {
 		if hideMetadata {

--- a/atc/api/present/worker_artifacts.go
+++ b/atc/api/present/worker_artifacts.go
@@ -6,7 +6,7 @@ import (
 )
 
 func WorkerArtifacts(artifacts []db.WorkerArtifact) []atc.WorkerArtifact {
-	wa := []atc.WorkerArtifact{}
+	wa := make([]atc.WorkerArtifact, 0, len(artifacts))
 	for _, a := range artifacts {
 		wa = append(wa, WorkerArtifact(a))
 	}

--- a/atc/api/resourceserver/list.go
+++ b/atc/api/resourceserver/list.go
@@ -20,7 +20,7 @@ func (s *Server) ListResources(pipeline db.Pipeline) http.Handler {
 			return
 		}
 
-		presentedResources := []atc.Resource{}
+		presentedResources := make([]atc.Resource, 0, len(resources))
 		for _, resource := range resources {
 			presentedResources = append(
 				presentedResources,

--- a/atc/api/resourceserver/list_all.go
+++ b/atc/api/resourceserver/list_all.go
@@ -30,8 +30,7 @@ func (s *Server) ListAllResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resources := []atc.Resource{}
-
+	resources := make([]atc.Resource, 0, len(dbResources))
 	for _, resource := range dbResources {
 		resources = append(
 			resources,

--- a/atc/api/resourceserver/versionserver/clear_resource_versions.go
+++ b/atc/api/resourceserver/versionserver/clear_resource_versions.go
@@ -44,19 +44,11 @@ func (s *Server) writeJSONResponse(w http.ResponseWriter, obj any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	responseJSON, err := json.Marshal(obj)
+	err := json.NewEncoder(w).Encode(obj)
 	if err != nil {
 		s.logger.Error("failed-to-marshal-response", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "failed to generate error response: %s", err)
 		return
 	}
-
-	_, err = w.Write(responseJSON)
-	if err != nil {
-		s.logger.Error("failed-to-write-response", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 }

--- a/atc/api/resourceserver/versionserver/input_to.go
+++ b/atc/api/resourceserver/versionserver/input_to.go
@@ -38,7 +38,7 @@ func (s *Server) ListBuildsWithVersionAsInput(pipeline db.Pipeline) http.Handler
 			return
 		}
 
-		presentedBuilds := []atc.Build{}
+		presentedBuilds := make([]atc.Build, 0, len(builds))
 		for _, build := range builds {
 			presentedBuilds = append(presentedBuilds, present.Build(build, nil, nil))
 		}

--- a/atc/api/resourceserver/versionserver/output_of.go
+++ b/atc/api/resourceserver/versionserver/output_of.go
@@ -38,7 +38,7 @@ func (s *Server) ListBuildsWithVersionAsOutput(pipeline db.Pipeline) http.Handle
 			return
 		}
 
-		presentedBuilds := []atc.Build{}
+		presentedBuilds := make([]atc.Build, 0, len(builds))
 		for _, build := range builds {
 			presentedBuilds = append(presentedBuilds, present.Build(build, nil, nil))
 		}

--- a/atc/api/volumeserver/list.go
+++ b/atc/api/volumeserver/list.go
@@ -25,7 +25,7 @@ func (s *Server) ListVolumes(team db.Team) http.Handler {
 
 		hLog.Debug("listed", lager.Data{"volume-count": len(volumes)})
 
-		presentedVolumes := []atc.Volume{}
+		presentedVolumes := make([]atc.Volume, 0, len(volumes))
 		for _, volume := range volumes {
 			if vol, err := present.Volume(volume); err != nil {
 				hLog.Error("failed-to-present-volume", err)


### PR DESCRIPTION
## Changes proposed by this PR

Simple cleanup of the `atc/api/` package. Prompted Claude to analyze the code and then I reviewed and implemented the legitimate issues/suggestions it found.

* Pre-allocate slices where possible to reduce the amount of slice growth and copying
* Switch `json.Marshal+Write` to `json.NewEncoder(w).Encode()` to remove intermediate allocations
* Removed the unused `sync.Mutex` from the `verifier`
