### PR TITLE
fix(atc): retain var_sources visibility inside across interpolation steps

### DIFF
--- a/atc/engine/build_step_delegate.go
+++ b/atc/engine/build_step_delegate.go
@@ -307,7 +307,7 @@ func (delegate *buildStepDelegate) ConstructAcrossSubsteps(templateBytes []byte,
 		for j, v := range acrossVars {
 			localVars[v.Var] = values[j]
 		}
-		
+
 		interpolatedBytes, err := template.Evaluate(ignoreMissingSourceVars{vars.NamedVariables{".": localVars}}, vars.EvaluateOpts{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to interpolate template: %w", err)
@@ -443,16 +443,16 @@ func (it *credVarsIterator) YieldCred(name, value string) {
 	}
 }
 
+var _ vars.Variables = (*ignoreMissingSourceVars)(nil)
+
 type ignoreMissingSourceVars struct {
 	vars vars.Variables
 }
 
 func (i ignoreMissingSourceVars) Get(ref vars.Reference) (any, bool, error) {
 	val, found, err := i.vars.Get(ref)
-	if err != nil {
-		if _, isMissingSource := err.(vars.MissingSourceError); isMissingSource {
-			return nil, false, nil
-		}
+	if _, isMissingSource := err.(vars.MissingSourceError); isMissingSource {
+		return nil, false, nil
 	}
 	return val, found, err
 }

--- a/atc/engine/build_step_delegate.go
+++ b/atc/engine/build_step_delegate.go
@@ -307,7 +307,8 @@ func (delegate *buildStepDelegate) ConstructAcrossSubsteps(templateBytes []byte,
 		for j, v := range acrossVars {
 			localVars[v.Var] = values[j]
 		}
-		interpolatedBytes, err := template.Evaluate(vars.NamedVariables{".": localVars}, vars.EvaluateOpts{})
+		
+		interpolatedBytes, err := template.Evaluate(ignoreMissingSourceVars{vars.NamedVariables{".": localVars}}, vars.EvaluateOpts{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to interpolate template: %w", err)
 		}
@@ -440,4 +441,22 @@ func (it *credVarsIterator) YieldCred(name, value string) {
 			it.line = strings.ReplaceAll(it.line, lineValue, "((redacted))")
 		}
 	}
+}
+
+type ignoreMissingSourceVars struct {
+	vars vars.Variables
+}
+
+func (i ignoreMissingSourceVars) Get(ref vars.Reference) (any, bool, error) {
+	val, found, err := i.vars.Get(ref)
+	if err != nil {
+		if _, isMissingSource := err.(vars.MissingSourceError); isMissingSource {
+			return nil, false, nil
+		}
+	}
+	return val, found, err
+}
+
+func (i ignoreMissingSourceVars) List() ([]vars.Reference, error) {
+	return i.vars.List()
 }

--- a/atc/engine/build_step_delegate_test.go
+++ b/atc/engine/build_step_delegate_test.go
@@ -416,7 +416,7 @@ var _ = Describe("BuildStepDelegate", func() {
 					"step": {
 						"id": "put-id",
 						"put": {
-							"name": "((.:v1))",
+							"name": "((.:v1))-((dummy-source:global-var))",
 							"type": "some-type",
 							"params": {
 								"p1": "((.:v2))",
@@ -428,7 +428,7 @@ var _ = Describe("BuildStepDelegate", func() {
 					"on_success": {
 						"id": "get-id",
 						"get": {
-							"name": "((.:v1))",
+							"name": "((.:v1))-((dummy-source:global-var))",
 							"type": "some-type",
 							"version_from": "put-id"
 						}
@@ -454,7 +454,7 @@ var _ = Describe("BuildStepDelegate", func() {
 							Step: atc.Plan{
 								ID: "some-plan-id/0/1",
 								Put: &atc.PutPlan{
-									Name: "a1",
+									Name: "a1-((dummy-source:global-var))",
 									Type: "some-type",
 									Params: atc.Params{
 										"p1":        "b1",
@@ -466,7 +466,7 @@ var _ = Describe("BuildStepDelegate", func() {
 							Next: atc.Plan{
 								ID: "some-plan-id/0/2",
 								Get: &atc.GetPlan{
-									Name:        "a1",
+									Name:        "a1-((dummy-source:global-var))",
 									Type:        "some-type",
 									VersionFrom: planIDPtr("some-plan-id/0/1"),
 								},
@@ -482,7 +482,7 @@ var _ = Describe("BuildStepDelegate", func() {
 							Step: atc.Plan{
 								ID: "some-plan-id/1/1",
 								Put: &atc.PutPlan{
-									Name: "a1",
+									Name: "a1-((dummy-source:global-var))",
 									Type: "some-type",
 									Params: atc.Params{
 										"p1":        "b1",
@@ -494,7 +494,7 @@ var _ = Describe("BuildStepDelegate", func() {
 							Next: atc.Plan{
 								ID: "some-plan-id/1/2",
 								Get: &atc.GetPlan{
-									Name:        "a1",
+									Name:        "a1-((dummy-source:global-var))",
 									Type:        "some-type",
 									VersionFrom: planIDPtr("some-plan-id/1/1"),
 								},


### PR DESCRIPTION
## Changes proposed by this PR

closes #8191

* When the across step was interpolating the local vars introduced by its own step, it would erroneously error on all non-local `((.:local-var))` source vars
* This PR catches these `MissingSourceError`'s and ignores them
* A final interpolation gets done by the concrete step(s) inside the `across` step, which will resolve or error on any remaining vars