### PR TITLE
fix resource types query returning duplicate resource types

### DIFF
--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -167,7 +167,7 @@ var resourceTypesQuery = psql.Select(
 	Join("pipelines p ON p.id = r.pipeline_id").
 	Join("teams t ON t.id = p.team_id").
 	LeftJoin("resource_configs c ON c.id = r.resource_config_id").
-	LeftJoin("resource_config_scopes ro ON ro.resource_config_id = c.id").
+	LeftJoin("resource_config_scopes ro ON ro.resource_config_id = c.id AND ro.resource_id IS NULL").
 	Where(sq.Eq{"r.active": true})
 
 type resourceType struct {

--- a/atc/db/resource_type_test.go
+++ b/atc/db/resource_type_test.go
@@ -289,6 +289,63 @@ var _ = Describe("ResourceType", func() {
 			})
 		})
 
+		Context("when a resource and resource type have the same Type and Source", func() {
+			BeforeEach(func() {
+				var (
+					created bool
+					err     error
+				)
+
+				pipeline, created, err = defaultTeam.SavePipeline(
+					atc.PipelineRef{Name: "pipeline-with-types"},
+					atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+						ResourceTypes: atc.ResourceTypes{
+							{
+								Name:   "some-type",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+					},
+					pipeline.ConfigVersion(),
+					false,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(created).To(BeFalse())
+
+				resourceType, found, err := pipeline.ResourceType("some-type")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				resource, found, err := pipeline.Resource("some-resource")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				resourceConfig, err := resourceConfigFactory.FindOrCreateResourceConfig("some-base-resource-type", atc.Source{"some": "repository"}, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				typeScope, err := resourceConfig.FindOrCreateScope(nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resourceType.SetResourceConfigScope(typeScope)).To(Succeed())
+
+				resourceScope, err := resourceConfig.FindOrCreateScope(intptr(resource.ID()))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resource.SetResourceConfigScope(resourceScope)).To(Succeed())
+			})
+
+			It("does not return duplicate resource types", func() {
+				Expect(resourceTypes).To(HaveLen(1))
+				Expect(resourceTypes[0].Name()).To(Equal("some-type"))
+			})
+		})
+
 		Context("Deserialize", func() {
 			var rts atc.ResourceTypes
 			JustBeforeEach(func() {


### PR DESCRIPTION
## Changes proposed by this PR

closes #9520

Re-submission of #9532 since it was submitted by a bot that was thwarted by EasyCLA.

I re-worded a few things in the test and verified that the test catches the bug.