### PR TITLE
feat(atc): natively inject BUILD_STATUS into resource metadata

### DIFF
--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -60,387 +60,352 @@ type stepperFactory struct {
 	lockFactory     lock.LockFactory
 }
 
+type planBuilder struct {
+	factory    *stepperFactory
+	build      db.Build
+	buildState string
+}
+
+func (pb *planBuilder) withBuildState(state string) *planBuilder {
+	return &planBuilder{factory: pb.factory, build: pb.build, buildState: state}
+}
+
 func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, error) {
 	if build.Schema() != supportedSchema {
 		return nil, errors.New("schema not supported")
 	}
 
+	pb := &planBuilder{factory: factory, build: build, buildState: build.Status().String()}
 	return func(plan atc.Plan) exec.Step {
-		return factory.buildStep(build, plan, string(build.Status()))
+		return pb.buildStep(plan)
 	}, nil
 }
 
-func (factory *stepperFactory) buildDelegateFactory(build db.Build, plan atc.Plan) DelegateFactory {
+func (pb *planBuilder) buildDelegateFactory(plan atc.Plan) DelegateFactory {
 	return DelegateFactory{
-		build:           build,
+		build:           pb.build,
 		plan:            plan,
-		rateLimiter:     factory.rateLimiter,
-		policyChecker:   factory.policyChecker,
-		dbWorkerFactory: factory.dbWorkerFactory,
-		lockFactory:     factory.lockFactory,
+		rateLimiter:     pb.factory.rateLimiter,
+		policyChecker:   pb.factory.policyChecker,
+		dbWorkerFactory: pb.factory.dbWorkerFactory,
+		lockFactory:     pb.factory.lockFactory,
 	}
 }
 
-func (factory *stepperFactory) buildStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildStep(plan atc.Plan) exec.Step {
 	if plan.InParallel != nil {
-		return factory.buildParallelStep(build, plan, buildState)
+		return pb.buildParallelStep(plan)
 	}
 
 	if plan.Across != nil {
-		return factory.buildAcrossStep(build, plan, buildState)
+		return pb.buildAcrossStep(plan)
 	}
 
 	if plan.Do != nil {
-		return factory.buildDoStep(build, plan, buildState)
+		return pb.buildDoStep(plan)
 	}
 
 	if plan.Timeout != nil {
-		return factory.buildTimeoutStep(build, plan, buildState)
+		return pb.buildTimeoutStep(plan)
 	}
 
 	if plan.Try != nil {
-		return factory.buildTryStep(build, plan, buildState)
+		return pb.buildTryStep(plan)
 	}
 
 	if plan.OnAbort != nil {
-		return factory.buildOnAbortStep(build, plan, buildState)
+		return pb.buildOnAbortStep(plan)
 	}
 
 	if plan.OnError != nil {
-		return factory.buildOnErrorStep(build, plan, buildState)
+		return pb.buildOnErrorStep(plan)
 	}
 
 	if plan.OnSuccess != nil {
-		return factory.buildOnSuccessStep(build, plan, buildState)
+		return pb.buildOnSuccessStep(plan)
 	}
 
 	if plan.OnFailure != nil {
-		return factory.buildOnFailureStep(build, plan, buildState)
+		return pb.buildOnFailureStep(plan)
 	}
 
 	if plan.Ensure != nil {
-		return factory.buildEnsureStep(build, plan, buildState)
+		return pb.buildEnsureStep(plan)
 	}
 
 	if plan.Run != nil {
-		return factory.buildRunStep(build, plan, buildState)
+		return pb.buildRunStep(plan)
 	}
 
 	if plan.Task != nil {
-		return factory.buildTaskStep(build, plan, buildState)
+		return pb.buildTaskStep(plan)
 	}
 
 	if plan.SetPipeline != nil {
-		return factory.buildSetPipelineStep(build, plan, buildState)
+		return pb.buildSetPipelineStep(plan)
 	}
 
 	if plan.LoadVar != nil {
-		return factory.buildLoadVarStep(build, plan, buildState)
+		return pb.buildLoadVarStep(plan)
 	}
 
 	if plan.Check != nil {
-		return factory.buildCheckStep(build, plan, buildState)
+		return pb.buildCheckStep(plan)
 	}
 
 	if plan.Get != nil {
-		return factory.buildGetStep(build, plan, buildState)
+		return pb.buildGetStep(plan)
 	}
 
 	if plan.Put != nil {
-		return factory.buildPutStep(build, plan, buildState)
+		return pb.buildPutStep(plan)
 	}
 
 	if plan.Retry != nil {
-		return factory.buildRetryStep(build, plan, buildState)
+		return pb.buildRetryStep(plan)
 	}
 
 	if plan.ArtifactInput != nil {
-		return factory.buildArtifactInputStep(build, plan, buildState)
+		return pb.buildArtifactInputStep(plan)
 	}
 
 	if plan.ArtifactOutput != nil {
-		return factory.buildArtifactOutputStep(build, plan, buildState)
+		return pb.buildArtifactOutputStep(plan)
 	}
 
 	return exec.IdentityStep{}
 }
 
-func (factory *stepperFactory) buildParallelStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildParallelStep(plan atc.Plan) exec.Step {
 
 	var steps []exec.Step
 
 	for _, innerPlan := range plan.InParallel.Steps {
 		innerPlan.Attempts = plan.Attempts
-		step := factory.buildStep(build, innerPlan, buildState)
+		step := pb.buildStep(innerPlan)
 		steps = append(steps, step)
 	}
 
 	return exec.InParallel(steps, plan.InParallel.Limit, plan.InParallel.FailFast)
 }
 
-func (factory *stepperFactory) buildAcrossStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
-	stepMetadata := factory.stepMetadata(
-		build,
-		factory.externalURL,
-		false,
-		buildState,
-	)
+func (pb *planBuilder) buildAcrossStep(plan atc.Plan) exec.Step {
+	stepMetadata := pb.stepMetadata(false)
 
 	acrossStep := exec.Across(
 		*plan.Across,
-		factory.buildDelegateFactory(build, plan),
+		pb.buildDelegateFactory(plan),
 		stepMetadata,
 	)
 
-	return exec.LogError(acrossStep, factory.buildDelegateFactory(build, plan))
+	return exec.LogError(acrossStep, pb.buildDelegateFactory(plan))
 }
 
-func (factory *stepperFactory) buildDoStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildDoStep(plan atc.Plan) exec.Step {
 	var step exec.Step = exec.IdentityStep{}
 
 	for i := len(*plan.Do) - 1; i >= 0; i-- {
 		innerPlan := (*plan.Do)[i]
 		innerPlan.Attempts = plan.Attempts
-		previous := factory.buildStep(build, innerPlan, buildState)
+		previous := pb.buildStep(innerPlan)
 		step = exec.OnSuccess(previous, step)
 	}
 
 	return step
 }
 
-func (factory *stepperFactory) buildTimeoutStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildTimeoutStep(plan atc.Plan) exec.Step {
 	innerPlan := plan.Timeout.Step
 	innerPlan.Attempts = plan.Attempts
-	step := factory.buildStep(build, innerPlan, buildState)
+	step := pb.buildStep(innerPlan)
 	return exec.Timeout(step, plan.Timeout.Duration)
 }
 
-func (factory *stepperFactory) buildTryStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildTryStep(plan atc.Plan) exec.Step {
 	innerPlan := plan.Try.Step
 	innerPlan.Attempts = plan.Attempts
-	step := factory.buildStep(build, innerPlan, buildState)
+	step := pb.buildStep(innerPlan)
 	return exec.Try(step)
 }
 
-func (factory *stepperFactory) buildOnAbortStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildOnAbortStep(plan atc.Plan) exec.Step {
 	plan.OnAbort.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.OnAbort.Step, buildState)
+	step := pb.buildStep(plan.OnAbort.Step)
 	plan.OnAbort.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.OnAbort.Next, string(db.BuildStatusAborted))
+	next := pb.withBuildState(db.BuildStatusAborted.String()).buildStep(plan.OnAbort.Next)
 	return exec.OnAbort(step, next)
 }
 
-func (factory *stepperFactory) buildOnErrorStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildOnErrorStep(plan atc.Plan) exec.Step {
 	plan.OnError.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.OnError.Step, buildState)
+	step := pb.buildStep(plan.OnError.Step)
 	plan.OnError.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.OnError.Next, string(db.BuildStatusErrored))
+	next := pb.withBuildState(db.BuildStatusErrored.String()).buildStep(plan.OnError.Next)
 	return exec.OnError(step, next)
 }
 
-func (factory *stepperFactory) buildOnSuccessStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildOnSuccessStep(plan atc.Plan) exec.Step {
 	plan.OnSuccess.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.OnSuccess.Step, buildState)
+	step := pb.buildStep(plan.OnSuccess.Step)
 	plan.OnSuccess.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.OnSuccess.Next, string(db.BuildStatusSucceeded))
+	next := pb.withBuildState(db.BuildStatusSucceeded.String()).buildStep(plan.OnSuccess.Next)
 	return exec.OnSuccess(step, next)
 }
 
-func (factory *stepperFactory) buildOnFailureStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildOnFailureStep(plan atc.Plan) exec.Step {
 	plan.OnFailure.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.OnFailure.Step, buildState)
+	step := pb.buildStep(plan.OnFailure.Step)
 	plan.OnFailure.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.OnFailure.Next, string(db.BuildStatusFailed))
+	next := pb.withBuildState(db.BuildStatusFailed.String()).buildStep(plan.OnFailure.Next)
 	return exec.OnFailure(step, next)
 }
 
-func (factory *stepperFactory) buildEnsureStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildEnsureStep(plan atc.Plan) exec.Step {
 	plan.Ensure.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.Ensure.Step, buildState)
+	step := pb.buildStep(plan.Ensure.Step)
 	plan.Ensure.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.Ensure.Next, buildState)
+	next := pb.buildStep(plan.Ensure.Next)
 	return exec.Ensure(step, next)
 }
 
-func (factory *stepperFactory) buildRetryStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildRetryStep(plan atc.Plan) exec.Step {
 	steps := []exec.Step{}
 
 	for index, innerPlan := range *plan.Retry {
 		innerPlan.Attempts = append(plan.Attempts, index+1)
 
-		step := factory.buildStep(build, innerPlan, buildState)
+		step := pb.buildStep(innerPlan)
 		steps = append(steps, step)
 	}
 
 	return exec.Retry(steps...)
 }
 
-func (factory *stepperFactory) buildGetStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildGetStep(plan atc.Plan) exec.Step {
 
-	containerMetadata := factory.containerMetadata(
-		build,
+	containerMetadata := pb.containerMetadata(
 		db.ContainerTypeGet,
 		plan.Get.Name,
 		plan.Attempts,
 	)
 
-	stepMetadata := factory.stepMetadata(
-		build,
-		factory.externalURL,
-		false,
-		buildState,
-	)
+	stepMetadata := pb.stepMetadata(false)
 
-	return factory.coreFactory.GetStep(
+	return pb.factory.coreFactory.GetStep(
 		plan,
 		stepMetadata,
 		containerMetadata,
-		factory.buildDelegateFactory(build, plan),
+		pb.buildDelegateFactory(plan),
 	)
 }
 
-func (factory *stepperFactory) buildPutStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildPutStep(plan atc.Plan) exec.Step {
 
-	containerMetadata := factory.containerMetadata(
-		build,
+	containerMetadata := pb.containerMetadata(
 		db.ContainerTypePut,
 		plan.Put.Name,
 		plan.Attempts,
 	)
 
-	stepMetadata := factory.stepMetadata(
-		build,
-		factory.externalURL,
-		plan.Put.ExposeBuildCreatedBy,
-		buildState,
-	)
+	stepMetadata := pb.stepMetadata(plan.Put.ExposeBuildCreatedBy)
 
-	return factory.coreFactory.PutStep(
+	return pb.factory.coreFactory.PutStep(
 		plan,
 		stepMetadata,
 		containerMetadata,
-		factory.buildDelegateFactory(build, plan),
+		pb.buildDelegateFactory(plan),
 	)
 }
 
-func (factory *stepperFactory) buildCheckStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
-	containerMetadata := factory.containerMetadata(
-		build,
+func (pb *planBuilder) buildCheckStep(plan atc.Plan) exec.Step {
+	containerMetadata := pb.containerMetadata(
 		db.ContainerTypeCheck,
 		plan.Check.Name,
 		plan.Attempts,
 	)
 
-	stepMetadata := factory.stepMetadata(
-		build,
-		factory.externalURL,
-		false,
-		buildState,
-	)
+	stepMetadata := pb.stepMetadata(false)
 
-	return factory.coreFactory.CheckStep(
+	return pb.factory.coreFactory.CheckStep(
 		plan,
 		stepMetadata,
 		containerMetadata,
-		factory.buildDelegateFactory(build, plan),
+		pb.buildDelegateFactory(plan),
 	)
 }
 
-func (factory *stepperFactory) buildRunStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
-	containerMetadata := factory.containerMetadata(
-		build,
+func (pb *planBuilder) buildRunStep(plan atc.Plan) exec.Step {
+	containerMetadata := pb.containerMetadata(
 		db.ContainerTypeRun,
 		plan.Run.Message,
 		plan.Attempts,
 	)
 
-	stepMetadata := factory.stepMetadata(
-		build,
-		factory.externalURL,
-		false,
-		buildState,
-	)
+	stepMetadata := pb.stepMetadata(false)
 
-	return factory.coreFactory.RunStep(
+	return pb.factory.coreFactory.RunStep(
 		plan,
 		stepMetadata,
 		containerMetadata,
-		factory.buildDelegateFactory(build, plan),
+		pb.buildDelegateFactory(plan),
 	)
 }
 
-func (factory *stepperFactory) buildTaskStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildTaskStep(plan atc.Plan) exec.Step {
 
-	containerMetadata := factory.containerMetadata(
-		build,
+	containerMetadata := pb.containerMetadata(
 		db.ContainerTypeTask,
 		plan.Task.Name,
 		plan.Attempts,
 	)
 
-	stepMetadata := factory.stepMetadata(
-		build,
-		factory.externalURL,
-		false,
-		buildState,
-	)
+	stepMetadata := pb.stepMetadata(false)
 
-	return factory.coreFactory.TaskStep(
+	return pb.factory.coreFactory.TaskStep(
 		plan,
 		stepMetadata,
 		containerMetadata,
-		factory.buildDelegateFactory(build, plan),
+		pb.buildDelegateFactory(plan),
 	)
 }
 
-func (factory *stepperFactory) buildSetPipelineStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildSetPipelineStep(plan atc.Plan) exec.Step {
 
-	stepMetadata := factory.stepMetadata(
-		build,
-		factory.externalURL,
-		false,
-		buildState,
-	)
+	stepMetadata := pb.stepMetadata(false)
 
-	return factory.coreFactory.SetPipelineStep(
+	return pb.factory.coreFactory.SetPipelineStep(
 		plan,
 		stepMetadata,
-		factory.buildDelegateFactory(build, plan),
+		pb.buildDelegateFactory(plan),
 	)
 }
 
-func (factory *stepperFactory) buildLoadVarStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
+func (pb *planBuilder) buildLoadVarStep(plan atc.Plan) exec.Step {
 
-	stepMetadata := factory.stepMetadata(
-		build,
-		factory.externalURL,
-		false,
-		buildState,
-	)
+	stepMetadata := pb.stepMetadata(false)
 
-	return factory.coreFactory.LoadVarStep(
+	return pb.factory.coreFactory.LoadVarStep(
 		plan,
 		stepMetadata,
-		factory.buildDelegateFactory(build, plan),
+		pb.buildDelegateFactory(plan),
 	)
 }
 
-func (factory *stepperFactory) buildArtifactInputStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
-	return factory.coreFactory.ArtifactInputStep(
+func (pb *planBuilder) buildArtifactInputStep(plan atc.Plan) exec.Step {
+	return pb.factory.coreFactory.ArtifactInputStep(
 		plan,
-		build,
+		pb.build,
 	)
 }
 
-func (factory *stepperFactory) buildArtifactOutputStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
-	return factory.coreFactory.ArtifactOutputStep(
+func (pb *planBuilder) buildArtifactOutputStep(plan atc.Plan) exec.Step {
+	return pb.factory.coreFactory.ArtifactOutputStep(
 		plan,
-		build,
+		pb.build,
 	)
 }
 
-func (factory *stepperFactory) containerMetadata(
-	build db.Build,
+func (pb *planBuilder) containerMetadata(
 	containerType db.ContainerType,
 	stepName string,
 	attempts []int,
@@ -451,50 +416,47 @@ func (factory *stepperFactory) containerMetadata(
 	}
 
 	var pipelineInstanceVars string
-	if build.PipelineInstanceVars() != nil {
-		instanceVars, _ := json.Marshal(build.PipelineInstanceVars())
+	if pb.build.PipelineInstanceVars() != nil {
+		instanceVars, _ := json.Marshal(pb.build.PipelineInstanceVars())
 		pipelineInstanceVars = string(instanceVars)
 	}
 
 	return db.ContainerMetadata{
 		Type: containerType,
 
-		PipelineID: build.PipelineID(),
-		JobID:      build.JobID(),
-		BuildID:    build.ID(),
+		PipelineID: pb.build.PipelineID(),
+		JobID:      pb.build.JobID(),
+		BuildID:    pb.build.ID(),
 
-		PipelineName:         build.PipelineName(),
+		PipelineName:         pb.build.PipelineName(),
 		PipelineInstanceVars: pipelineInstanceVars,
-		JobName:              build.JobName(),
-		BuildName:            build.Name(),
+		JobName:              pb.build.JobName(),
+		BuildName:            pb.build.Name(),
 
 		StepName: stepName,
 		Attempt:  strings.Join(attemptStrs, "."),
 	}
 }
 
-func (factory *stepperFactory) stepMetadata(
-	build db.Build,
-	externalURL string,
+func (pb *planBuilder) stepMetadata(
 	exposeBuildCreatedBy bool,
-	buildState string,
 ) exec.StepMetadata {
 	meta := exec.StepMetadata{
-		BuildID:              build.ID(),
-		BuildName:            build.Name(),
-		TeamID:               build.TeamID(),
-		TeamName:             build.TeamName(),
-		JobID:                build.JobID(),
-		JobName:              build.JobName(),
-		PipelineID:           build.PipelineID(),
-		PipelineName:         build.PipelineName(),
-		PipelineInstanceVars: build.PipelineInstanceVars(),
-		InstanceVarsQuery:    build.PipelineRef().QueryParams(),
-		ExternalURL:          externalURL,
-		BuildState:           buildState,
+		BuildID:              pb.build.ID(),
+		BuildName:            pb.build.Name(),
+		TeamID:               pb.build.TeamID(),
+		TeamName:             pb.build.TeamName(),
+		JobID:                pb.build.JobID(),
+		JobName:              pb.build.JobName(),
+		PipelineID:           pb.build.PipelineID(),
+		PipelineName:         pb.build.PipelineName(),
+		PipelineInstanceVars: pb.build.PipelineInstanceVars(),
+		InstanceVarsQuery:    pb.build.PipelineRef().QueryParams(),
+		ExternalURL:          pb.factory.externalURL,
+		BuildState:           pb.buildState,
 	}
-	if exposeBuildCreatedBy && build.CreatedBy() != nil {
-		meta.CreatedBy = *build.CreatedBy()
+	if exposeBuildCreatedBy && pb.build.CreatedBy() != nil {
+		meta.CreatedBy = *pb.build.CreatedBy()
 	}
 	return meta
 }

--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -75,7 +75,7 @@ func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, er
 		return nil, errors.New("schema not supported")
 	}
 
-	pb := &planBuilder{factory: factory, build: build, buildStatus: build.Status().String()}
+	pb := &planBuilder{factory: factory, build: build}
 	return func(plan atc.Plan) exec.Step {
 		return pb.buildStep(plan)
 	}, nil

--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -66,7 +66,7 @@ func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, er
 	}
 
 	return func(plan atc.Plan) exec.Step {
-		return factory.buildStep(build, plan)
+		return factory.buildStep(build, plan, string(build.Status()))
 	}, nil
 }
 
@@ -81,108 +81,109 @@ func (factory *stepperFactory) buildDelegateFactory(build db.Build, plan atc.Pla
 	}
 }
 
-func (factory *stepperFactory) buildStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	if plan.InParallel != nil {
-		return factory.buildParallelStep(build, plan)
+		return factory.buildParallelStep(build, plan, buildState)
 	}
 
 	if plan.Across != nil {
-		return factory.buildAcrossStep(build, plan)
+		return factory.buildAcrossStep(build, plan, buildState)
 	}
 
 	if plan.Do != nil {
-		return factory.buildDoStep(build, plan)
+		return factory.buildDoStep(build, plan, buildState)
 	}
 
 	if plan.Timeout != nil {
-		return factory.buildTimeoutStep(build, plan)
+		return factory.buildTimeoutStep(build, plan, buildState)
 	}
 
 	if plan.Try != nil {
-		return factory.buildTryStep(build, plan)
+		return factory.buildTryStep(build, plan, buildState)
 	}
 
 	if plan.OnAbort != nil {
-		return factory.buildOnAbortStep(build, plan)
+		return factory.buildOnAbortStep(build, plan, buildState)
 	}
 
 	if plan.OnError != nil {
-		return factory.buildOnErrorStep(build, plan)
+		return factory.buildOnErrorStep(build, plan, buildState)
 	}
 
 	if plan.OnSuccess != nil {
-		return factory.buildOnSuccessStep(build, plan)
+		return factory.buildOnSuccessStep(build, plan, buildState)
 	}
 
 	if plan.OnFailure != nil {
-		return factory.buildOnFailureStep(build, plan)
+		return factory.buildOnFailureStep(build, plan, buildState)
 	}
 
 	if plan.Ensure != nil {
-		return factory.buildEnsureStep(build, plan)
+		return factory.buildEnsureStep(build, plan, buildState)
 	}
 
 	if plan.Run != nil {
-		return factory.buildRunStep(build, plan)
+		return factory.buildRunStep(build, plan, buildState)
 	}
 
 	if plan.Task != nil {
-		return factory.buildTaskStep(build, plan)
+		return factory.buildTaskStep(build, plan, buildState)
 	}
 
 	if plan.SetPipeline != nil {
-		return factory.buildSetPipelineStep(build, plan)
+		return factory.buildSetPipelineStep(build, plan, buildState)
 	}
 
 	if plan.LoadVar != nil {
-		return factory.buildLoadVarStep(build, plan)
+		return factory.buildLoadVarStep(build, plan, buildState)
 	}
 
 	if plan.Check != nil {
-		return factory.buildCheckStep(build, plan)
+		return factory.buildCheckStep(build, plan, buildState)
 	}
 
 	if plan.Get != nil {
-		return factory.buildGetStep(build, plan)
+		return factory.buildGetStep(build, plan, buildState)
 	}
 
 	if plan.Put != nil {
-		return factory.buildPutStep(build, plan)
+		return factory.buildPutStep(build, plan, buildState)
 	}
 
 	if plan.Retry != nil {
-		return factory.buildRetryStep(build, plan)
+		return factory.buildRetryStep(build, plan, buildState)
 	}
 
 	if plan.ArtifactInput != nil {
-		return factory.buildArtifactInputStep(build, plan)
+		return factory.buildArtifactInputStep(build, plan, buildState)
 	}
 
 	if plan.ArtifactOutput != nil {
-		return factory.buildArtifactOutputStep(build, plan)
+		return factory.buildArtifactOutputStep(build, plan, buildState)
 	}
 
 	return exec.IdentityStep{}
 }
 
-func (factory *stepperFactory) buildParallelStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildParallelStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 
 	var steps []exec.Step
 
 	for _, innerPlan := range plan.InParallel.Steps {
 		innerPlan.Attempts = plan.Attempts
-		step := factory.buildStep(build, innerPlan)
+		step := factory.buildStep(build, innerPlan, buildState)
 		steps = append(steps, step)
 	}
 
 	return exec.InParallel(steps, plan.InParallel.Limit, plan.InParallel.FailFast)
 }
 
-func (factory *stepperFactory) buildAcrossStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildAcrossStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	stepMetadata := factory.stepMetadata(
 		build,
 		factory.externalURL,
 		false,
+		buildState,
 	)
 
 	acrossStep := exec.Across(
@@ -194,87 +195,87 @@ func (factory *stepperFactory) buildAcrossStep(build db.Build, plan atc.Plan) ex
 	return exec.LogError(acrossStep, factory.buildDelegateFactory(build, plan))
 }
 
-func (factory *stepperFactory) buildDoStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildDoStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	var step exec.Step = exec.IdentityStep{}
 
 	for i := len(*plan.Do) - 1; i >= 0; i-- {
 		innerPlan := (*plan.Do)[i]
 		innerPlan.Attempts = plan.Attempts
-		previous := factory.buildStep(build, innerPlan)
+		previous := factory.buildStep(build, innerPlan, buildState)
 		step = exec.OnSuccess(previous, step)
 	}
 
 	return step
 }
 
-func (factory *stepperFactory) buildTimeoutStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildTimeoutStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	innerPlan := plan.Timeout.Step
 	innerPlan.Attempts = plan.Attempts
-	step := factory.buildStep(build, innerPlan)
+	step := factory.buildStep(build, innerPlan, buildState)
 	return exec.Timeout(step, plan.Timeout.Duration)
 }
 
-func (factory *stepperFactory) buildTryStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildTryStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	innerPlan := plan.Try.Step
 	innerPlan.Attempts = plan.Attempts
-	step := factory.buildStep(build, innerPlan)
+	step := factory.buildStep(build, innerPlan, buildState)
 	return exec.Try(step)
 }
 
-func (factory *stepperFactory) buildOnAbortStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildOnAbortStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	plan.OnAbort.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.OnAbort.Step)
+	step := factory.buildStep(build, plan.OnAbort.Step, buildState)
 	plan.OnAbort.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.OnAbort.Next)
+	next := factory.buildStep(build, plan.OnAbort.Next, string(db.BuildStatusAborted))
 	return exec.OnAbort(step, next)
 }
 
-func (factory *stepperFactory) buildOnErrorStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildOnErrorStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	plan.OnError.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.OnError.Step)
+	step := factory.buildStep(build, plan.OnError.Step, buildState)
 	plan.OnError.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.OnError.Next)
+	next := factory.buildStep(build, plan.OnError.Next, string(db.BuildStatusErrored))
 	return exec.OnError(step, next)
 }
 
-func (factory *stepperFactory) buildOnSuccessStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildOnSuccessStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	plan.OnSuccess.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.OnSuccess.Step)
+	step := factory.buildStep(build, plan.OnSuccess.Step, buildState)
 	plan.OnSuccess.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.OnSuccess.Next)
+	next := factory.buildStep(build, plan.OnSuccess.Next, string(db.BuildStatusSucceeded))
 	return exec.OnSuccess(step, next)
 }
 
-func (factory *stepperFactory) buildOnFailureStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildOnFailureStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	plan.OnFailure.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.OnFailure.Step)
+	step := factory.buildStep(build, plan.OnFailure.Step, buildState)
 	plan.OnFailure.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.OnFailure.Next)
+	next := factory.buildStep(build, plan.OnFailure.Next, string(db.BuildStatusFailed))
 	return exec.OnFailure(step, next)
 }
 
-func (factory *stepperFactory) buildEnsureStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildEnsureStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	plan.Ensure.Step.Attempts = plan.Attempts
-	step := factory.buildStep(build, plan.Ensure.Step)
+	step := factory.buildStep(build, plan.Ensure.Step, buildState)
 	plan.Ensure.Next.Attempts = plan.Attempts
-	next := factory.buildStep(build, plan.Ensure.Next)
+	next := factory.buildStep(build, plan.Ensure.Next, buildState)
 	return exec.Ensure(step, next)
 }
 
-func (factory *stepperFactory) buildRetryStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildRetryStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	steps := []exec.Step{}
 
 	for index, innerPlan := range *plan.Retry {
 		innerPlan.Attempts = append(plan.Attempts, index+1)
 
-		step := factory.buildStep(build, innerPlan)
+		step := factory.buildStep(build, innerPlan, buildState)
 		steps = append(steps, step)
 	}
 
 	return exec.Retry(steps...)
 }
 
-func (factory *stepperFactory) buildGetStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildGetStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 
 	containerMetadata := factory.containerMetadata(
 		build,
@@ -287,6 +288,7 @@ func (factory *stepperFactory) buildGetStep(build db.Build, plan atc.Plan) exec.
 		build,
 		factory.externalURL,
 		false,
+		buildState,
 	)
 
 	return factory.coreFactory.GetStep(
@@ -297,7 +299,7 @@ func (factory *stepperFactory) buildGetStep(build db.Build, plan atc.Plan) exec.
 	)
 }
 
-func (factory *stepperFactory) buildPutStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildPutStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 
 	containerMetadata := factory.containerMetadata(
 		build,
@@ -310,6 +312,7 @@ func (factory *stepperFactory) buildPutStep(build db.Build, plan atc.Plan) exec.
 		build,
 		factory.externalURL,
 		plan.Put.ExposeBuildCreatedBy,
+		buildState,
 	)
 
 	return factory.coreFactory.PutStep(
@@ -320,7 +323,7 @@ func (factory *stepperFactory) buildPutStep(build db.Build, plan atc.Plan) exec.
 	)
 }
 
-func (factory *stepperFactory) buildCheckStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildCheckStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	containerMetadata := factory.containerMetadata(
 		build,
 		db.ContainerTypeCheck,
@@ -332,6 +335,7 @@ func (factory *stepperFactory) buildCheckStep(build db.Build, plan atc.Plan) exe
 		build,
 		factory.externalURL,
 		false,
+		buildState,
 	)
 
 	return factory.coreFactory.CheckStep(
@@ -342,7 +346,7 @@ func (factory *stepperFactory) buildCheckStep(build db.Build, plan atc.Plan) exe
 	)
 }
 
-func (factory *stepperFactory) buildRunStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildRunStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	containerMetadata := factory.containerMetadata(
 		build,
 		db.ContainerTypeRun,
@@ -354,6 +358,7 @@ func (factory *stepperFactory) buildRunStep(build db.Build, plan atc.Plan) exec.
 		build,
 		factory.externalURL,
 		false,
+		buildState,
 	)
 
 	return factory.coreFactory.RunStep(
@@ -364,7 +369,7 @@ func (factory *stepperFactory) buildRunStep(build db.Build, plan atc.Plan) exec.
 	)
 }
 
-func (factory *stepperFactory) buildTaskStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildTaskStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 
 	containerMetadata := factory.containerMetadata(
 		build,
@@ -377,6 +382,7 @@ func (factory *stepperFactory) buildTaskStep(build db.Build, plan atc.Plan) exec
 		build,
 		factory.externalURL,
 		false,
+		buildState,
 	)
 
 	return factory.coreFactory.TaskStep(
@@ -387,12 +393,13 @@ func (factory *stepperFactory) buildTaskStep(build db.Build, plan atc.Plan) exec
 	)
 }
 
-func (factory *stepperFactory) buildSetPipelineStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildSetPipelineStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 
 	stepMetadata := factory.stepMetadata(
 		build,
 		factory.externalURL,
 		false,
+		buildState,
 	)
 
 	return factory.coreFactory.SetPipelineStep(
@@ -402,12 +409,13 @@ func (factory *stepperFactory) buildSetPipelineStep(build db.Build, plan atc.Pla
 	)
 }
 
-func (factory *stepperFactory) buildLoadVarStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildLoadVarStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 
 	stepMetadata := factory.stepMetadata(
 		build,
 		factory.externalURL,
 		false,
+		buildState,
 	)
 
 	return factory.coreFactory.LoadVarStep(
@@ -417,14 +425,14 @@ func (factory *stepperFactory) buildLoadVarStep(build db.Build, plan atc.Plan) e
 	)
 }
 
-func (factory *stepperFactory) buildArtifactInputStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildArtifactInputStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	return factory.coreFactory.ArtifactInputStep(
 		plan,
 		build,
 	)
 }
 
-func (factory *stepperFactory) buildArtifactOutputStep(build db.Build, plan atc.Plan) exec.Step {
+func (factory *stepperFactory) buildArtifactOutputStep(build db.Build, plan atc.Plan, buildState string) exec.Step {
 	return factory.coreFactory.ArtifactOutputStep(
 		plan,
 		build,
@@ -469,6 +477,7 @@ func (factory *stepperFactory) stepMetadata(
 	build db.Build,
 	externalURL string,
 	exposeBuildCreatedBy bool,
+	buildState string,
 ) exec.StepMetadata {
 	meta := exec.StepMetadata{
 		BuildID:              build.ID(),
@@ -482,6 +491,7 @@ func (factory *stepperFactory) stepMetadata(
 		PipelineInstanceVars: build.PipelineInstanceVars(),
 		InstanceVarsQuery:    build.PipelineRef().QueryParams(),
 		ExternalURL:          externalURL,
+		BuildState:           buildState,
 	}
 	if exposeBuildCreatedBy && build.CreatedBy() != nil {
 		meta.CreatedBy = *build.CreatedBy()

--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -61,13 +61,13 @@ type stepperFactory struct {
 }
 
 type planBuilder struct {
-	factory    *stepperFactory
-	build      db.Build
-	buildState string
+	factory     *stepperFactory
+	build       db.Build
+	buildStatus string
 }
 
-func (pb *planBuilder) withBuildState(state string) *planBuilder {
-	return &planBuilder{factory: pb.factory, build: pb.build, buildState: state}
+func (pb *planBuilder) withBuildStatus(state string) *planBuilder {
+	return &planBuilder{factory: pb.factory, build: pb.build, buildStatus: state}
 }
 
 func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, error) {
@@ -75,7 +75,7 @@ func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, er
 		return nil, errors.New("schema not supported")
 	}
 
-	pb := &planBuilder{factory: factory, build: build, buildState: build.Status().String()}
+	pb := &planBuilder{factory: factory, build: build, buildStatus: build.Status().String()}
 	return func(plan atc.Plan) exec.Step {
 		return pb.buildStep(plan)
 	}, nil
@@ -232,7 +232,7 @@ func (pb *planBuilder) buildOnAbortStep(plan atc.Plan) exec.Step {
 	plan.OnAbort.Step.Attempts = plan.Attempts
 	step := pb.buildStep(plan.OnAbort.Step)
 	plan.OnAbort.Next.Attempts = plan.Attempts
-	next := pb.withBuildState(db.BuildStatusAborted.String()).buildStep(plan.OnAbort.Next)
+	next := pb.withBuildStatus(db.BuildStatusAborted.String()).buildStep(plan.OnAbort.Next)
 	return exec.OnAbort(step, next)
 }
 
@@ -240,7 +240,7 @@ func (pb *planBuilder) buildOnErrorStep(plan atc.Plan) exec.Step {
 	plan.OnError.Step.Attempts = plan.Attempts
 	step := pb.buildStep(plan.OnError.Step)
 	plan.OnError.Next.Attempts = plan.Attempts
-	next := pb.withBuildState(db.BuildStatusErrored.String()).buildStep(plan.OnError.Next)
+	next := pb.withBuildStatus(db.BuildStatusErrored.String()).buildStep(plan.OnError.Next)
 	return exec.OnError(step, next)
 }
 
@@ -248,7 +248,7 @@ func (pb *planBuilder) buildOnSuccessStep(plan atc.Plan) exec.Step {
 	plan.OnSuccess.Step.Attempts = plan.Attempts
 	step := pb.buildStep(plan.OnSuccess.Step)
 	plan.OnSuccess.Next.Attempts = plan.Attempts
-	next := pb.withBuildState(db.BuildStatusSucceeded.String()).buildStep(plan.OnSuccess.Next)
+	next := pb.withBuildStatus(db.BuildStatusSucceeded.String()).buildStep(plan.OnSuccess.Next)
 	return exec.OnSuccess(step, next)
 }
 
@@ -256,7 +256,7 @@ func (pb *planBuilder) buildOnFailureStep(plan atc.Plan) exec.Step {
 	plan.OnFailure.Step.Attempts = plan.Attempts
 	step := pb.buildStep(plan.OnFailure.Step)
 	plan.OnFailure.Next.Attempts = plan.Attempts
-	next := pb.withBuildState(db.BuildStatusFailed.String()).buildStep(plan.OnFailure.Next)
+	next := pb.withBuildStatus(db.BuildStatusFailed.String()).buildStep(plan.OnFailure.Next)
 	return exec.OnFailure(step, next)
 }
 
@@ -453,7 +453,7 @@ func (pb *planBuilder) stepMetadata(
 		PipelineInstanceVars: pb.build.PipelineInstanceVars(),
 		InstanceVarsQuery:    pb.build.PipelineRef().QueryParams(),
 		ExternalURL:          pb.factory.externalURL,
-		BuildState:           pb.buildState,
+		BuildStatus:          pb.buildStatus,
 	}
 	if exposeBuildCreatedBy && pb.build.CreatedBy() != nil {
 		meta.CreatedBy = *pb.build.CreatedBy()

--- a/atc/engine/builder_test.go
+++ b/atc/engine/builder_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Builder", func() {
 					PipelineInstanceVars: atc.InstanceVars{"branch": "master"},
 					ExternalURL:          "http://example.com",
 					CreatedBy:            "some-user",
-					BuildState:           "started",
+					BuildStatus:          "started",
 				}
 
 				expectedMetadataWithoutCreatedBy = exec.StepMetadata{
@@ -104,7 +104,7 @@ var _ = Describe("Builder", func() {
 					PipelineName:         "some-pipeline",
 					PipelineInstanceVars: atc.InstanceVars{"branch": "master"},
 					ExternalURL:          "http://example.com",
-					BuildState:           "started",
+					BuildStatus:          "started",
 				}
 			})
 
@@ -680,7 +680,7 @@ var _ = Describe("Builder", func() {
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(dependentGetPlan))
 							expectedMeta := expectedMetadataWithoutCreatedBy
-							expectedMeta.BuildState = "succeeded"
+							expectedMeta.BuildStatus = "succeeded"
 							Expect(stepMetadata).To(Equal(expectedMeta))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								Type:                 db.ContainerTypeGet,
@@ -784,7 +784,7 @@ var _ = Describe("Builder", func() {
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
 							Expect(plan).To(Equal(failureTaskPlan))
 							expectedMeta := expectedMetadataWithoutCreatedBy
-							expectedMeta.BuildState = "failed"
+							expectedMeta.BuildStatus = "failed"
 							Expect(stepMetadata).To(Equal(expectedMeta))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,
@@ -804,7 +804,7 @@ var _ = Describe("Builder", func() {
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(1)
 							Expect(plan).To(Equal(successTaskPlan))
 							expectedMeta := expectedMetadataWithoutCreatedBy
-							expectedMeta.BuildState = "succeeded"
+							expectedMeta.BuildStatus = "succeeded"
 							Expect(stepMetadata).To(Equal(expectedMeta))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,
@@ -824,7 +824,7 @@ var _ = Describe("Builder", func() {
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(3)
 							Expect(plan).To(Equal(nextTaskPlan))
 							expectedMeta := expectedMetadataWithoutCreatedBy
-							expectedMeta.BuildState = "succeeded"
+							expectedMeta.BuildStatus = "succeeded"
 							Expect(stepMetadata).To(Equal(expectedMeta))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,

--- a/atc/engine/builder_test.go
+++ b/atc/engine/builder_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Builder", func() {
 				fakeBuild.TeamIDReturns(1111)
 				someUser := "some-user"
 				fakeBuild.CreatedByReturns(&someUser)
+				fakeBuild.StatusReturns("started")
 
 				expectedMetadataWithCreatedBy = exec.StepMetadata{
 					BuildID:              4444,
@@ -89,6 +90,7 @@ var _ = Describe("Builder", func() {
 					PipelineInstanceVars: atc.InstanceVars{"branch": "master"},
 					ExternalURL:          "http://example.com",
 					CreatedBy:            "some-user",
+					BuildState:           "started",
 				}
 
 				expectedMetadataWithoutCreatedBy = exec.StepMetadata{
@@ -102,6 +104,7 @@ var _ = Describe("Builder", func() {
 					PipelineName:         "some-pipeline",
 					PipelineInstanceVars: atc.InstanceVars{"branch": "master"},
 					ExternalURL:          "http://example.com",
+					BuildState:           "started",
 				}
 			})
 
@@ -676,7 +679,9 @@ var _ = Describe("Builder", func() {
 						It("constructs the dependent get correctly", func() {
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(dependentGetPlan))
-							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
+							expectedMeta := expectedMetadataWithoutCreatedBy
+							expectedMeta.BuildState = "succeeded"
+							Expect(stepMetadata).To(Equal(expectedMeta))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								Type:                 db.ContainerTypeGet,
 								StepName:             "some-get",
@@ -778,7 +783,9 @@ var _ = Describe("Builder", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
 							Expect(plan).To(Equal(failureTaskPlan))
-							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
+							expectedMeta := expectedMetadataWithoutCreatedBy
+							expectedMeta.BuildState = "failed"
+							Expect(stepMetadata).To(Equal(expectedMeta))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,
 								PipelineName:         "some-pipeline",
@@ -796,7 +803,9 @@ var _ = Describe("Builder", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(1)
 							Expect(plan).To(Equal(successTaskPlan))
-							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
+							expectedMeta := expectedMetadataWithoutCreatedBy
+							expectedMeta.BuildState = "succeeded"
+							Expect(stepMetadata).To(Equal(expectedMeta))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,
 								PipelineName:         "some-pipeline",
@@ -814,7 +823,9 @@ var _ = Describe("Builder", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(3)
 							Expect(plan).To(Equal(nextTaskPlan))
-							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
+							expectedMeta := expectedMetadataWithoutCreatedBy
+							expectedMeta.BuildState = "succeeded"
+							Expect(stepMetadata).To(Equal(expectedMeta))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,
 								PipelineName:         "some-pipeline",

--- a/atc/engine/builder_test.go
+++ b/atc/engine/builder_test.go
@@ -90,7 +90,6 @@ var _ = Describe("Builder", func() {
 					PipelineInstanceVars: atc.InstanceVars{"branch": "master"},
 					ExternalURL:          "http://example.com",
 					CreatedBy:            "some-user",
-					BuildStatus:          "started",
 				}
 
 				expectedMetadataWithoutCreatedBy = exec.StepMetadata{
@@ -104,7 +103,6 @@ var _ = Describe("Builder", func() {
 					PipelineName:         "some-pipeline",
 					PipelineInstanceVars: atc.InstanceVars{"branch": "master"},
 					ExternalURL:          "http://example.com",
-					BuildStatus:          "started",
 				}
 			})
 
@@ -679,9 +677,8 @@ var _ = Describe("Builder", func() {
 						It("constructs the dependent get correctly", func() {
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(dependentGetPlan))
-							expectedMeta := expectedMetadataWithoutCreatedBy
-							expectedMeta.BuildStatus = "succeeded"
-							Expect(stepMetadata).To(Equal(expectedMeta))
+							expectedMetadataWithoutCreatedBy.BuildStatus = db.BuildStatusSucceeded.String()
+							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								Type:                 db.ContainerTypeGet,
 								StepName:             "some-get",
@@ -783,9 +780,8 @@ var _ = Describe("Builder", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
 							Expect(plan).To(Equal(failureTaskPlan))
-							expectedMeta := expectedMetadataWithoutCreatedBy
-							expectedMeta.BuildStatus = "failed"
-							Expect(stepMetadata).To(Equal(expectedMeta))
+							expectedMetadataWithoutCreatedBy.BuildStatus = db.BuildStatusFailed.String()
+							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,
 								PipelineName:         "some-pipeline",
@@ -803,9 +799,8 @@ var _ = Describe("Builder", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(1)
 							Expect(plan).To(Equal(successTaskPlan))
-							expectedMeta := expectedMetadataWithoutCreatedBy
-							expectedMeta.BuildStatus = "succeeded"
-							Expect(stepMetadata).To(Equal(expectedMeta))
+							expectedMetadataWithoutCreatedBy.BuildStatus = db.BuildStatusSucceeded.String()
+							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,
 								PipelineName:         "some-pipeline",
@@ -823,9 +818,8 @@ var _ = Describe("Builder", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
 							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(3)
 							Expect(plan).To(Equal(nextTaskPlan))
-							expectedMeta := expectedMetadataWithoutCreatedBy
-							expectedMeta.BuildStatus = "succeeded"
-							Expect(stepMetadata).To(Equal(expectedMeta))
+							expectedMetadataWithoutCreatedBy.BuildStatus = db.BuildStatusSucceeded.String()
+							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
 								PipelineID:           2222,
 								PipelineName:         "some-pipeline",

--- a/atc/exec/step_metadata.go
+++ b/atc/exec/step_metadata.go
@@ -19,10 +19,16 @@ type StepMetadata struct {
 	InstanceVarsQuery    url.Values
 	ExternalURL          string
 	CreatedBy            string
+	BuildState           string
 }
 
 func (metadata StepMetadata) Env() []string {
 	env := []string{}
+
+	if metadata.BuildState != "" {
+		env = append(env, "BUILD_STATE="+metadata.BuildState)
+	}
+
 
 	if metadata.BuildID != 0 {
 		env = append(env, fmt.Sprintf("BUILD_ID=%d", metadata.BuildID))

--- a/atc/exec/step_metadata.go
+++ b/atc/exec/step_metadata.go
@@ -19,16 +19,15 @@ type StepMetadata struct {
 	InstanceVarsQuery    url.Values
 	ExternalURL          string
 	CreatedBy            string
-	BuildState           string
+	BuildStatus          string
 }
 
 func (metadata StepMetadata) Env() []string {
 	env := []string{}
 
-	if metadata.BuildState != "" {
-		env = append(env, "BUILD_STATE="+metadata.BuildState)
+	if metadata.BuildStatus != "" {
+		env = append(env, "BUILD_STATUS="+metadata.BuildStatus)
 	}
-
 
 	if metadata.BuildID != 0 {
 		env = append(env, fmt.Sprintf("BUILD_ID=%d", metadata.BuildID))

--- a/atc/exec/step_metadata_test.go
+++ b/atc/exec/step_metadata_test.go
@@ -26,7 +26,7 @@ var _ = Describe("StepMetadata", func() {
 					PipelineName: "some-pipeline-name",
 					ExternalURL:  "https://www.example.com",
 					CreatedBy:    "someone",
-					BuildState:   "success",
+					BuildStatus:  "success",
 				}
 			})
 

--- a/atc/exec/step_metadata_test.go
+++ b/atc/exec/step_metadata_test.go
@@ -44,7 +44,7 @@ var _ = Describe("StepMetadata", func() {
 					"BUILD_URL=https://www.example.com/teams/some-team/pipelines/some-pipeline-name/jobs/some-job-name/builds/42",
 					"BUILD_URL_SHORT=https://www.example.com/builds/1",
 					"BUILD_CREATED_BY=someone",
-					"BUILD_STATE=success",
+					"BUILD_STATUS=success",
 				))
 			})
 		})

--- a/atc/exec/step_metadata_test.go
+++ b/atc/exec/step_metadata_test.go
@@ -26,6 +26,7 @@ var _ = Describe("StepMetadata", func() {
 					PipelineName: "some-pipeline-name",
 					ExternalURL:  "https://www.example.com",
 					CreatedBy:    "someone",
+					BuildState:   "success",
 				}
 			})
 
@@ -43,6 +44,7 @@ var _ = Describe("StepMetadata", func() {
 					"BUILD_URL=https://www.example.com/teams/some-team/pipelines/some-pipeline-name/jobs/some-job-name/builds/42",
 					"BUILD_URL_SHORT=https://www.example.com/builds/1",
 					"BUILD_CREATED_BY=someone",
+					"BUILD_STATE=success",
 				))
 			})
 		})


### PR DESCRIPTION
When using a resource within a hook step (e.g., `on_success`, `on_failure`, `on_error`, `on_abort`), the execution step is now context-aware of the build state sequence that triggered it. This modifies the builder tree to propagate the hook's execution state down to the resource environment variable natively, reducing configuration redundancy.

Resolves #8541

## Changes proposed by this PR
closes #8541

* Modified [atc/exec/step_metadata.go](cci:7://file:///Users/arakaki/projects/open-source/concourse/atc/exec/step_metadata.go:0:0-0:0) by adding a `BuildState` string that natively generates the `BUILD_STATE` environment variable.
* Refactored step initialization throughout [atc/engine/builder.go](cci:7://file:///Users/arakaki/projects/open-source/concourse/atc/engine/builder.go:0:0-0:0) to thread a contextual tracking of the overarching `BuildState`.
* Modified the specific `on_success`, `on_failure`, `on_error`, and `on_abort` builder wrappers to appropriately pass `"succeeded"`, `"failed"`, `"errored"`, and `"aborted"` identifiers downstream when parsing nested plans.
* Updated related [atc/engine/builder_test.go](cci:7://file:///Users/arakaki/projects/open-source/concourse/atc/engine/builder_test.go:0:0-0:0) and [atc/exec/step_metadata_test.go](cci:7://file:///Users/arakaki/projects/open-source/concourse/atc/exec/step_metadata_test.go:0:0-0:0) test suites with explicit assertions checking that `$BUILD_STATE` parses correctly within nested pipeline hooks.

## Notes to reviewer
The engine passes the state by mapping hook-specific constants directly (e.g., `db.BuildStatusSucceeded`) dynamically when establishing the hierarchical step tree layout inside `.Next` fields. This elegantly isolates the behavior down recursively regardless of how deep the `in_parallel`/[do](cci:1://file:///Users/arakaki/projects/open-source/concourse/atc/exec/put_step.go:31:1-31:19)/[try](cci:1://file:///Users/arakaki/projects/open-source/concourse/atc/engine/builder.go:264:0-275:1) blocks scale. 
All unit checks passed successfully validating this nested environment allocation. 

## Release Note
* Added contextual `$BUILD_STATE` metadata generation globally natively exposed when instantiating arbitrary hooks (simplifying parameter configurations for notification resources out-of-the-box).