### PR TITLE
Allow pending builds in paused pipelines to be aborted and automatically abort pending builds in archived pipelines

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -120,7 +120,9 @@ var latestCompletedBuildQuery = psql.Select("max(id)").
 type Build interface {
 	PipelineRef
 
+	// The globally unique ID of the build
 	ID() int
+	// The job-scoped build number
 	Name() string
 
 	RunStateID() string

--- a/atc/db/dbfakes/fake_job.go
+++ b/atc/db/dbfakes/fake_job.go
@@ -383,6 +383,16 @@ type FakeJob struct {
 	pipelineInstanceVarsReturnsOnCall map[int]struct {
 		result1 atc.InstanceVars
 	}
+	PipelineIsArchivedStub        func() bool
+	pipelineIsArchivedMutex       sync.RWMutex
+	pipelineIsArchivedArgsForCall []struct {
+	}
+	pipelineIsArchivedReturns struct {
+		result1 bool
+	}
+	pipelineIsArchivedReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	PipelineIsPausedStub        func() bool
 	pipelineIsPausedMutex       sync.RWMutex
 	pipelineIsPausedArgsForCall []struct {
@@ -2359,6 +2369,59 @@ func (fake *FakeJob) PipelineInstanceVarsReturnsOnCall(i int, result1 atc.Instan
 	}
 	fake.pipelineInstanceVarsReturnsOnCall[i] = struct {
 		result1 atc.InstanceVars
+	}{result1}
+}
+
+func (fake *FakeJob) PipelineIsArchived() bool {
+	fake.pipelineIsArchivedMutex.Lock()
+	ret, specificReturn := fake.pipelineIsArchivedReturnsOnCall[len(fake.pipelineIsArchivedArgsForCall)]
+	fake.pipelineIsArchivedArgsForCall = append(fake.pipelineIsArchivedArgsForCall, struct {
+	}{})
+	stub := fake.PipelineIsArchivedStub
+	fakeReturns := fake.pipelineIsArchivedReturns
+	fake.recordInvocation("PipelineIsArchived", []interface{}{})
+	fake.pipelineIsArchivedMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeJob) PipelineIsArchivedCallCount() int {
+	fake.pipelineIsArchivedMutex.RLock()
+	defer fake.pipelineIsArchivedMutex.RUnlock()
+	return len(fake.pipelineIsArchivedArgsForCall)
+}
+
+func (fake *FakeJob) PipelineIsArchivedCalls(stub func() bool) {
+	fake.pipelineIsArchivedMutex.Lock()
+	defer fake.pipelineIsArchivedMutex.Unlock()
+	fake.PipelineIsArchivedStub = stub
+}
+
+func (fake *FakeJob) PipelineIsArchivedReturns(result1 bool) {
+	fake.pipelineIsArchivedMutex.Lock()
+	defer fake.pipelineIsArchivedMutex.Unlock()
+	fake.PipelineIsArchivedStub = nil
+	fake.pipelineIsArchivedReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeJob) PipelineIsArchivedReturnsOnCall(i int, result1 bool) {
+	fake.pipelineIsArchivedMutex.Lock()
+	defer fake.pipelineIsArchivedMutex.Unlock()
+	fake.PipelineIsArchivedStub = nil
+	if fake.pipelineIsArchivedReturnsOnCall == nil {
+		fake.pipelineIsArchivedReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.pipelineIsArchivedReturnsOnCall[i] = struct {
+		result1 bool
 	}{result1}
 }
 

--- a/atc/db/dbfakes/fake_job.go
+++ b/atc/db/dbfakes/fake_job.go
@@ -383,6 +383,16 @@ type FakeJob struct {
 	pipelineInstanceVarsReturnsOnCall map[int]struct {
 		result1 atc.InstanceVars
 	}
+	PipelineIsPausedStub        func() bool
+	pipelineIsPausedMutex       sync.RWMutex
+	pipelineIsPausedArgsForCall []struct {
+	}
+	pipelineIsPausedReturns struct {
+		result1 bool
+	}
+	pipelineIsPausedReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	PipelineNameStub        func() string
 	pipelineNameMutex       sync.RWMutex
 	pipelineNameArgsForCall []struct {
@@ -2349,6 +2359,59 @@ func (fake *FakeJob) PipelineInstanceVarsReturnsOnCall(i int, result1 atc.Instan
 	}
 	fake.pipelineInstanceVarsReturnsOnCall[i] = struct {
 		result1 atc.InstanceVars
+	}{result1}
+}
+
+func (fake *FakeJob) PipelineIsPaused() bool {
+	fake.pipelineIsPausedMutex.Lock()
+	ret, specificReturn := fake.pipelineIsPausedReturnsOnCall[len(fake.pipelineIsPausedArgsForCall)]
+	fake.pipelineIsPausedArgsForCall = append(fake.pipelineIsPausedArgsForCall, struct {
+	}{})
+	stub := fake.PipelineIsPausedStub
+	fakeReturns := fake.pipelineIsPausedReturns
+	fake.recordInvocation("PipelineIsPaused", []interface{}{})
+	fake.pipelineIsPausedMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeJob) PipelineIsPausedCallCount() int {
+	fake.pipelineIsPausedMutex.RLock()
+	defer fake.pipelineIsPausedMutex.RUnlock()
+	return len(fake.pipelineIsPausedArgsForCall)
+}
+
+func (fake *FakeJob) PipelineIsPausedCalls(stub func() bool) {
+	fake.pipelineIsPausedMutex.Lock()
+	defer fake.pipelineIsPausedMutex.Unlock()
+	fake.PipelineIsPausedStub = stub
+}
+
+func (fake *FakeJob) PipelineIsPausedReturns(result1 bool) {
+	fake.pipelineIsPausedMutex.Lock()
+	defer fake.pipelineIsPausedMutex.Unlock()
+	fake.PipelineIsPausedStub = nil
+	fake.pipelineIsPausedReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeJob) PipelineIsPausedReturnsOnCall(i int, result1 bool) {
+	fake.pipelineIsPausedMutex.Lock()
+	defer fake.pipelineIsPausedMutex.Unlock()
+	fake.PipelineIsPausedStub = nil
+	if fake.pipelineIsPausedReturnsOnCall == nil {
+		fake.pipelineIsPausedReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.pipelineIsPausedReturnsOnCall[i] = struct {
+		result1 bool
 	}{result1}
 }
 

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -83,6 +83,7 @@ type Job interface {
 	PausedAt() time.Time
 	// Returns true if the pipeline the job belongs to is paused
 	PipelineIsPaused() bool
+	PipelineIsArchived() bool
 	Pause(pausedBy string) error
 	Unpause() error
 
@@ -136,7 +137,8 @@ var jobsQuery = psql.Select(
 	"j.disable_reruns",
 	"j.paused_by",
 	"j.paused_at",
-	"p.paused").
+	"p.paused",
+	"p.archived").
 	From("jobs j").
 	LeftJoin("pipelines p ON j.pipeline_id = p.id").
 	LeftJoin("teams t ON p.team_id = t.id")
@@ -162,6 +164,7 @@ type job struct {
 	pausedBy              string
 	pausedAt              time.Time
 	pipelinePaused        bool
+	pipelineArchived      bool
 	public                bool
 	firstLoggedBuildID    int
 	teamID                int
@@ -227,6 +230,7 @@ func (j *job) Paused() bool                     { return j.paused }
 func (j *job) PausedAt() time.Time              { return j.pausedAt }
 func (j *job) PausedBy() string                 { return j.pausedBy }
 func (j *job) PipelineIsPaused() bool           { return j.pipelinePaused }
+func (j *job) PipelineIsArchived() bool         { return j.pipelineArchived }
 func (j *job) Public() bool                     { return j.public }
 func (j *job) FirstLoggedBuildID() int          { return j.firstLoggedBuildID }
 func (j *job) TeamID() int                      { return j.teamID }
@@ -1399,7 +1403,7 @@ func scanJob(j *job, row scannable) error {
 	)
 
 	m := pgtype.NewMap()
-	err := row.Scan(&j.id, &j.name, &config, &j.paused, &j.public, &j.firstLoggedBuildID, &j.pipelineID, &j.pipelineName, &pipelineInstanceVars, &j.teamID, &j.teamName, &nonce, m.SQLScanner(&j.tags), &j.hasNewInputs, &j.scheduleRequestedTime, &j.maxInFlight, &j.disableManualTrigger, &j.disableReruns, &pausedBy, &pausedAt, &j.pipelinePaused)
+	err := row.Scan(&j.id, &j.name, &config, &j.paused, &j.public, &j.firstLoggedBuildID, &j.pipelineID, &j.pipelineName, &pipelineInstanceVars, &j.teamID, &j.teamName, &nonce, m.SQLScanner(&j.tags), &j.hasNewInputs, &j.scheduleRequestedTime, &j.maxInFlight, &j.disableManualTrigger, &j.disableReruns, &pausedBy, &pausedAt, &j.pipelinePaused, &j.pipelineArchived)
 	if err != nil {
 		return err
 	}

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -81,6 +81,8 @@ type Job interface {
 	Paused() bool
 	PausedBy() string
 	PausedAt() time.Time
+	// Returns true if the pipeline the job belongs to is paused
+	PipelineIsPaused() bool
 	Pause(pausedBy string) error
 	Unpause() error
 
@@ -133,7 +135,8 @@ var jobsQuery = psql.Select(
 	"j.disable_manual_trigger",
 	"j.disable_reruns",
 	"j.paused_by",
-	"j.paused_at").
+	"j.paused_at",
+	"p.paused").
 	From("jobs j").
 	LeftJoin("pipelines p ON j.pipeline_id = p.id").
 	LeftJoin("teams t ON p.team_id = t.id")
@@ -158,6 +161,7 @@ type job struct {
 	paused                bool
 	pausedBy              string
 	pausedAt              time.Time
+	pipelinePaused        bool
 	public                bool
 	firstLoggedBuildID    int
 	teamID                int
@@ -222,6 +226,7 @@ func (j *job) Name() string                     { return j.name }
 func (j *job) Paused() bool                     { return j.paused }
 func (j *job) PausedAt() time.Time              { return j.pausedAt }
 func (j *job) PausedBy() string                 { return j.pausedBy }
+func (j *job) PipelineIsPaused() bool           { return j.pipelinePaused }
 func (j *job) Public() bool                     { return j.public }
 func (j *job) FirstLoggedBuildID() int          { return j.firstLoggedBuildID }
 func (j *job) TeamID() int                      { return j.teamID }
@@ -607,21 +612,16 @@ func (j *job) ScheduleBuild(build Build) (bool, error) {
 		return true, nil
 	}
 
+	if j.paused || j.pipelinePaused {
+		return false, nil
+	}
+
 	tx, err := j.conn.Begin()
 	if err != nil {
 		return false, err
 	}
 
 	defer tx.Rollback()
-
-	paused, err := j.isPipelineOrJobPaused(tx)
-	if err != nil {
-		return false, err
-	}
-
-	if paused {
-		return false, nil
-	}
 
 	reached, err := j.isMaxInFlightReached(tx, build.ID())
 	if err != nil {
@@ -1389,25 +1389,6 @@ func (j *job) getNextBuildInputs(tx Tx) ([]BuildInput, error) {
 	return buildInputs, err
 }
 
-func (j *job) isPipelineOrJobPaused(tx Tx) (bool, error) {
-	if j.paused {
-		return true, nil
-	}
-
-	var paused bool
-	err := psql.Select("paused").
-		From("pipelines").
-		Where(sq.Eq{"id": j.pipelineID}).
-		RunWith(tx).
-		QueryRow().
-		Scan(&paused)
-	if err != nil {
-		return false, err
-	}
-
-	return paused, nil
-}
-
 func scanJob(j *job, row scannable) error {
 	var (
 		config               sql.NullString
@@ -1418,7 +1399,7 @@ func scanJob(j *job, row scannable) error {
 	)
 
 	m := pgtype.NewMap()
-	err := row.Scan(&j.id, &j.name, &config, &j.paused, &j.public, &j.firstLoggedBuildID, &j.pipelineID, &j.pipelineName, &pipelineInstanceVars, &j.teamID, &j.teamName, &nonce, m.SQLScanner(&j.tags), &j.hasNewInputs, &j.scheduleRequestedTime, &j.maxInFlight, &j.disableManualTrigger, &j.disableReruns, &pausedBy, &pausedAt)
+	err := row.Scan(&j.id, &j.name, &config, &j.paused, &j.public, &j.firstLoggedBuildID, &j.pipelineID, &j.pipelineName, &pipelineInstanceVars, &j.teamID, &j.teamName, &nonce, m.SQLScanner(&j.tags), &j.hasNewInputs, &j.scheduleRequestedTime, &j.maxInFlight, &j.disableManualTrigger, &j.disableReruns, &pausedBy, &pausedAt, &j.pipelinePaused)
 	if err != nil {
 		return err
 	}

--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -87,15 +87,13 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 		Where(sq.Expr("j.schedule_requested > j.last_scheduled")).
 		Where(sq.Eq{
 			"j.active": true,
-			"j.paused": false,
-			"p.paused": false,
 		}).
 		RunWith(tx).
 		Query()
 	if err != nil {
 		return nil, err
 	}
-	defer Close(rows) // Properly defer closing the main job rows
+	defer Close(rows)
 
 	jobs, err := scanJobs(j.conn, j.lockFactory, rows)
 	if err != nil {
@@ -108,6 +106,11 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 	pipelineResourceTypes := make(map[int]ResourceTypes)
 	pipelinePrototypes := make(map[int]Prototypes)
 	for _, job := range jobs {
+		if job.Paused() || job.PipelineIsPaused() {
+			schedulerJobs = append(schedulerJobs, SchedulerJob{Job: job})
+			continue
+		}
+
 		resourceRows, err := tx.Query(`WITH inputs AS (
                 SELECT ji.resource_id from job_inputs ji where ji.job_id = $1
                 UNION

--- a/atc/db/job_factory_test.go
+++ b/atc/db/job_factory_test.go
@@ -505,6 +505,15 @@ var _ = Describe("JobFactory", func() {
 					Jobs: atc.JobConfigs{
 						{Name: "job-name"},
 					},
+					Resources: atc.ResourceConfigs{
+						{Name: "resource-name", Type: "type-name"},
+					},
+					ResourceTypes: atc.ResourceTypes{
+						{Name: "type-name"},
+					},
+					Prototypes: atc.Prototypes{
+						{Name: "prototype-name"},
+					},
 				}, db.ConfigVersion(1), false)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -520,10 +529,65 @@ var _ = Describe("JobFactory", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("does not fetch that job", func() {
+			It("does fetch that job", func() {
 				jobs, err := jobFactory.JobsToSchedule()
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(jobs)).To(Equal(0))
+				Expect(jobs).To(HaveLen(1))
+			})
+
+			It("does not fetch the resources or prototypes for the job", func() {
+				jobs, err := jobFactory.JobsToSchedule()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(jobs).To(HaveLen(1))
+				Expect(jobs[0].Resources).To(HaveLen(0))
+				Expect(jobs[0].ResourceTypes).To(HaveLen(0))
+				Expect(jobs[0].Prototypes).To(HaveLen(0))
+			})
+		})
+
+		Context("when the pipeline is paused but it's job has a later schedule requested time", func() {
+			BeforeEach(func() {
+				pipeline1, _, err := defaultTeam.SavePipeline(atc.PipelineRef{Name: "fake-pipeline"}, atc.Config{
+					Jobs: atc.JobConfigs{
+						{Name: "job-name"},
+					},
+					Resources: atc.ResourceConfigs{
+						{Name: "resource-name", Type: "type-name"},
+					},
+					ResourceTypes: atc.ResourceTypes{
+						{Name: "type-name"},
+					},
+					Prototypes: atc.Prototypes{
+						{Name: "prototype-name"},
+					},
+				}, db.ConfigVersion(1), false)
+				Expect(err).ToNot(HaveOccurred())
+
+				var found bool
+				job1, found, err = pipeline1.Job("job-name")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				err = job1.RequestSchedule()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = pipeline1.Pause("")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("does fetch that job", func() {
+				jobs, err := jobFactory.JobsToSchedule()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(jobs)).To(Equal(1))
+			})
+
+			It("does not fetch the resources or prototypes for the job", func() {
+				jobs, err := jobFactory.JobsToSchedule()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(jobs).To(HaveLen(1))
+				Expect(jobs[0].Resources).To(HaveLen(0))
+				Expect(jobs[0].ResourceTypes).To(HaveLen(0))
+				Expect(jobs[0].Prototypes).To(HaveLen(0))
 			})
 		})
 
@@ -545,34 +609,6 @@ var _ = Describe("JobFactory", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				_, _, err = defaultTeam.SavePipeline(atc.PipelineRef{Name: "fake-pipeline"}, atc.Config{}, pipeline1.ConfigVersion(), false)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("does not fetch that job", func() {
-				jobs, err := jobFactory.JobsToSchedule()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(len(jobs)).To(Equal(0))
-			})
-		})
-
-		Context("when the pipeline is paused but it's job has a later schedule requested time", func() {
-			BeforeEach(func() {
-				pipeline1, _, err := defaultTeam.SavePipeline(atc.PipelineRef{Name: "fake-pipeline"}, atc.Config{
-					Jobs: atc.JobConfigs{
-						{Name: "job-name"},
-					},
-				}, db.ConfigVersion(1), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				var found bool
-				job1, found, err = pipeline1.Job("job-name")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				err = job1.RequestSchedule()
-				Expect(err).ToNot(HaveOccurred())
-
-				err = pipeline1.Pause("")
 				Expect(err).ToNot(HaveOccurred())
 			})
 

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -1546,7 +1546,7 @@ func saveResources(tx Tx, resources atc.ResourceConfigs, pipelineID int) (map[st
 
 	existingResources, err := existingResources(tx, pipelineID)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	for _, resource := range resources {

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -238,7 +238,7 @@ func (s *buildStarter) tryStartNextPendingBuild(
 		"build-name": nextPendingBuild.Name(),
 	})
 
-	if nextPendingBuild.IsAborted() {
+	if nextPendingBuild.IsAborted() || job.PipelineIsArchived() {
 		logger.Debug("cancel-aborted-pending-build")
 
 		err := nextPendingBuild.Finish(db.BuildStatusAborted)

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -232,6 +232,8 @@ func (s *buildStarter) tryStartNextPendingBuild(
 	job db.SchedulerJob,
 ) (startResults, error) {
 	logger = logger.Session("try-start-next-pending-build", lager.Data{
+		"pipeline":   job.PipelineName(),
+		"job":        job.Name(),
 		"build-id":   nextPendingBuild.ID(),
 		"build-name": nextPendingBuild.Name(),
 	})

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -249,6 +249,46 @@ var _ = Describe("BuildStarter", func() {
 				})
 			})
 
+			Context("when the pipeline is archived", func() {
+				BeforeEach(func() {
+					job.PipelineIsArchivedReturns(true)
+				})
+
+				JustBeforeEach(func() {
+					needsReschedule, tryStartErr = buildStarter.TryStartPendingBuildsForJob(
+						testLogger,
+						db.SchedulerJob{
+							Job:           job,
+							Resources:     resources,
+							ResourceTypes: resourceTypes,
+							Prototypes:    prototypes,
+						},
+						jobInputs,
+					)
+				})
+
+				It("aborts the pending build", func() {
+					Expect(createdBuild.FinishCallCount()).To(Equal(1))
+					Expect(createdBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusAborted))
+				})
+
+				It("returns without error", func() {
+					Expect(tryStartErr).NotTo(HaveOccurred())
+					Expect(needsReschedule).To(BeFalse())
+				})
+
+				Context("when finishing the build fails", func() {
+					BeforeEach(func() {
+						createdBuild.FinishReturns(disaster)
+					})
+
+					It("returns an error", func() {
+						Expect(tryStartErr).To(Equal(fmt.Errorf("finish aborted build: %w", disaster)))
+						Expect(needsReschedule).To(BeFalse())
+					})
+				})
+			})
+
 			Context("when manually triggered", func() {
 				BeforeEach(func() {
 					createdBuild.IsManuallyTriggeredReturns(true)

--- a/atc/scheduler/scheduler.go
+++ b/atc/scheduler/scheduler.go
@@ -21,6 +21,8 @@ type Algorithm interface {
 	) (db.InputMapping, bool, bool, error)
 }
 
+var _ BuildScheduler = (*Scheduler)(nil)
+
 type Scheduler struct {
 	Algorithm    Algorithm
 	BuildStarter BuildStarter
@@ -31,6 +33,12 @@ func (s *Scheduler) Schedule(
 	logger lager.Logger,
 	job db.SchedulerJob,
 ) (bool, error) {
+	if job.Paused() || job.PipelineIsPaused() {
+		// Skip making more db calls and check for any pending builds that users
+		// may be trying to abort
+		return s.BuildStarter.TryStartPendingBuildsForJob(logger, job, nil)
+	}
+
 	jobInputs, err := job.AlgorithmInputs()
 	if err != nil {
 		return false, fmt.Errorf("inputs: %w", err)

--- a/atc/scheduler/scheduler_test.go
+++ b/atc/scheduler/scheduler_test.go
@@ -477,5 +477,41 @@ var _ = Describe("Scheduler", func() {
 				Expect(scheduleErr).To(Equal(fmt.Errorf("inputs: %w", disaster)))
 			})
 		})
+
+		Context("when the pipeline is paused", func() {
+			BeforeEach(func() {
+				fakeJob.PipelineIsPausedReturns(true)
+			})
+
+			It("does not schedule the job", func() {
+				Expect(scheduleErr).To(BeNil())
+
+				Expect(fakeBuildStarter.TryStartPendingBuildsForJobCallCount()).To(Equal(1))
+				_, _, inputConfigs := fakeBuildStarter.TryStartPendingBuildsForJobArgsForCall(0)
+				Expect(inputConfigs).To(BeNil())
+
+				Expect(fakeJob.AlgorithmInputsCallCount()).To(Equal(0))
+				Expect(fakeJob.RequestScheduleCallCount()).To(Equal(0))
+				Expect(fakeJob.SaveNextInputMappingCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when the job is paused", func() {
+			BeforeEach(func() {
+				fakeJob.PausedReturns(true)
+			})
+
+			It("does not schedule the job", func() {
+				Expect(scheduleErr).To(BeNil())
+
+				Expect(fakeBuildStarter.TryStartPendingBuildsForJobCallCount()).To(Equal(1))
+				_, _, inputConfigs := fakeBuildStarter.TryStartPendingBuildsForJobArgsForCall(0)
+				Expect(inputConfigs).To(BeNil())
+
+				Expect(fakeJob.AlgorithmInputsCallCount()).To(Equal(0))
+				Expect(fakeJob.RequestScheduleCallCount()).To(Equal(0))
+				Expect(fakeJob.SaveNextInputMappingCallCount()).To(Equal(0))
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

closes #9519

This PR fixes a bug and adds an enhancement.

* Enhancement: automatically abort pending builds in archived pipelines
  * I tested and it was possible for a user to manually abort the build
* Bug: pending builds can be aborted even when the pipeline is paused
  * This bug was introduced in v6.0.0, when a lot of changes were made to the scheduler and adjacent components. See the note for more details.


## Notes to reviewer

This bug was introduced in v6.0.0 when big changes were made to the
scheduler and related db components. It was made by a change to the
JobFactory query that fetches jobs that need scheduling. The query would
filter out jobs and pipelines that were paused, making it impossible for
us to abort any builds that were part of paused jobs or pipelines.

Changing this query alone fixes the bug without any weird scheduling
regressions. The rest of the changes are to ensure we don't consume any
more resources than we need to, ensuring performance doesn't degrade
since we'll definitely fetch more builds now.

First, I had to update db.Job to include info about its pipeline being
paused or not. That leverages the existing job query already used across
the codebase. That information is exposed via the PipelineIsPaused()
func.

With this info, the scheduler can now detect if the job or pipeline is
paused and take a shorter path, skipping all the algorithm calls.

We then rely on db.Job.ScheduleBuild() to see that the job or pipeline
is paused, and not schedule any pending builds. I was also able to
remove one query from db.Job.isPipelineOrJobPaused() since the info it
queried for was now part of db.Job.pipelinePaused.

Overall there should be very minimal impact on performance from this
change.
