### PR TITLE
Database cleanup and optimizations

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1460,7 +1460,7 @@ func (b *build) AdoptInputsAndPipes() ([]BuildInput, bool, error) {
 		}
 	}
 
-	buildInputs := []BuildInput{}
+	buildInputs := make([]BuildInput, 0, len(inputs))
 
 	for inputName, input := range inputs {
 		var versionBlob string

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -318,7 +318,7 @@ var _ = Describe("CheckFactory", func() {
 
 			Context("when build is created in db", func() {
 				It("creates a check plan", func() {
-					var rts atc.ResourceTypes
+					rts := atc.ResourceTypes{}
 					Expect(fakeResourceType.CheckPlanCallCount()).To(Equal(1))
 					_, types, version, interval, defaults, _, _ := fakeResourceType.CheckPlanArgsForCall(0)
 					Expect(version).To(Equal(atc.Version{"from": "version"}))
@@ -347,7 +347,7 @@ var _ = Describe("CheckFactory", func() {
 				})
 
 				It("creates a check plan", func() {
-					var rts atc.ResourceTypes
+					rts := atc.ResourceTypes{}
 					Expect(fakeResourceType.CheckPlanCallCount()).To(Equal(1))
 					_, types, version, interval, defaults, _, _ := fakeResourceType.CheckPlanArgsForCall(0)
 					Expect(version).To(Equal(atc.Version{"from": "version"}))

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -1508,17 +1508,15 @@ func requestScheduleOnDownstreamJobs(tx Tx, jobID int) error {
 		jobIDs = append(jobIDs, id)
 	}
 
-	for _, jID := range jobIDs {
-		_, err := psql.Update("jobs").
-			Set("schedule_requested", sq.Expr("now()")).
-			Where(sq.Eq{
-				"id": jID,
-			}).
-			RunWith(tx).
-			Exec()
-		if err != nil {
-			return err
-		}
+	_, err = psql.Update("jobs").
+		Set("schedule_requested", sq.Expr("now()")).
+		Where(sq.Eq{
+			"id": jobIDs,
+		}).
+		RunWith(tx).
+		Exec()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -293,6 +293,7 @@ func (j *job) AlgorithmInputs() (InputConfigs, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	var inputs InputConfigs
 	m := pgtype.NewMap()
@@ -366,6 +367,7 @@ func (j *job) Inputs() ([]atc.JobInput, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	var inputs []atc.JobInput
 	m := pgtype.NewMap()
@@ -421,6 +423,7 @@ func (j *job) Outputs() ([]atc.JobOutput, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	var outputs []atc.JobOutput
 	for rows.Next() {
@@ -1044,6 +1047,7 @@ func (j *job) getSerialGroups(tx Tx) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	var serialGroups []string
 	for rows.Next() {

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -209,10 +209,10 @@ func (j *job) SetHasNewInputs(hasNewInputs bool) error {
 
 type Jobs []Job
 
-func (jobs Jobs) Configs() (atc.JobConfigs, error) {
-	var configs atc.JobConfigs
+func (js Jobs) Configs() (atc.JobConfigs, error) {
+	configs := make(atc.JobConfigs, 0, len(js))
 
-	for _, j := range jobs {
+	for _, j := range js {
 		config, err := j.Config()
 		if err != nil {
 			return nil, err

--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -100,70 +100,36 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 		return nil, err
 	}
 
-	es := j.conn.EncryptionStrategy()
-
-	var schedulerJobs SchedulerJobs
-	pipelineResourceTypes := make(map[int]ResourceTypes)
-	pipelinePrototypes := make(map[int]Prototypes)
+	// Separate paused from non-paused jobs; only non-paused jobs need
+	// resource, resource type, and prototype lookups.
+	schedulerJobs := make(SchedulerJobs, 0, len(jobs))
+	var nonPausedJobs []Job
+	var nonPausedJobIDs []int
 	for _, job := range jobs {
 		if job.Paused() || job.PipelineIsPaused() {
 			schedulerJobs = append(schedulerJobs, SchedulerJob{Job: job})
-			continue
+		} else {
+			nonPausedJobs = append(nonPausedJobs, job)
+			nonPausedJobIDs = append(nonPausedJobIDs, job.ID())
 		}
+	}
 
-		resourceRows, err := tx.Query(`WITH inputs AS (
-                SELECT ji.resource_id from job_inputs ji where ji.job_id = $1
-                UNION
-                SELECT jo.resource_id from job_outputs jo where jo.job_id = $1
-            )
-            SELECT r.name, r.type, r.config, r.nonce
-            From resources r
-            Join inputs i on i.resource_id = r.id`, job.ID())
+	if len(nonPausedJobs) == 0 {
+		err = tx.Commit()
 		if err != nil {
 			return nil, err
 		}
-		defer Close(resourceRows)
+		return schedulerJobs, nil
+	}
 
-		var schedulerResources SchedulerResources
-		for resourceRows.Next() {
-			var name, type_ string
-			var configBlob []byte
-			var nonce sql.NullString
+	jobResources, err := j.fetchJobResources(tx, nonPausedJobIDs)
+	if err != nil {
+		return nil, err
+	}
 
-			err = resourceRows.Scan(&name, &type_, &configBlob, &nonce)
-			if err != nil {
-				return nil, err
-			}
-
-			var noncense *string
-			if nonce.Valid {
-				noncense = &nonce.String
-			}
-
-			decryptedConfig, err := es.Decrypt(string(configBlob), noncense)
-			if err != nil {
-				return nil, err
-			}
-
-			var config atc.ResourceConfig
-			err = json.Unmarshal(decryptedConfig, &config)
-			if err != nil {
-				return nil, err
-			}
-
-			schedulerResources = append(schedulerResources, SchedulerResource{
-				Name:                 name,
-				Type:                 type_,
-				Source:               config.Source,
-				ExposeBuildCreatedBy: config.ExposeBuildCreatedBy,
-			})
-		}
-		if err = resourceRows.Err(); err != nil {
-			resourceRows.Close()
-			return nil, err
-		}
-		resourceRows.Close()
-
+	pipelineResourceTypes := make(map[int]ResourceTypes)
+	pipelinePrototypes := make(map[int]Prototypes)
+	for _, job := range nonPausedJobs {
 		resourceTypes, found := pipelineResourceTypes[job.PipelineID()]
 		if !found {
 			resourceTypeRows, err := resourceTypesQuery.
@@ -174,12 +140,12 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 			if err != nil {
 				return nil, err
 			}
-			defer Close(resourceTypeRows)
 
 			for resourceTypeRows.Next() {
 				resourceType := newEmptyResourceType(j.conn, j.lockFactory)
 				err := scanResourceType(resourceType, resourceTypeRows)
 				if err != nil {
+					resourceTypeRows.Close()
 					return nil, err
 				}
 
@@ -204,12 +170,12 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 			if err != nil {
 				return nil, err
 			}
-			defer Close(prototypeRows)
 
 			for prototypeRows.Next() {
 				prototype := newEmptyPrototype(j.conn, j.lockFactory)
 				err := scanPrototype(prototype, prototypeRows)
 				if err != nil {
+					prototypeRows.Close()
 					return nil, err
 				}
 
@@ -226,7 +192,7 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 
 		schedulerJobs = append(schedulerJobs, SchedulerJob{
 			Job:           job,
-			Resources:     schedulerResources,
+			Resources:     jobResources[job.ID()],
 			ResourceTypes: resourceTypes.Deserialize(),
 			Prototypes:    prototypes.Configs(),
 		})
@@ -238,6 +204,65 @@ func (j *jobFactory) JobsToSchedule() (SchedulerJobs, error) {
 	}
 
 	return schedulerJobs, nil
+}
+
+func (j *jobFactory) fetchJobResources(tx Tx, jobIDs []int) (map[int]SchedulerResources, error) {
+	rows, err := tx.Query(`
+		SELECT sub.job_id, r.name, r.type, r.config, r.nonce
+		FROM (
+			SELECT ji.job_id, ji.resource_id FROM job_inputs ji WHERE ji.job_id = ANY($1)
+			UNION
+			SELECT jo.job_id, jo.resource_id FROM job_outputs jo WHERE jo.job_id = ANY($1)
+		) sub
+		JOIN resources r ON r.id = sub.resource_id`, jobIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer Close(rows)
+
+	es := j.conn.EncryptionStrategy()
+	result := make(map[int]SchedulerResources)
+
+	for rows.Next() {
+		var jobID int
+		var name, rsType string
+		var configBlob []byte
+		var nonce sql.NullString
+
+		err = rows.Scan(&jobID, &name, &rsType, &configBlob, &nonce)
+		if err != nil {
+			return nil, err
+		}
+
+		var noncense *string
+		if nonce.Valid {
+			noncense = &nonce.String
+		}
+
+		decryptedConfig, err := es.Decrypt(string(configBlob), noncense)
+		if err != nil {
+			return nil, err
+		}
+
+		var config atc.ResourceConfig
+		err = json.Unmarshal(decryptedConfig, &config)
+		if err != nil {
+			return nil, err
+		}
+
+		result[jobID] = append(result[jobID], SchedulerResource{
+			Name:                 name,
+			Type:                 rsType,
+			Source:               config.Source,
+			ExposeBuildCreatedBy: config.ExposeBuildCreatedBy,
+		})
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 func (j *jobFactory) VisibleJobs(teamNames []string) ([]atc.JobSummary, error) {

--- a/atc/db/listener.go
+++ b/atc/db/listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"code.cloudfoundry.org/lager/v3"
 	"github.com/cenkalti/backoff/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -20,6 +21,8 @@ type PgxListener struct {
 	channels   map[string]struct{}
 	cancelFunc context.CancelFunc
 	comms      chan struct{}
+
+	logger lager.Logger
 }
 
 var (
@@ -29,7 +32,7 @@ var (
 	start         struct{}
 )
 
-func NewPgxListener(pool *pgxpool.Pool) *PgxListener {
+func NewPgxListener(pool *pgxpool.Pool, log lager.Logger) *PgxListener {
 	conn, err := pool.Acquire(context.Background())
 	if err != nil {
 		panic(err)
@@ -41,6 +44,7 @@ func NewPgxListener(pool *pgxpool.Pool) *PgxListener {
 		notify:   make(chan *pgconn.Notification, 32),
 		comms:    make(chan struct{}),
 		channels: make(map[string]struct{}),
+		logger:   log.Session("db-listener"),
 	}
 
 	go l.ListenerMain()
@@ -121,12 +125,15 @@ func (l *PgxListener) listenerLoop() {
 				// Will retry to a max of 15mins
 				_, err = backoff.Retry(ctx, l.reconnect, backoff.WithBackOff(backoff.NewExponentialBackOff()))
 				if err != nil {
-					panic(fmt.Errorf("unable to reconnect to the database: %w", err))
+					l.logger.Error("reconnect-to-db", fmt.Errorf("unable to reconnect to the database: %w", err))
 				}
 
 				//listen to all channels again
 				for channel, _ := range l.channels {
-					l.conn.Exec(ctx, fmt.Sprintf("LISTEN %s", channel))
+					_, err := l.conn.Exec(ctx, fmt.Sprintf("LISTEN %s", channel))
+					if err != nil {
+						l.logger.Error("error-listening-to-channel", err, lager.Data{"channel": channel})
+					}
 				}
 			}
 			cancel()

--- a/atc/db/listener_test.go
+++ b/atc/db/listener_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -17,17 +19,19 @@ var _ = Describe("PgxListener", func() {
 		err          error
 		notifierConn db.DbConn
 		listener     *db.PgxListener
+		logger       lager.Logger
 
 		testPayload = "hello"
 	)
 
 	BeforeEach(func(ctx context.Context) {
+		logger = lagertest.NewTestLogger("")
 		notifierConn = postgresRunner.OpenConn()
 
 		pool, err := pgxpool.New(ctx, postgresRunner.DataSourceName())
 		Expect(err).ToNot(HaveOccurred())
 
-		listener = db.NewPgxListener(pool)
+		listener = db.NewPgxListener(pool, logger)
 		Expect(listener).ToNot(BeNil())
 	})
 

--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -76,18 +76,18 @@ func Open(logger lager.Logger, driver, dsn string, newKey, oldKey *encryption.Ke
 			return nil, err
 		}
 
-		return NewConn(name, sqlDB, dsn, oldKey, newKey)
+		return NewConn(logger, name, sqlDB, dsn, oldKey, newKey)
 	}
 }
 
-func NewConn(name string, sqlDB *sql.DB, dsn string, oldKey, newKey *encryption.Key) (DbConn, error) {
+func NewConn(logger lager.Logger, name string, sqlDB *sql.DB, dsn string, oldKey, newKey *encryption.Key) (DbConn, error) {
 	// only used for the LISTEN/NOTIFY commands
 	pool, err := pgxpool.New(context.Background(), dsn)
 	if err != nil {
 		return nil, err
 	}
 
-	listener := NewPgxListener(pool)
+	listener := NewPgxListener(pool, logger)
 
 	var strategy encryption.Strategy
 	if newKey != nil {

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -1291,6 +1291,7 @@ func requestScheduleForJobsInPipeline(tx Tx, pipelineID int) error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	var jobIDs []int
 	for rows.Next() {

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -1304,17 +1304,15 @@ func requestScheduleForJobsInPipeline(tx Tx, pipelineID int) error {
 		jobIDs = append(jobIDs, id)
 	}
 
-	for _, jID := range jobIDs {
-		_, err := psql.Update("jobs").
-			Set("schedule_requested", sq.Expr("now()")).
-			Where(sq.Eq{
-				"id": jID,
-			}).
-			RunWith(tx).
-			Exec()
-		if err != nil {
-			return err
-		}
+	_, err = psql.Update("jobs").
+		Set("schedule_requested", sq.Expr("now()")).
+		Where(sq.Eq{
+			"id": jobIDs,
+		}).
+		RunWith(tx).
+		Exec()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -1143,17 +1143,15 @@ func requestScheduleForJobsUsingResource(tx Tx, resourceID int) error {
 		jobs = append(jobs, jid)
 	}
 
-	for _, j := range jobs {
-		_, err := psql.Update("jobs").
-			Set("schedule_requested", sq.Expr("now()")).
-			Where(sq.Eq{
-				"id": j,
-			}).
-			RunWith(tx).
-			Exec()
-		if err != nil {
-			return err
-		}
+	_, err = psql.Update("jobs").
+		Set("schedule_requested", sq.Expr("now()")).
+		Where(sq.Eq{
+			"id": jobs,
+		}).
+		RunWith(tx).
+		Exec()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -214,7 +214,7 @@ func (resources Resources) Lookup(name string) (Resource, bool) {
 }
 
 func (resources Resources) Configs() atc.ResourceConfigs {
-	var configs atc.ResourceConfigs
+	configs := make(atc.ResourceConfigs, 0, len(resources))
 	for _, r := range resources {
 		configs = append(configs, r.Config())
 	}

--- a/atc/db/resource_cache_lifecycle.go
+++ b/atc/db/resource_cache_lifecycle.go
@@ -162,7 +162,7 @@ func (f *resourceCacheLifecycle) CleanUpInvalidCaches(logger lager.Logger) error
 		var cacheID int
 		err = rows.Scan(&cacheID)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		deletedCacheIDs = append(deletedCacheIDs, cacheID)

--- a/atc/db/resource_factory.go
+++ b/atc/db/resource_factory.go
@@ -78,6 +78,7 @@ func (r *resourceFactory) AllResources() ([]Resource, error) {
 func scanResources(resourceRows *sql.Rows, conn DbConn, lockFactory lock.LockFactory) ([]Resource, error) {
 	var resources []Resource
 
+	defer resourceRows.Close()
 	for resourceRows.Next() {
 		resource := newEmptyResource(conn, lockFactory)
 		err := scanResource(resource, resourceRows)

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -87,7 +87,7 @@ func (resourceTypes ResourceTypes) Filter(checkable Checkable) ResourceTypes {
 }
 
 func (resourceTypes ResourceTypes) Deserialize() atc.ResourceTypes {
-	var atcResourceTypes atc.ResourceTypes
+	atcResourceTypes := make(atc.ResourceTypes, 0, len(resourceTypes))
 
 	for _, t := range resourceTypes {
 		// Apply source defaults to resource types
@@ -118,7 +118,7 @@ func (resourceTypes ResourceTypes) Deserialize() atc.ResourceTypes {
 }
 
 func (resourceTypes ResourceTypes) Configs() atc.ResourceTypes {
-	var configs atc.ResourceTypes
+	configs := make(atc.ResourceTypes, 0, len(resourceTypes))
 
 	for _, r := range resourceTypes {
 		configs = append(configs, atc.ResourceType{

--- a/atc/db/worker_factory.go
+++ b/atc/db/worker_factory.go
@@ -89,7 +89,7 @@ func (f *workerFactory) VisibleWorkers(teamNames []string) ([]Worker, error) {
 		return slices.Contains(teamNames, worker.TeamName())
 	}
 
-	visibleWorkers := []Worker{}
+	visibleWorkers := make([]Worker, 0, len(workers))
 	for _, worker := range workers {
 		if isVisible(worker) {
 			visibleWorkers = append(visibleWorkers, worker)


### PR DESCRIPTION
## Changes proposed by this PR

This PR cleans up a few things and makes a few optimizations as well.

- Updated the `PgxListener` to log errors instead of `panic`
- Preallocate slices to the length of incoming objects. Eliminates copy/growth operations
- Updated three spots where we set the `schedule_requested` column for multiple jobs in a for loop, doing one query per job. Now we do a single batch query by passing in the list of job ID's to update with a `WHERE id IN (...)` clause
- Updated the JobFactory to fetch all job resources in one batch query instead of once per job.