### PR TITLE
Don't error if the overlaysDir does not exist during orphan volume cleanup

### DIFF
--- a/worker/baggageclaim/baggageclaimcmd/driver_linux.go
+++ b/worker/baggageclaim/baggageclaimcmd/driver_linux.go
@@ -68,7 +68,13 @@ func (cmd *BaggageclaimCommand) driver(logger lager.Logger) (volume.Driver, erro
 	var d volume.Driver
 	switch cmd.Driver {
 	case "overlay":
+		err := os.MkdirAll(cmd.OverlaysDir, 0755)
+		if err != nil {
+			return nil, err
+		}
+
 		d = driver.NewOverlayDriver(logger, cmd.OverlaysDir)
+
 		if !kernelSupportsOverlay {
 			return nil, errors.New("overlay driver requires kernel version >= 4.0.0")
 		}

--- a/worker/baggageclaim/volume/driver/overlay_linux.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -255,6 +256,16 @@ func (driver *OverlayDriver) workDir(vol volume.FilesystemVolume) string {
 }
 
 func (driver *OverlayDriver) RemoveOrphanedResources(knownHandles map[string]struct{}) error {
+	_, err := os.Stat(driver.OverlaysDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// If dir does not exist yet then there's nothing to remove
+			return nil
+		} else {
+			return fmt.Errorf("checking overlay dir exists: %w", err)
+		}
+	}
+
 	entries, err := os.ReadDir(driver.OverlaysDir)
 	if err != nil {
 		return fmt.Errorf("read overlays dir: %w", err)

--- a/worker/baggageclaim/volume/driver/overlay_linux_test.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux_test.go
@@ -173,6 +173,19 @@ var _ = Describe("Overlay", func() {
 			err := overlayDrv.RemoveOrphanedResources(knownHandles)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		Context("when the overlays dir does not exist", func() {
+			BeforeEach(func() {
+				err := os.RemoveAll(overlaysDir)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("does not error", func() {
+				knownHandles := map[string]struct{}{}
+				err := overlayDrv.RemoveOrphanedResources(knownHandles)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 	})
 
 })


### PR DESCRIPTION
## Changes proposed by this PR

Error users see in worker logs:
```
"worker.baggageclaim.filesystem.failed-to-remove-orphaned-driver-resources","data":{"error":"read overlays dir: open /opt/concourse/worker/overlays: no such file or directory"
```

This error happens when volumes don't exist on the worker yet, which is what eventually creates the `overlaysDir`. If the worker doesn't have any volumes then it'll encounter this error during each `volume-sweep` that the web node initiates.

Also took the chance to have the worker make `overlaysDir` automatically if the overlay driver is being used.