### PR TITLE
Don't allow pipelines or teams containing '/' to be set with the set_pipeline step

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -98,6 +98,12 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 		return false, nil
 	}
 
+	if strings.Contains(step.plan.Team, "/") {
+		fmt.Fprintln(delegate.Stderr(), "ERROR: team name cannot contain '/'")
+		delegate.Finished(logger, false)
+		return false, nil
+	}
+
 	source := setPipelineSource{
 		ctx:      ctx,
 		logger:   logger,

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -92,6 +92,12 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 		step.plan.Team = ""
 	}
 
+	if strings.Contains(step.plan.Name, "/") {
+		fmt.Fprintln(delegate.Stderr(), "ERROR: pipeline name cannot contain '/'")
+		delegate.Finished(logger, false)
+		return false, nil
+	}
+
 	source := setPipelineSource{
 		ctx:      ctx,
 		logger:   logger,

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -614,6 +614,19 @@ jobs:
 		})
 	})
 
+	Context("when team name contains '/'", func() {
+		BeforeEach(func() {
+			spPlan.Team = "some/team"
+			fakeStreamer.StreamFileReturns(&fakeReadCloser{str: pipelineContent}, nil)
+		})
+
+		It("should fail with error", func() {
+			Expect(stderr).To(gbytes.Say("ERROR: team name cannot contain '/'"))
+			Expect(stepOk).To(BeFalse())
+			Expect(stepErr).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("when pipeline name contains '/'", func() {
 		BeforeEach(func() {
 			spPlan.Name = "some/pipeline"

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -613,6 +613,19 @@ jobs:
 			})
 		})
 	})
+
+	Context("when pipeline name contains '/'", func() {
+		BeforeEach(func() {
+			spPlan.Name = "some/pipeline"
+			fakeStreamer.StreamFileReturns(&fakeReadCloser{str: pipelineContent}, nil)
+		})
+
+		It("should fail with error invalid identifier", func() {
+			Expect(stderr).To(gbytes.Say("ERROR: pipeline name cannot contain '/'"))
+			Expect(stepOk).To(BeFalse())
+			Expect(stepErr).ToNot(HaveOccurred())
+		})
+	})
 })
 
 type fakeReadCloser struct {

--- a/fly/commands/set_team.go
+++ b/fly/commands/set_team.go
@@ -1,9 +1,11 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
@@ -32,6 +34,10 @@ type SetTeamCommand struct {
 }
 
 func (command *SetTeamCommand) Validate() ([]concourse.ConfigWarning, error) {
+	if strings.Contains(command.Team.Name(), "/") {
+		return nil, errors.New("team name cannot contain '/'")
+	}
+
 	var warnings []concourse.ConfigWarning
 	warning, err := atc.ValidateIdentifier(command.Team.Name(), "team")
 	if err != nil {

--- a/fly/integration/set_team_test.go
+++ b/fly/integration/set_team_test.go
@@ -470,6 +470,16 @@ var _ = Describe("set-team", func() {
 		})
 	})
 
+	Context("when team name contains '/'", func() {
+		It("returns an error", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "set-team", "--team-name", "some/team", "--local-user", "foo")
+			sess, err := gexec.Start(flyCmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(sess.Err).Should(gbytes.Say("team name cannot contain '/'"))
+			Eventually(sess).Should(gexec.Exit(1))
+		})
+	})
+
 	Context("using command line args", func() {
 		Describe("flag validation", func() {
 			Describe("no auth", func() {


### PR DESCRIPTION
## Changes proposed by this PR

closes #8475 

The `set_pipeline` step will now error if a pipeline name contains forward slashes `/`, which is what `fly set-pipeline` currently does.

```
ERROR: pipeline name cannot contain '/'
```

We do this same check in the `fly set-pipeline` command: https://github.com/concourse/concourse/blob/6e4c92efde567111733698ffd49660762fbbaf68/fly/commands/set_pipeline.go#L40-L42

I verified that we don't need to enforce this for resource or job names. Fly currently let's you set these and the UI does not break when resources or jobs have `/` in their name.

<img width="416" height="138" alt="image" src="https://github.com/user-attachments/assets/221af4bb-52d2-4260-803a-96cdc3bf39b2" />

### Update

`fly set-team` and the `set_pipeline` step will error on teams containing `/` as well now. Teams with this character already didn't work in the web UI. The fact we have no bug reports regarding this leads me to think that no one has tried making a team with a `/` in its name, so I don't think we're breaking anything for users.

Marking this as a breaking change though and will warn users to rename their teams before upgrading.
