### PR TITLE
Worker healthcheck endpoint returns a detailed json response

### DIFF
--- a/worker/healthchecker.go
+++ b/worker/healthchecker.go
@@ -2,11 +2,23 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"sync"
 	"time"
 
 	"code.cloudfoundry.org/lager/v3"
 )
+
+type componentHealth struct {
+	Healthy       bool   `json:"healthy"`
+	ResponseError string `json:"response_error"`
+}
+
+type healthResponse struct {
+	Garden       componentHealth `json:"garden"`
+	Baggageclaim componentHealth `json:"baggageclaim"`
+}
 
 type healthChecker struct {
 	baggageclaimAddr string
@@ -42,22 +54,42 @@ func doRequest(ctx context.Context, url string) error {
 }
 
 func (h *healthChecker) CheckHealth(w http.ResponseWriter, req *http.Request) {
-	var err error
-
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(h.timeout))
 	defer cancel()
 
-	err = doRequest(ctx, h.gardenAddr+"/ping")
-	if err != nil {
-		w.WriteHeader(503)
-		h.logger.Error("failed-to-ping-garden-server", err)
-		return
+	resp := healthResponse{
+		Garden:       componentHealth{Healthy: true},
+		Baggageclaim: componentHealth{Healthy: true},
 	}
 
-	err = doRequest(ctx, h.baggageclaimAddr+"/volumes")
-	if err != nil {
-		w.WriteHeader(503)
-		h.logger.Error("failed-to-list-volumes-on-baggageclaim-server", err)
-		return
+	var gardenErr, baggageclaimErr error
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		gardenErr = doRequest(ctx, h.gardenAddr+"/ping")
+	})
+
+	wg.Go(func() {
+		baggageclaimErr = doRequest(ctx, h.baggageclaimAddr+"/volumes")
+	})
+
+	wg.Wait()
+
+	if gardenErr != nil {
+		resp.Garden.Healthy = false
+		resp.Garden.ResponseError = gardenErr.Error()
+		h.logger.Error("failed-to-ping-garden-server", gardenErr)
 	}
+
+	if baggageclaimErr != nil {
+		resp.Baggageclaim.Healthy = false
+		resp.Baggageclaim.ResponseError = baggageclaimErr.Error()
+		h.logger.Error("failed-to-list-volumes-on-baggageclaim-server", baggageclaimErr)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if !resp.Garden.Healthy || !resp.Baggageclaim.Healthy {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+	json.NewEncoder(w).Encode(resp)
 }

--- a/worker/healthchecker_test.go
+++ b/worker/healthchecker_test.go
@@ -1,6 +1,8 @@
 package worker_test
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -12,6 +14,25 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+type componentHealth struct {
+	Healthy       bool   `json:"healthy"`
+	ResponseError string `json:"response_error"`
+}
+
+type healthResponseBody struct {
+	Garden       componentHealth `json:"garden"`
+	Baggageclaim componentHealth `json:"baggageclaim"`
+}
+
+func parseHealthResponse(resp *http.Response) healthResponseBody {
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).ToNot(HaveOccurred())
+	var result healthResponseBody
+	Expect(json.Unmarshal(body, &result)).To(Succeed())
+	return result
+}
 
 var _ = Describe("CheckHealth", func() {
 	var (
@@ -83,7 +104,11 @@ var _ = Describe("CheckHealth", func() {
 			})
 
 			It("doesn't wait forever", func() {
-				Expect(resp.StatusCode).To(Equal(503))
+				Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+				body := parseHealthResponse(resp)
+				Expect(body.Garden.Healthy).To(BeTrue())
+				Expect(body.Baggageclaim.Healthy).To(BeFalse())
+				Expect(body.Baggageclaim.ResponseError).ToNot(BeEmpty())
 			})
 		})
 
@@ -92,8 +117,13 @@ var _ = Describe("CheckHealth", func() {
 				baggageclaim.Close()
 			})
 
-			It("returns 503", func() {
-				Expect(resp.StatusCode).To(Equal(503))
+			It("returns 503 with baggageclaim unhealthy", func() {
+				Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+				body := parseHealthResponse(resp)
+				Expect(body.Garden.Healthy).To(BeTrue())
+				Expect(body.Garden.ResponseError).To(BeEmpty())
+				Expect(body.Baggageclaim.Healthy).To(BeFalse())
+				Expect(body.Baggageclaim.ResponseError).ToNot(BeEmpty())
 			})
 		})
 
@@ -102,14 +132,23 @@ var _ = Describe("CheckHealth", func() {
 				garden.Close()
 			})
 
-			It("returns 503", func() {
-				Expect(resp.StatusCode).To(Equal(503))
+			It("returns 503 with garden unhealthy", func() {
+				Expect(resp.StatusCode).To(Equal(http.StatusServiceUnavailable))
+				body := parseHealthResponse(resp)
+				Expect(body.Garden.Healthy).To(BeFalse())
+				Expect(body.Garden.ResponseError).ToNot(BeEmpty())
 			})
 		})
 
 		Context("having baggageclaim AND garden up", func() {
-			It("returns 200", func() {
-				Expect(resp.StatusCode).To(Equal(200))
+			It("returns 200 with json response", func() {
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"))
+				body := parseHealthResponse(resp)
+				Expect(body.Garden.Healthy).To(BeTrue())
+				Expect(body.Garden.ResponseError).To(BeEmpty())
+				Expect(body.Baggageclaim.Healthy).To(BeTrue())
+				Expect(body.Baggageclaim.ResponseError).To(BeEmpty())
 			})
 		})
 	})


### PR DESCRIPTION
## Changes proposed by this PR

Have the worker healthcheck endpoint return a detailed json response.

JSON payload will look like:

```json
{
  "garden": {
    "healthy": true,
    "response_error": ""
  },
  "baggageclaim": {
    "healthy": true,
    "response_error": ""
  }
}
```

The HTTP status code will either be 200, or 503 if either components are unhealthy.

Not sure how useful the `response_error` will ever be. In all (most?) cases, operators will need to check worker logs for a more detailed message logged by the failing component(s).

I think this will be useful for the healthpoint RFC as well: https://github.com/concourse/rfcs/pull/141
