### PR TITLE
feat(ui): display non-zero tasks exit codes in pipeline UI

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -857,6 +857,7 @@ steps =
         , initialize = Nothing
         , start = Nothing
         , finish = Nothing
+        , exitStatus = Nothing
         , tabFocus = STModels.Auto
         , expandedHeaders = Dict.empty
         , initializationExpanded = False

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -201,7 +201,7 @@ handleEvent event ( model, effects ) =
             )
 
         FinishTask origin exitStatus time ->
-            ( updateStep origin.id (finishStep (exitStatus == 0) (Just time)) model
+            ( updateStep origin.id (finishStep (exitStatus == 0) (Just time) << setStepExitStatus exitStatus) model
             , effects
             )
 
@@ -380,6 +380,11 @@ setStepInitialize time step =
 setStepStart : Time.Posix -> Step -> Step
 setStepStart time step =
     { step | start = Just time }
+
+
+setStepExitStatus : Int -> Step -> Step
+setStepExitStatus status step =
+    { step | exitStatus = Just status }
 
 
 setStepFinish : Maybe Time.Posix -> Step -> Step

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -92,6 +92,7 @@ type alias Step =
     , initialize : Maybe Time.Posix
     , start : Maybe Time.Posix
     , finish : Maybe Time.Posix
+    , exitStatus : Maybe Int
     , tabFocus : TabFocus
     , expandedHeaders : Dict Int Bool
     , initializationExpanded : Bool

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -366,6 +366,7 @@ constructStep { id, step } =
     , initialize = Nothing
     , start = Nothing
     , finish = Nothing
+    , exitStatus = Nothing
     , tabFocus = Auto
     , expandedHeaders = Dict.empty
     , initializationExpanded = False
@@ -868,6 +869,14 @@ viewStepWithBody model session depth step body =
                     Just _ ->
                         viewInitializationToggle step
 
+                    Nothing ->
+                        Html.text ""
+                , case step.exitStatus of
+                    Just status ->
+                        if status /= 0 then
+                            Html.span [ class "exit-status", style "display" "flex", style "align-items" "center", style "margin-right" "10px", style "color" Colors.error, style "font-weight" "bold" ] [ Html.text ("exit: " ++ String.fromInt status) ]
+                        else
+                            Html.text ""
                     Nothing ->
                         Html.text ""
                 , viewStepState step.state (Just step.id)

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -70,6 +70,7 @@ someVersionedStep version id buildStep state =
     , initialize = Nothing
     , start = Nothing
     , finish = Nothing
+    , exitStatus = Nothing
     , tabFocus = Models.Auto
     , expandedHeaders = Dict.empty
     , initializationExpanded = False


### PR DESCRIPTION
## Description
Resolves #2673.  

This PR introduces an enhancement to the Concourse Pipeline UI. Previously, when a task step failed inside a pipeline, users had to painstakingly dig through verbose logs just to locate the numeric UNIX Exit Status of the task. 
While the ATC engine safely broadcasts the `ExitStatus` integer via the [FinishTask](cci:2://file:///Users/arakaki/projects/open-source/concourse/atc/event/events.go:17:0-21:1) event, the Elm component [Output.elm](cci:7://file:///Users/arakaki/projects/open-source/concourse/web/elm/src/Build/Output/Output.elm:0:0-0:0) natively discarded this integer after evaluating whether it evaluated to `0` or not to assign `StepStateSucceeded` / `StepStateFailed`.
This modification wires the exit status deeply into the Elm components, storing `exitStatus : Maybe Int` in the Step View's Data Model natively, preventing its loss. It introduces a lightweight error label right next to the Step State icon. Now, when the task concludes with a non-zero exit status, the `[exit: 1]` signature is conspicuously displayed next to the task's failure status, heavily accelerating debug times.  

## Changes
* **[web/elm/src/Build/StepTree/Models.elm](cci:7://file:///Users/arakaki/projects/open-source/concourse/web/elm/src/Build/StepTree/Models.elm:0:0-0:0)**: Updated [Step](cci:2://file:///Users/arakaki/projects/open-source/concourse/atc/exec/step_metadata.go:8:0-21:1) structure to track `exitStatus : Maybe Int`.
* **[web/elm/src/Build/Output/Output.elm](cci:7://file:///Users/arakaki/projects/open-source/concourse/web/elm/src/Build/Output/Output.elm:0:0-0:0)**: Created `setStepExitStatus` and piped `exitStatus` natively from incoming `finish-task` WebSocket envelopes into the state manager explicitly discarding the [(exit_status == 0)](cci:1://file:///Users/arakaki/projects/open-source/concourse/vars/named_vars.go:4:0-18:1) boolean trap.
* **[web/elm/src/Build/StepTree/StepTree.elm](cci:7://file:///Users/arakaki/projects/open-source/concourse/web/elm/src/Build/StepTree/StepTree.elm:0:0-0:0)**: Attached an `exit: N` markup block adjacent to `viewStepState`.
<details>
<summary>Elm Compilation verification</summary>
npx --yes elm make src/Main.elm
Success! Compiled 7 modules.
</details>  
  
## Display the status
<img width="2556" height="326" alt="Captura de Tela 2026-04-12 às 14 55 05" src="https://github.com/user-attachments/assets/3373e52e-011f-4e7d-b1db-e6eb342d1b62" />
