### PR TITLE
Add TTL/expiry for task caches and `CONCOURSE_DEFAULT_TASK_CACHE_TTL`

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -280,6 +280,8 @@ type RunCommand struct {
 	DefaultPutTimeout  time.Duration `long:"default-put-timeout" description:"Default timeout of put steps"`
 	DefaultTaskTimeout time.Duration `long:"default-task-timeout" description:"Default timeout of task steps"`
 
+	DefaultTaskCacheTTL time.Duration `long:"default-task-cache-ttl" default:"0s" description:"Default TTL for task caches. Caches unused for this duration will be garbage-collected. 0s means no expiry."`
+
 	NumGoroutineThreshold int `long:"num-goroutine-threshold" description:"When number of goroutines reaches to this threshold, then slow down current ATC. This helps distribute workloads across ATCs evenly."`
 
 	DBNotificationBusQueueSize int `long:"db-notification-bus-queue-size" default:"10000" description:"DB notification bus queue size, default is 10000. If UI often misses loading running build logs, then consider to increase the queue size."`
@@ -1720,6 +1722,13 @@ func (cmd *RunCommand) validate() error {
 		)
 	}
 
+	if cmd.DefaultTaskCacheTTL > 0 && cmd.DefaultTaskCacheTTL < time.Second {
+		errs = multierror.Append(
+			errs,
+			errors.New("default-task-cache-ttl must be 0s or >= 1s. A TTL of < 1s is not supported."),
+		)
+	}
+
 	if err := cmd.validateCustomRoles(); err != nil {
 		errs = multierror.Append(errs, err)
 	}
@@ -1859,6 +1868,7 @@ func (cmd *RunCommand) constructEngine(
 				cmd.DefaultGetTimeout,
 				cmd.DefaultPutTimeout,
 				cmd.DefaultTaskTimeout,
+				cmd.DefaultTaskCacheTTL,
 			),
 			cmd.ExternalURL.String(),
 			rateLimiter,

--- a/atc/db/dbfakes/fake_created_volume.go
+++ b/atc/db/dbfakes/fake_created_volume.go
@@ -3,6 +3,7 @@ package dbfakes
 
 import (
 	"sync"
+	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
@@ -118,12 +119,13 @@ type FakeCreatedVolume struct {
 		result1 *db.UsedWorkerResourceCache
 		result2 error
 	}
-	InitializeTaskCacheStub        func(int, string, string) error
+	InitializeTaskCacheStub        func(int, string, string, time.Duration) error
 	initializeTaskCacheMutex       sync.RWMutex
 	initializeTaskCacheArgsForCall []struct {
 		arg1 int
 		arg2 string
 		arg3 string
+		arg4 time.Duration
 	}
 	initializeTaskCacheReturns struct {
 		result1 error
@@ -765,20 +767,21 @@ func (fake *FakeCreatedVolume) InitializeStreamedResourceCacheReturnsOnCall(i in
 	}{result1, result2}
 }
 
-func (fake *FakeCreatedVolume) InitializeTaskCache(arg1 int, arg2 string, arg3 string) error {
+func (fake *FakeCreatedVolume) InitializeTaskCache(arg1 int, arg2 string, arg3 string, arg4 time.Duration) error {
 	fake.initializeTaskCacheMutex.Lock()
 	ret, specificReturn := fake.initializeTaskCacheReturnsOnCall[len(fake.initializeTaskCacheArgsForCall)]
 	fake.initializeTaskCacheArgsForCall = append(fake.initializeTaskCacheArgsForCall, struct {
 		arg1 int
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 time.Duration
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.InitializeTaskCacheStub
 	fakeReturns := fake.initializeTaskCacheReturns
-	fake.recordInvocation("InitializeTaskCache", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("InitializeTaskCache", []interface{}{arg1, arg2, arg3, arg4})
 	fake.initializeTaskCacheMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -792,17 +795,17 @@ func (fake *FakeCreatedVolume) InitializeTaskCacheCallCount() int {
 	return len(fake.initializeTaskCacheArgsForCall)
 }
 
-func (fake *FakeCreatedVolume) InitializeTaskCacheCalls(stub func(int, string, string) error) {
+func (fake *FakeCreatedVolume) InitializeTaskCacheCalls(stub func(int, string, string, time.Duration) error) {
 	fake.initializeTaskCacheMutex.Lock()
 	defer fake.initializeTaskCacheMutex.Unlock()
 	fake.InitializeTaskCacheStub = stub
 }
 
-func (fake *FakeCreatedVolume) InitializeTaskCacheArgsForCall(i int) (int, string, string) {
+func (fake *FakeCreatedVolume) InitializeTaskCacheArgsForCall(i int) (int, string, string, time.Duration) {
 	fake.initializeTaskCacheMutex.RLock()
 	defer fake.initializeTaskCacheMutex.RUnlock()
 	argsForCall := fake.initializeTaskCacheArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeCreatedVolume) InitializeTaskCacheReturns(result1 error) {

--- a/atc/db/dbfakes/fake_task_cache_factory.go
+++ b/atc/db/dbfakes/fake_task_cache_factory.go
@@ -3,6 +3,7 @@ package dbfakes
 
 import (
 	"sync"
+	"time"
 
 	"github.com/concourse/concourse/atc/db"
 )
@@ -25,12 +26,13 @@ type FakeTaskCacheFactory struct {
 		result2 bool
 		result3 error
 	}
-	FindOrCreateStub        func(int, string, string) (db.UsedTaskCache, error)
+	FindOrCreateStub        func(int, string, string, time.Duration) (db.UsedTaskCache, error)
 	findOrCreateMutex       sync.RWMutex
 	findOrCreateArgsForCall []struct {
 		arg1 int
 		arg2 string
 		arg3 string
+		arg4 time.Duration
 	}
 	findOrCreateReturns struct {
 		result1 db.UsedTaskCache
@@ -113,20 +115,21 @@ func (fake *FakeTaskCacheFactory) FindReturnsOnCall(i int, result1 db.UsedTaskCa
 	}{result1, result2, result3}
 }
 
-func (fake *FakeTaskCacheFactory) FindOrCreate(arg1 int, arg2 string, arg3 string) (db.UsedTaskCache, error) {
+func (fake *FakeTaskCacheFactory) FindOrCreate(arg1 int, arg2 string, arg3 string, arg4 time.Duration) (db.UsedTaskCache, error) {
 	fake.findOrCreateMutex.Lock()
 	ret, specificReturn := fake.findOrCreateReturnsOnCall[len(fake.findOrCreateArgsForCall)]
 	fake.findOrCreateArgsForCall = append(fake.findOrCreateArgsForCall, struct {
 		arg1 int
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 time.Duration
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.FindOrCreateStub
 	fakeReturns := fake.findOrCreateReturns
-	fake.recordInvocation("FindOrCreate", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("FindOrCreate", []interface{}{arg1, arg2, arg3, arg4})
 	fake.findOrCreateMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -140,17 +143,17 @@ func (fake *FakeTaskCacheFactory) FindOrCreateCallCount() int {
 	return len(fake.findOrCreateArgsForCall)
 }
 
-func (fake *FakeTaskCacheFactory) FindOrCreateCalls(stub func(int, string, string) (db.UsedTaskCache, error)) {
+func (fake *FakeTaskCacheFactory) FindOrCreateCalls(stub func(int, string, string, time.Duration) (db.UsedTaskCache, error)) {
 	fake.findOrCreateMutex.Lock()
 	defer fake.findOrCreateMutex.Unlock()
 	fake.FindOrCreateStub = stub
 }
 
-func (fake *FakeTaskCacheFactory) FindOrCreateArgsForCall(i int) (int, string, string) {
+func (fake *FakeTaskCacheFactory) FindOrCreateArgsForCall(i int) (int, string, string, time.Duration) {
 	fake.findOrCreateMutex.RLock()
 	defer fake.findOrCreateMutex.RUnlock()
 	argsForCall := fake.findOrCreateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeTaskCacheFactory) FindOrCreateReturns(result1 db.UsedTaskCache, result2 error) {

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -2112,7 +2112,7 @@ var _ = Describe("Job", func() {
 					found bool
 				)
 
-				usedTaskCache, err := taskCacheFactory.FindOrCreate(job.ID(), "some-task", "some-path")
+				usedTaskCache, err := taskCacheFactory.FindOrCreate(job.ID(), "some-task", "some-path", 0)
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = workerTaskCacheFactory.FindOrCreate(db.WorkerTaskCache{
@@ -2126,7 +2126,7 @@ var _ = Describe("Job", func() {
 				Expect(found).To(BeTrue())
 				Expect(someOtherJob).ToNot(BeNil())
 
-				otherUsedTaskCache, err := taskCacheFactory.FindOrCreate(someOtherJob.ID(), "some-other-task", "some-other-path")
+				otherUsedTaskCache, err := taskCacheFactory.FindOrCreate(someOtherJob.ID(), "some-other-task", "some-other-path", 0)
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = workerTaskCacheFactory.FindOrCreate(db.WorkerTaskCache{

--- a/atc/db/migration/migrations/1776182280_add_ttl_to_task_caches.down.sql
+++ b/atc/db/migration/migrations/1776182280_add_ttl_to_task_caches.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task_caches DROP COLUMN last_used;
+ALTER TABLE task_caches DROP COLUMN ttl;

--- a/atc/db/migration/migrations/1776182280_add_ttl_to_task_caches.up.sql
+++ b/atc/db/migration/migrations/1776182280_add_ttl_to_task_caches.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task_caches ADD COLUMN last_used timestamp with time zone NOT NULL DEFAULT now();
+ALTER TABLE task_caches ADD COLUMN ttl bigint NOT NULL DEFAULT 0;

--- a/atc/db/task_cache.go
+++ b/atc/db/task_cache.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 )
@@ -11,6 +12,7 @@ type usedTaskCache struct {
 	jobID    int
 	stepName string
 	path     string
+	ttl      time.Duration
 }
 
 type UsedTaskCache interface {
@@ -19,12 +21,14 @@ type UsedTaskCache interface {
 	JobID() int
 	StepName() string
 	Path() string
+	TTL() time.Duration
 }
 
-func (tc *usedTaskCache) ID() int          { return tc.id }
-func (tc *usedTaskCache) JobID() int       { return tc.jobID }
-func (tc *usedTaskCache) StepName() string { return tc.stepName }
-func (tc *usedTaskCache) Path() string     { return tc.path }
+func (tc *usedTaskCache) ID() int            { return tc.id }
+func (tc *usedTaskCache) JobID() int         { return tc.jobID }
+func (tc *usedTaskCache) StepName() string   { return tc.stepName }
+func (tc *usedTaskCache) Path() string       { return tc.path }
+func (tc *usedTaskCache) TTL() time.Duration { return tc.ttl }
 
 func (f usedTaskCache) findOrCreate(tx Tx) (UsedTaskCache, error) {
 	utc, found, err := f.find(tx)
@@ -39,17 +43,22 @@ func (f usedTaskCache) findOrCreate(tx Tx) (UsedTaskCache, error) {
 				"job_id",
 				"step_name",
 				"path",
+				"last_used",
+				"ttl",
 			).
 			Values(
 				f.jobID,
 				f.stepName,
 				f.path,
+				sq.Expr("now()"),
+				int64(f.ttl.Seconds()),
 			).
 			Suffix(`
 					ON CONFLICT (job_id, step_name, path) DO UPDATE SET
-						job_id = ?
+						last_used = now(),
+						ttl = ?
 					RETURNING id
-				`, f.jobID).
+				`, int64(f.ttl.Seconds())).
 			RunWith(tx).
 			QueryRow().
 			Scan(&id)
@@ -62,6 +71,7 @@ func (f usedTaskCache) findOrCreate(tx Tx) (UsedTaskCache, error) {
 			jobID:    f.jobID,
 			stepName: f.stepName,
 			path:     f.path,
+			ttl:      f.ttl,
 		}, nil
 	}
 
@@ -69,8 +79,11 @@ func (f usedTaskCache) findOrCreate(tx Tx) (UsedTaskCache, error) {
 }
 
 func (f usedTaskCache) find(runner sq.Runner) (UsedTaskCache, bool, error) {
-	var id int
-	err := psql.Select("id").
+	var (
+		id         int
+		ttlSeconds int64
+	)
+	err := psql.Select("id", "ttl").
 		From("task_caches").
 		Where(sq.Eq{
 			"job_id":    f.jobID,
@@ -79,7 +92,7 @@ func (f usedTaskCache) find(runner sq.Runner) (UsedTaskCache, bool, error) {
 		}).
 		RunWith(runner).
 		QueryRow().
-		Scan(&id)
+		Scan(&id, &ttlSeconds)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, false, nil
@@ -93,6 +106,7 @@ func (f usedTaskCache) find(runner sq.Runner) (UsedTaskCache, bool, error) {
 		jobID:    f.jobID,
 		stepName: f.stepName,
 		path:     f.path,
+		ttl:      time.Duration(ttlSeconds) * time.Second,
 	}, true, nil
 
 }

--- a/atc/db/task_cache.go
+++ b/atc/db/task_cache.go
@@ -31,51 +31,42 @@ func (tc *usedTaskCache) Path() string       { return tc.path }
 func (tc *usedTaskCache) TTL() time.Duration { return tc.ttl }
 
 func (f usedTaskCache) findOrCreate(tx Tx) (UsedTaskCache, error) {
-	utc, found, err := f.find(tx)
-	if err != nil {
-		return nil, err
-	}
-
-	if !found {
-		var id int
-		err = psql.Insert("task_caches").
-			Columns(
-				"job_id",
-				"step_name",
-				"path",
-				"last_used",
-				"ttl",
-			).
-			Values(
-				f.jobID,
-				f.stepName,
-				f.path,
-				sq.Expr("now()"),
-				int64(f.ttl.Seconds()),
-			).
-			Suffix(`
+	var id int
+	err := psql.Insert("task_caches").
+		Columns(
+			"job_id",
+			"step_name",
+			"path",
+			"last_used",
+			"ttl",
+		).
+		Values(
+			f.jobID,
+			f.stepName,
+			f.path,
+			sq.Expr("now()"),
+			int64(f.ttl.Seconds()),
+		).
+		Suffix(`
 					ON CONFLICT (job_id, step_name, path) DO UPDATE SET
 						last_used = now(),
 						ttl = ?
 					RETURNING id
 				`, int64(f.ttl.Seconds())).
-			RunWith(tx).
-			QueryRow().
-			Scan(&id)
-		if err != nil {
-			return nil, err
-		}
-
-		return &usedTaskCache{
-			id:       id,
-			jobID:    f.jobID,
-			stepName: f.stepName,
-			path:     f.path,
-			ttl:      f.ttl,
-		}, nil
+		RunWith(tx).
+		QueryRow().
+		Scan(&id)
+	if err != nil {
+		return nil, err
 	}
 
-	return utc, nil
+	return &usedTaskCache{
+		id:       id,
+		jobID:    f.jobID,
+		stepName: f.stepName,
+		path:     f.path,
+		ttl:      f.ttl,
+	}, nil
 }
 
 func (f usedTaskCache) find(runner sq.Runner) (UsedTaskCache, bool, error) {

--- a/atc/db/task_cache_factory.go
+++ b/atc/db/task_cache_factory.go
@@ -1,9 +1,11 @@
 package db
 
+import "time"
+
 //counterfeiter:generate . TaskCacheFactory
 type TaskCacheFactory interface {
 	Find(jobID int, stepName string, path string) (UsedTaskCache, bool, error)
-	FindOrCreate(jobID int, stepName string, path string) (UsedTaskCache, error)
+	FindOrCreate(jobID int, stepName string, path string, ttl time.Duration) (UsedTaskCache, error)
 }
 
 type taskCacheFactory struct {
@@ -24,7 +26,7 @@ func (f *taskCacheFactory) Find(jobID int, stepName string, path string) (UsedTa
 	}.find(f.conn)
 }
 
-func (f *taskCacheFactory) FindOrCreate(jobID int, stepName string, path string) (UsedTaskCache, error) {
+func (f *taskCacheFactory) FindOrCreate(jobID int, stepName string, path string, ttl time.Duration) (UsedTaskCache, error) {
 	tx, err := f.conn.Begin()
 	if err != nil {
 		return nil, err
@@ -36,6 +38,7 @@ func (f *taskCacheFactory) FindOrCreate(jobID int, stepName string, path string)
 		jobID:    jobID,
 		stepName: stepName,
 		path:     path,
+		ttl:      ttl,
 	}.findOrCreate(tx)
 
 	if err != nil {

--- a/atc/db/task_cache_factory_test.go
+++ b/atc/db/task_cache_factory_test.go
@@ -1,6 +1,8 @@
 package db_test
 
 import (
+	"time"
+
 	"github.com/concourse/concourse/atc/db"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -37,6 +39,18 @@ var _ = Describe("TaskCacheFactory", func() {
 					0,
 				)
 				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("updates the existing task cache's ttl", func() {
+				updatedTaskCache, err := taskCacheFactory.FindOrCreate(
+					defaultJob.ID(),
+					"some-step",
+					"some-path",
+					1*time.Hour,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedTaskCache.ID()).To(Equal(usedTaskCache.ID()))
+				Expect(updatedTaskCache.TTL()).ToNot(Equal(usedTaskCache.TTL()))
 			})
 
 			It("creates a new task cache for another task", func() {

--- a/atc/db/task_cache_factory_test.go
+++ b/atc/db/task_cache_factory_test.go
@@ -16,6 +16,7 @@ var _ = Describe("TaskCacheFactory", func() {
 					defaultJob.ID(),
 					"some-step",
 					"some-path",
+					0,
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(usedTaskCache.ID()).ToNot(BeNil())
@@ -33,6 +34,7 @@ var _ = Describe("TaskCacheFactory", func() {
 					defaultJob.ID(),
 					"some-step",
 					"some-path",
+					0,
 				)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -42,6 +44,7 @@ var _ = Describe("TaskCacheFactory", func() {
 					defaultJob.ID(),
 					"some-other-step",
 					"some-path",
+					0,
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(otherTaskCache.ID()).ToNot(Equal(usedTaskCache.ID()))
@@ -74,6 +77,7 @@ var _ = Describe("TaskCacheFactory", func() {
 					defaultJob.ID(),
 					"some-step",
 					"some-path",
+					0,
 				)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/atc/db/task_cache_lifecycle.go
+++ b/atc/db/task_cache_lifecycle.go
@@ -22,14 +22,15 @@ func NewTaskCacheLifecycle(conn DbConn) TaskCacheLifecycle {
 func (f *taskCacheLifecycle) CleanUpInvalidTaskCaches() ([]int, error) {
 	rows, err := psql.Delete("task_caches tc").
 		Where(sq.Expr(`tc.id IN (
-            SELECT tc.id 
-            FROM task_caches tc
-            JOIN jobs j ON j.id = tc.job_id
-            JOIN pipelines p ON p.id = j.pipeline_id
-            WHERE p.archived OR
-                (p.paused AND j.next_build_id IS NULL) OR
-                (j.paused AND j.next_build_id IS NULL)
-        )`)).
+				SELECT tc.id
+				FROM task_caches tc
+				JOIN jobs j ON j.id = tc.job_id
+				JOIN pipelines p ON p.id = j.pipeline_id
+				WHERE p.archived
+					OR (p.paused AND j.next_build_id IS NULL)
+					OR (j.paused AND j.next_build_id IS NULL)
+			)
+			OR (tc.ttl > 0 AND tc.last_used + make_interval(secs => tc.ttl) < now())`)).
 		Suffix("RETURNING id").
 		RunWith(f.conn).
 		Query()

--- a/atc/db/task_cache_lifecycle_test.go
+++ b/atc/db/task_cache_lifecycle_test.go
@@ -1,6 +1,8 @@
 package db_test
 
 import (
+	"time"
+
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbtest"
@@ -37,10 +39,10 @@ var _ = Describe("TaskCacheLifecycle", func() {
 				},
 			}),
 		)
-		taskCache, err := taskCacheFactory.FindOrCreate(archivedScenario.Job("some-job").ID(), "some-step", "some-path")
+		taskCache, err := taskCacheFactory.FindOrCreate(archivedScenario.Job("some-job").ID(), "some-step", "some-path", 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = taskCacheFactory.FindOrCreate(otherScenario.Job("some-other-job").ID(), "some-step", "some-path")
+		_, err = taskCacheFactory.FindOrCreate(otherScenario.Job("some-other-job").ID(), "some-step", "some-path", 0)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = archivedScenario.Pipeline.Archive()
@@ -76,13 +78,13 @@ var _ = Describe("TaskCacheLifecycle", func() {
 		err := finishedBuild.Finish(db.BuildStatusSucceeded)
 		Expect(err).ToNot(HaveOccurred())
 
-		taskCache, err := taskCacheFactory.FindOrCreate(otherScenario.Job("some-other-job").ID(), "some-step", "some-path")
+		taskCache, err := taskCacheFactory.FindOrCreate(otherScenario.Job("some-other-job").ID(), "some-step", "some-path", 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-1").ID(), "some-step", "some-path")
+		_, err = taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-1").ID(), "some-step", "some-path", 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-2").ID(), "some-step", "some-path")
+		_, err = taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-2").ID(), "some-step", "some-path", 0)
 		Expect(err).ToNot(HaveOccurred())
 
 		err = pausedScenario.Pipeline.Pause("tester")
@@ -119,14 +121,82 @@ var _ = Describe("TaskCacheLifecycle", func() {
 		err = pausedScenario.Job("some-job-2").Pause("tester")
 		Expect(err).ToNot(HaveOccurred())
 
-		taskCache, err := taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-1").ID(), "some-step", "some-path")
+		taskCache, err := taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-1").ID(), "some-step", "some-path", 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		_, err = taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-2").ID(), "some-step", "some-path")
+		_, err = taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-2").ID(), "some-step", "some-path", 0)
 		Expect(err).ToNot(HaveOccurred())
 
 		deletedCacheIDs, err := taskCacheLifecycle.CleanUpInvalidTaskCaches()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(deletedCacheIDs).To(ConsistOf(taskCache.ID()))
+	})
+
+	Context("task cache has a ttl of zero", func() {
+		It("does not remove the cache", func() {
+			ttl := time.Duration(0)
+			unpausedScenario := dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: []atc.JobConfig{
+						{Name: "some-job"},
+					},
+				}),
+			)
+			err := unpausedScenario.Pipeline.Unpause()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = taskCacheFactory.FindOrCreate(unpausedScenario.Job("some-job").ID(), "some-step", "some-path", ttl)
+			Expect(err).ToNot(HaveOccurred())
+
+			deletedCacheIDs, err := taskCacheLifecycle.CleanUpInvalidTaskCaches()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deletedCacheIDs).To(BeEmpty())
+		})
+	})
+
+	Context("task cache has a ttl greater than zero", func() {
+		It("does remove the cache when the ttl has been reached", func() {
+			ttl := 1 * time.Second
+			unpausedScenario := dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: []atc.JobConfig{
+						{Name: "some-job"},
+					},
+				}),
+			)
+			err := unpausedScenario.Pipeline.Unpause()
+			Expect(err).ToNot(HaveOccurred())
+
+			taskCache, err := taskCacheFactory.FindOrCreate(unpausedScenario.Job("some-job").ID(), "some-step", "some-path", ttl)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("waiting for ttl to pass", func() {
+				time.Sleep(ttl + (1 * time.Second))
+			})
+
+			deletedCacheIDs, err := taskCacheLifecycle.CleanUpInvalidTaskCaches()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deletedCacheIDs).To(ConsistOf(taskCache.ID()))
+		})
+
+		It("doesn't remove the cache when the ttl is not reached", func() {
+			ttl := 1 * time.Hour
+			unpausedScenario := dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: []atc.JobConfig{
+						{Name: "some-job"},
+					},
+				}),
+			)
+			err := unpausedScenario.Pipeline.Unpause()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = taskCacheFactory.FindOrCreate(unpausedScenario.Job("some-job").ID(), "some-step", "some-path", ttl)
+			Expect(err).ToNot(HaveOccurred())
+
+			deletedCacheIDs, err := taskCacheLifecycle.CleanUpInvalidTaskCaches()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deletedCacheIDs).To(BeEmpty())
+		})
 	})
 })

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -2885,14 +2885,14 @@ var _ = Describe("Team", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-task", "some-path")
+			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-task", "some-path", 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, found, err = taskCacheFactory.Find(job.ID(), "some-task", "some-path")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-nested-task", "some-path")
+			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-nested-task", "some-path", 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, found, err = taskCacheFactory.Find(job.ID(), "some-nested-task", "some-path")
@@ -2921,14 +2921,14 @@ var _ = Describe("Team", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-task", "some-path")
+			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-task", "some-path", 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, found, err = taskCacheFactory.Find(job.ID(), "some-task", "some-path")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-nested-task", "some-path")
+			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-nested-task", "some-path", 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, found, err = taskCacheFactory.Find(job.ID(), "some-nested-task", "some-path")
@@ -2972,7 +2972,7 @@ var _ = Describe("Team", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-task", "some-path")
+			_, err = taskCacheFactory.FindOrCreate(job.ID(), "some-task", "some-path", 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, found, err = taskCacheFactory.Find(job.ID(), "some-task", "some-path")
@@ -2983,7 +2983,7 @@ var _ = Describe("Team", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			_, err = taskCacheFactory.FindOrCreate(otherJob.ID(), "some-task", "some-path")
+			_, err = taskCacheFactory.FindOrCreate(otherJob.ID(), "some-task", "some-path", 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, found, err = taskCacheFactory.Find(otherJob.ID(), "some-task", "some-path")

--- a/atc/db/volume.go
+++ b/atc/db/volume.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -164,7 +165,7 @@ type CreatedVolume interface {
 	InitializeStreamedResourceCache(ResourceCache, int) (*UsedWorkerResourceCache, error)
 	GetResourceCacheID() int
 	InitializeArtifact(name string, buildID int) (WorkerArtifact, error)
-	InitializeTaskCache(jobID int, stepName string, path string) error
+	InitializeTaskCache(jobID int, stepName string, path string, ttl time.Duration) error
 
 	ContainerHandle() string
 	ParentHandle() string
@@ -548,7 +549,7 @@ func initializeArtifact(conn DbConn, volumeID int, name string, buildID int) (Wo
 	return workerArtifact, nil
 }
 
-func (volume *createdVolume) InitializeTaskCache(jobID int, stepName string, path string) error {
+func (volume *createdVolume) InitializeTaskCache(jobID int, stepName string, path string, ttl time.Duration) error {
 	tx, err := volume.conn.Begin()
 	if err != nil {
 		return err
@@ -560,6 +561,7 @@ func (volume *createdVolume) InitializeTaskCache(jobID int, stepName string, pat
 		jobID:    jobID,
 		stepName: stepName,
 		path:     path,
+		ttl:      ttl,
 	}.findOrCreate(tx)
 	if err != nil {
 		return err

--- a/atc/db/volume_repository_test.go
+++ b/atc/db/volume_repository_test.go
@@ -56,7 +56,7 @@ var _ = Describe("VolumeRepository", func() {
 		)
 
 		It("returns task cache volumes", func() {
-			taskCache, err := taskCacheFactory.FindOrCreate(defaultJob.ID(), "some-step", "some-path")
+			taskCache, err := taskCacheFactory.FindOrCreate(defaultJob.ID(), "some-step", "some-path", 0)
 			Expect(err).NotTo(HaveOccurred())
 
 			usedWorkerTaskCache, err := workerTaskCacheFactory.FindOrCreate(db.WorkerTaskCache{

--- a/atc/db/volume_test.go
+++ b/atc/db/volume_test.go
@@ -589,7 +589,7 @@ var _ = Describe("Volume", func() {
 				existingTaskCacheVolume, err = v.Created()
 				Expect(err).ToNot(HaveOccurred())
 
-				err = existingTaskCacheVolume.InitializeTaskCache(defaultJob.ID(), "some-step", "some-cache-path")
+				err = existingTaskCacheVolume.InitializeTaskCache(defaultJob.ID(), "some-step", "some-cache-path", 0)
 				Expect(err).ToNot(HaveOccurred())
 
 				v, err = volumeRepository.CreateContainerVolume(defaultTeam.ID(), defaultWorker.Name(), creatingContainer, "some-other-path")
@@ -600,7 +600,7 @@ var _ = Describe("Volume", func() {
 			})
 
 			It("sets current volume as worker task cache volume", func() {
-				taskCache, err := taskCacheFactory.FindOrCreate(defaultJob.ID(), "some-step", "some-cache-path")
+				taskCache, err := taskCacheFactory.FindOrCreate(defaultJob.ID(), "some-step", "some-cache-path", 0)
 				Expect(err).ToNot(HaveOccurred())
 
 				createdVolume, found, err := volumeRepository.FindTaskCacheVolume(defaultTeam.ID(), defaultWorker.Name(), taskCache)
@@ -609,7 +609,7 @@ var _ = Describe("Volume", func() {
 				Expect(createdVolume).ToNot(BeNil())
 				Expect(createdVolume.Handle()).To(Equal(existingTaskCacheVolume.Handle()))
 
-				err = volume.InitializeTaskCache(defaultJob.ID(), "some-step", "some-cache-path")
+				err = volume.InitializeTaskCache(defaultJob.ID(), "some-step", "some-cache-path", 0)
 				Expect(err).ToNot(HaveOccurred())
 
 				createdVolume, found, err = volumeRepository.FindTaskCacheVolume(defaultTeam.ID(), defaultWorker.Name(), taskCache)
@@ -891,7 +891,7 @@ var _ = Describe("Volume", func() {
 
 	Describe("Task cache volumes", func() {
 		It("returns volume type and task identifier", func() {
-			taskCache, err := taskCacheFactory.FindOrCreate(defaultJob.ID(), "some-task", "some-path")
+			taskCache, err := taskCacheFactory.FindOrCreate(defaultJob.ID(), "some-task", "some-path", 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			uwtc, err := workerTaskCacheFactory.FindOrCreate(db.WorkerTaskCache{

--- a/atc/db/worker_task_cache_factory_test.go
+++ b/atc/db/worker_task_cache_factory_test.go
@@ -11,7 +11,7 @@ var _ = Describe("WorkerTaskCache", func() {
 	var workerTaskCache db.WorkerTaskCache
 
 	BeforeEach(func() {
-		taskCache, err := taskCacheFactory.FindOrCreate(1, "some-step", "some-path")
+		taskCache, err := taskCacheFactory.FindOrCreate(1, "some-step", "some-path", 0)
 		Expect(err).ToNot(HaveOccurred())
 
 		workerTaskCache = db.WorkerTaskCache{

--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -30,6 +30,7 @@ type coreStepFactory struct {
 	defaultGetTimeout     time.Duration
 	defaultPutTimeout     time.Duration
 	defaultTaskTimeout    time.Duration
+	defaultTaskCacheTTL   time.Duration
 }
 
 func NewCoreStepFactory(
@@ -48,6 +49,7 @@ func NewCoreStepFactory(
 	defaultGetTimeout time.Duration,
 	defaultPutTimeout time.Duration,
 	defaultTaskTimeout time.Duration,
+	defaultTaskCacheTTL time.Duration,
 ) CoreStepFactory {
 	return &coreStepFactory{
 		pool:                  pool,
@@ -65,6 +67,7 @@ func NewCoreStepFactory(
 		defaultGetTimeout:     defaultGetTimeout,
 		defaultPutTimeout:     defaultPutTimeout,
 		defaultTaskTimeout:    defaultTaskTimeout,
+		defaultTaskCacheTTL:   defaultTaskCacheTTL,
 	}
 }
 
@@ -191,6 +194,7 @@ func (factory *coreStepFactory) TaskStep(
 		factory.streamer,
 		delegateFactory,
 		factory.defaultTaskTimeout,
+		factory.defaultTaskCacheTTL,
 	)
 
 	taskStep = exec.LogError(taskStep, delegateFactory)

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -86,16 +86,17 @@ type TaskDelegate interface {
 // TaskStep executes a TaskConfig, whose inputs will be fetched from the
 // artifact.Repository and outputs will be added to the artifact.Repository.
 type TaskStep struct {
-	planID             atc.PlanID
-	plan               atc.TaskPlan
-	defaultLimits      atc.ContainerLimits
-	metadata           StepMetadata
-	containerMetadata  db.ContainerMetadata
-	strategy           worker.PlacementStrategy
-	workerPool         Pool
-	streamer           Streamer
-	delegateFactory    TaskDelegateFactory
-	defaultTaskTimeout time.Duration
+	planID              atc.PlanID
+	plan                atc.TaskPlan
+	defaultLimits       atc.ContainerLimits
+	metadata            StepMetadata
+	containerMetadata   db.ContainerMetadata
+	strategy            worker.PlacementStrategy
+	workerPool          Pool
+	streamer            Streamer
+	delegateFactory     TaskDelegateFactory
+	defaultTaskTimeout  time.Duration
+	defaultTaskCacheTTL time.Duration
 }
 
 func NewTaskStep(
@@ -109,18 +110,20 @@ func NewTaskStep(
 	streamer Streamer,
 	delegateFactory TaskDelegateFactory,
 	defaultTaskTimeout time.Duration,
+	defaultTaskCacheTTL time.Duration,
 ) Step {
 	return &TaskStep{
-		planID:             planID,
-		plan:               plan,
-		defaultLimits:      defaultLimits,
-		metadata:           metadata,
-		containerMetadata:  containerMetadata,
-		strategy:           strategy,
-		workerPool:         workerPool,
-		streamer:           streamer,
-		delegateFactory:    delegateFactory,
-		defaultTaskTimeout: defaultTaskTimeout,
+		planID:              planID,
+		plan:                plan,
+		defaultLimits:       defaultLimits,
+		metadata:            metadata,
+		containerMetadata:   containerMetadata,
+		strategy:            strategy,
+		workerPool:          workerPool,
+		streamer:            streamer,
+		delegateFactory:     delegateFactory,
+		defaultTaskTimeout:  defaultTaskTimeout,
+		defaultTaskCacheTTL: defaultTaskCacheTTL,
 	}
 }
 
@@ -335,7 +338,7 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 
 	// Do not initialize caches for one-off builds
 	if step.metadata.JobID != 0 {
-		if err := step.registerCaches(ctx, repository, config, volumeMounts, step.containerMetadata); err != nil {
+		if err := step.registerCaches(ctx, config, volumeMounts, step.containerMetadata); err != nil {
 			return false, err
 		}
 	}
@@ -496,9 +499,22 @@ func (step *TaskStep) registerOutputs(logger lager.Logger, repository *build.Rep
 	}
 }
 
-func (step *TaskStep) registerCaches(ctx context.Context, repository *build.Repository, config atc.TaskConfig, volumeMounts []runtime.VolumeMount, metadata db.ContainerMetadata) error {
+func (step *TaskStep) registerCaches(ctx context.Context, config atc.TaskConfig, volumeMounts []runtime.VolumeMount, metadata db.ContainerMetadata) error {
 	logger := lagerctx.FromContext(ctx)
 	for _, cacheConfig := range config.Caches {
+		var ttl time.Duration
+		if cacheConfig.TTL != "" {
+			var err error
+			ttl, err = time.ParseDuration(cacheConfig.TTL)
+			if err != nil {
+				return fmt.Errorf("invalid cache ttl %q: %w", cacheConfig.TTL, err)
+			}
+		}
+
+		if ttl == 0 && step.defaultTaskCacheTTL > 0 {
+			ttl = step.defaultTaskCacheTTL
+		}
+
 		for _, volumeMount := range volumeMounts {
 			mountPath := resolvePath(metadata.WorkingDirectory, cacheConfig.Path)
 			if filepath.Clean(volumeMount.MountPath) == mountPath {
@@ -511,6 +527,7 @@ func (step *TaskStep) registerCaches(ctx context.Context, repository *build.Repo
 					step.plan.Name,
 					cacheConfig.Path,
 					step.plan.Privileged,
+					ttl,
 				)
 				if err != nil {
 					return err

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -70,7 +70,8 @@ var _ = Describe("TaskStep", func() {
 
 		expectedOwner = db.NewBuildStepContainerOwner(stepMetadata.BuildID, planID, stepMetadata.TeamID)
 
-		defaultTaskTimeout time.Duration = 0
+		defaultTaskTimeout  time.Duration = 0
+		defaultTaskCacheTTL time.Duration = 0
 	)
 
 	BeforeEach(func() {
@@ -125,6 +126,7 @@ var _ = Describe("TaskStep", func() {
 			fakeStreamer,
 			fakeDelegateFactory,
 			defaultTaskTimeout,
+			defaultTaskCacheTTL,
 		)
 
 		stepOk, stepErr = taskStep.Run(ctx, state)
@@ -645,6 +647,90 @@ var _ = Describe("TaskStep", func() {
 				})
 
 				itRegistersCaches(false)
+			})
+		})
+
+		Context("when task config's cache TTL is not set", func() {
+			var volume1 *runtimetest.Volume
+
+			BeforeEach(func() {
+				stepMetadata.JobID = 12
+
+				taskPlan.Config.Caches = []atc.TaskCacheConfig{
+					{Path: "some-path-1"},
+				}
+
+				volume1 = runtimetest.NewVolume("volume1")
+
+				chosenContainer.Mounts = []runtime.VolumeMount{
+					{
+						Volume:    volume1,
+						MountPath: "some-artifact-root/some-path-1",
+					},
+				}
+			})
+
+			Context("when defaultTaskCacheTTL is set", func() {
+				BeforeEach(func() {
+					defaultTaskCacheTTL = 24 * time.Hour
+					DeferCleanup(func() {
+						defaultTaskCacheTTL = 0
+					})
+				})
+
+				It("uses the defaultTaskCacheTTL", func() {
+					Expect(volume1.TaskCacheInitialized).To(BeTrue())
+					Expect(volume1.TaskCacheTTL).To(Equal(24 * time.Hour))
+				})
+			})
+
+			Context("when defaultTaskCacheTTL is not set", func() {
+				It("uses zero TTL", func() {
+					Expect(volume1.TaskCacheInitialized).To(BeTrue())
+					Expect(volume1.TaskCacheTTL).To(Equal(time.Duration(0)))
+				})
+			})
+		})
+
+		Context("when task config's cache TTL is set", func() {
+			var volume1 *runtimetest.Volume
+
+			BeforeEach(func() {
+				stepMetadata.JobID = 12
+
+				taskPlan.Config.Caches = []atc.TaskCacheConfig{
+					{Path: "some-path-1", TTL: "1h"},
+				}
+
+				volume1 = runtimetest.NewVolume("volume1")
+
+				chosenContainer.Mounts = []runtime.VolumeMount{
+					{
+						Volume:    volume1,
+						MountPath: "some-artifact-root/some-path-1",
+					},
+				}
+			})
+
+			Context("when defaultTaskCacheTTL is also set", func() {
+				BeforeEach(func() {
+					defaultTaskCacheTTL = 24 * time.Hour
+					DeferCleanup(func() {
+						defaultTaskCacheTTL = 0
+					})
+				})
+
+				It("uses task config's cache TTL over defaultTaskCacheTTL", func() {
+					Expect(volume1.TaskCacheInitialized).To(BeTrue())
+					Expect(volume1.TaskCacheTTL).To(Equal(1 * time.Hour))
+				})
+			})
+
+			Context("when defaultTaskCacheTTL is not set", func() {
+				It("uses cacheConfig.TTL", func() {
+					Expect(volume1.TaskCacheInitialized).To(BeTrue())
+					Expect(volume1.TaskCacheTTL).To(Equal(1 * time.Hour))
+				})
 			})
 		})
 

--- a/atc/runtime/runtimetest/volume.go
+++ b/atc/runtime/runtimetest/volume.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing/fstest"
+	"time"
 
 	"github.com/concourse/concourse/atc/compression"
 	"github.com/concourse/concourse/atc/db"
@@ -28,6 +29,7 @@ type Volume struct {
 	ResourceCacheInitialized  bool
 	ResourceCacheStreamedFrom int
 	TaskCacheInitialized      bool
+	TaskCacheTTL              time.Duration
 	DBVolume_                 *dbfakes.FakeCreatedVolume
 }
 
@@ -73,8 +75,9 @@ func (v *Volume) InitializeStreamedResourceCache(_ context.Context, _ db.Resourc
 	return nil, nil
 }
 
-func (v *Volume) InitializeTaskCache(_ context.Context, _ int, _, _ string, _ bool) error {
+func (v *Volume) InitializeTaskCache(_ context.Context, _ int, _, _ string, _ bool, ttl time.Duration) error {
 	v.TaskCacheInitialized = true
+	v.TaskCacheTTL = ttl
 	return nil
 }
 

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -327,7 +327,7 @@ type Volume interface {
 
 	// InitializeTaskCache is called upon a successful run of the task step to
 	// register this Volume as a task cache.
-	InitializeTaskCache(ctx context.Context, jobID int, stepName string, path string, privileged bool) error
+	InitializeTaskCache(ctx context.Context, jobID int, stepName string, path string, privileged bool, ttl time.Duration) error
 
 	DBVolume() db.CreatedVolume
 }

--- a/atc/task.go
+++ b/atc/task.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/yaml"
 )
@@ -194,6 +195,28 @@ type TaskOutputConfig struct {
 
 type TaskCacheConfig struct {
 	Path string `json:"path,omitempty"`
+	TTL  string `json:"ttl,omitempty"`
+}
+
+func (c *TaskCacheConfig) UnmarshalJSON(data []byte) error {
+	type alias TaskCacheConfig
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+
+	if a.TTL != "" {
+		d, err := time.ParseDuration(a.TTL)
+		if err != nil {
+			return fmt.Errorf("invalid cache ttl '%s': %w", a.TTL, err)
+		}
+		if d < time.Second {
+			return fmt.Errorf("cache ttl must be at least 1s, got '%s'", a.TTL)
+		}
+	}
+
+	*c = TaskCacheConfig(a)
+	return nil
 }
 
 type TaskEnv map[string]string

--- a/atc/task_test.go
+++ b/atc/task_test.go
@@ -172,6 +172,61 @@ run: {path: a/file}
 				})
 			})
 
+			Context("given a valid task config with cache ttl", func() {
+				It("parses a valid ttl", func() {
+					data := []byte(`
+platform: beos
+run: {path: a/file}
+caches:
+- path: some-path
+  ttl: 24h
+`)
+					task, err := NewTaskConfig(data)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(task.Caches).To(Equal([]TaskCacheConfig{
+						{Path: "some-path", TTL: "24h"},
+					}))
+				})
+
+				It("allows blank ttl", func() {
+					data := []byte(`
+platform: beos
+run: {path: a/file}
+caches:
+- path: some-path
+`)
+					task, err := NewTaskConfig(data)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(task.Caches).To(Equal([]TaskCacheConfig{
+						{Path: "some-path"},
+					}))
+				})
+
+				It("rejects ttl shorter than 1s", func() {
+					data := []byte(`
+platform: beos
+run: {path: a/file}
+caches:
+- path: some-path
+  ttl: 500ms
+`)
+					_, err := NewTaskConfig(data)
+					Expect(err).To(MatchError(ContainSubstring("cache ttl must be at least 1s")))
+				})
+
+				It("rejects an invalid ttl string", func() {
+					data := []byte(`
+platform: beos
+run: {path: a/file}
+caches:
+- path: some-path
+  ttl: notaduration
+`)
+					_, err := NewTaskConfig(data)
+					Expect(err).To(MatchError(ContainSubstring("invalid cache ttl")))
+				})
+			})
+
 			Context("given a valid task config with extra keys", func() {
 				It("returns an error", func() {
 					data := []byte(`

--- a/atc/worker/gardenruntime/volume.go
+++ b/atc/worker/gardenruntime/volume.go
@@ -77,12 +77,12 @@ func (v Volume) InitializeStreamedResourceCache(ctx context.Context, cache db.Re
 	return uwrc, nil
 }
 
-func (v Volume) InitializeTaskCache(ctx context.Context, jobID int, stepName string, path string, privileged bool) error {
+func (v Volume) InitializeTaskCache(ctx context.Context, jobID int, stepName string, path string, privileged bool, ttl time.Duration) error {
 	logger := lagerctx.FromContext(ctx)
 	path = filepath.Clean(path)
 
 	if v.dbVolume.ParentHandle() == "" {
-		return v.dbVolume.InitializeTaskCache(jobID, stepName, path)
+		return v.dbVolume.InitializeTaskCache(jobID, stepName, path, ttl)
 	}
 
 	logger.Debug("creating-an-import-volume", lager.Data{"path": v.bcVolume.Path()})
@@ -100,7 +100,7 @@ func (v Volume) InitializeTaskCache(ctx context.Context, jobID int, stepName str
 		return err
 	}
 
-	return importVolume.InitializeTaskCache(ctx, jobID, stepName, path, privileged)
+	return importVolume.InitializeTaskCache(ctx, jobID, stepName, path, privileged, ttl)
 }
 
 func (v Volume) COWStrategy() baggageclaim.COWStrategy {
@@ -331,7 +331,7 @@ func (worker *Worker) createVolumeForTaskCache(
 	path string,
 ) (Volume, error) {
 	logger := lagerctx.FromContext(ctx)
-	usedTaskCache, err := worker.db.TaskCacheFactory.FindOrCreate(jobID, stepName, path)
+	usedTaskCache, err := worker.db.TaskCacheFactory.FindOrCreate(jobID, stepName, path, 0)
 	if err != nil {
 		logger.Error("failed-to-find-or-create-task-cache-in-db", err)
 		return Volume{}, err

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -1031,11 +1031,11 @@ var _ = Describe("Garden Worker", func() {
 		)
 
 		origCacheHitVol := scenario.WorkerVolume("worker", "previous-cache-1").(gardenruntime.Volume)
-		err := origCacheHitVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "cache-hit", false)
+		err := origCacheHitVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "cache-hit", false, 0)
 		Expect(err).ToNot(HaveOccurred())
 
 		origWorkdirCacheVol := scenario.WorkerVolume("worker", "previous-cache-2").(gardenruntime.Volume)
-		err = origWorkdirCacheVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, ".", false)
+		err = origWorkdirCacheVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, ".", false, 0)
 		Expect(err).ToNot(HaveOccurred())
 
 		worker := scenario.Worker("worker")
@@ -1071,15 +1071,15 @@ var _ = Describe("Garden Worker", func() {
 		var newWorkdirVol *grt.Volume
 		By("re-initializing the cache volumes", func() {
 			cacheHitVol := volumeMount(volumeMounts, "/workdir/cache-hit").Volume.(gardenruntime.Volume)
-			err := cacheHitVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "./cache-hit", false)
+			err := cacheHitVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "./cache-hit", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			workdirVol := volumeMount(volumeMounts, "/workdir").Volume.(gardenruntime.Volume)
-			err = workdirVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, ".", false)
+			err = workdirVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, ".", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			cacheMissVol := volumeMount(volumeMounts, "/cache-miss").Volume.(gardenruntime.Volume)
-			err = cacheMissVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache-miss", false)
+			err = cacheMissVol.InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache-miss", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("validating an import volume was created only when the cache already existed", func() {

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -278,13 +278,13 @@ var _ = Describe("Container Placement Strategies", func() {
 			)
 
 			err := scenario.WorkerVolume("worker1", "cache1_worker1").
-				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache1", false)
+				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache1", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 			err = scenario.WorkerVolume("worker1", "cache2_worker1").
-				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache2", false)
+				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache2", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 			err = scenario.WorkerVolume("worker2", "cache1_worker2").
-				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache1", false)
+				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache1", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			workers, err := volumeLocalityStrategy().Order(logger, scenario.Pool, scenario.DB.Workers, runtime.ContainerSpec{
@@ -328,13 +328,13 @@ var _ = Describe("Container Placement Strategies", func() {
 			)
 
 			err := scenario.WorkerVolume("worker1", "cache1_worker1").
-				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache1", false)
+				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache1", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 			err = scenario.WorkerVolume("worker1", "cache2_worker1").
-				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache2", false)
+				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache2", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 			err = scenario.WorkerVolume("worker2", "cache1_worker2").
-				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache1", false)
+				InitializeTaskCache(ctx, scenario.JobID, scenario.StepName, "/cache1", false, 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			workers, err := volumeLocalityStrategy().Order(logger, scenario.Pool, []db.Worker{scenario.Worker("worker1").DBWorker()}, runtime.ContainerSpec{


### PR DESCRIPTION
## Changes proposed by this PR

This PR adds a `ttl` param to the `task.caches` object and a web node flag `CONCOURSE_DEFAULT_TASK_CACHE_TTL` which defaults to a value of `0s` (no expiry).

Task caches currently only expire if a pipeline or job is paused/archived/deleted. For an active pipeline/job with task caches, the caches will grow forever and never be GC'd. This can result in worker disks slowly filling up over several days or weeks unless the cache user takes deliberate steps to manage their task cache.

When upgrading to a version with this feature all existing task caches will receive a TTL of 0 (no expiry). If a default TTL is set, as task caches are used, their TTL will be updated to the default or the one configured in the task. The task-level configuration takes precedence over the web-node level setting.

Example pipeline:
```yaml
jobs:
- name: job
  plan:
  - task: cache
    config:
      platform: linux
      image_resource:
        type: mock
        source: {mirror_self: true}
      caches:
        - path: /cache/never-expires
        - path: /cache/expires
          ttl: 1m

      run:
        path: sh
        args:
        - -exc
        - |
          echo hello
```