### PR TITLE
log container placement strategies being used by web node

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1113,7 +1113,7 @@ func (cmd *RunCommand) backendComponents(
 		return nil, err
 	}
 
-	buildContainerStrategy, noInputBuildContainerStrategy, checkBuildContainerStrategy, err := cmd.chooseBuildContainerStrategy()
+	buildContainerStrategy, noInputBuildContainerStrategy, checkBuildContainerStrategy, err := worker.NewPlacementStrategy(logger, cmd.ContainerPlacementStrategyOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -1796,10 +1796,6 @@ func constructLockConns(driverName, connectionString string) ([lock.FactoryCount
 		conns[i] = dbConn
 	}
 	return conns, nil
-}
-
-func (cmd *RunCommand) chooseBuildContainerStrategy() (worker.PlacementStrategy, worker.PlacementStrategy, worker.PlacementStrategy, error) {
-	return worker.NewPlacementStrategy(cmd.ContainerPlacementStrategyOptions)
 }
 
 func (cmd *RunCommand) configureAuthForDefaultTeam(teamFactory db.TeamFactory) error {

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"time"
 
+	"code.cloudfoundry.org/lager/v3/lagertest"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
@@ -126,10 +127,11 @@ var _ = Describe("CheckStep", func() {
 		}
 
 		var err error
-		_, noInputStrategy, checkStrategy, err = worker.NewPlacementStrategy(worker.PlacementOptions{
-			NoInputStrategies: []string{},
-			CheckStrategies:   []string{},
-		})
+		_, noInputStrategy, checkStrategy, err = worker.NewPlacementStrategy(lagertest.NewTestLogger("atc"),
+			worker.PlacementOptions{
+				NoInputStrategies: []string{},
+				CheckStrategies:   []string{},
+			})
 		Expect(err).ToNot(HaveOccurred())
 
 		expires := db.ContainerOwnerExpiries{

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -26,7 +26,7 @@ var (
 	ErrTooManyVolumes    = errors.New("worker has too many volumes")
 )
 
-func NewPlacementStrategy(options PlacementOptions) (PlacementStrategy, PlacementStrategy, PlacementStrategy, error) {
+func NewPlacementStrategy(logger lager.Logger, options PlacementOptions) (PlacementStrategy, PlacementStrategy, PlacementStrategy, error) {
 	// If no-input-container-placement-strategy is not configured, then just use
 	// container-placement-strategy.
 	if len(options.NoInputStrategies) == 0 {
@@ -45,6 +45,12 @@ func NewPlacementStrategy(options PlacementOptions) (PlacementStrategy, Placemen
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	logger.Info("container-placement-strategies", lager.Data{
+		"build-strategies":    options.Strategies,
+		"no-input-strategies": options.NoInputStrategies,
+		"check-strategies":    options.CheckStrategies,
+	})
 
 	return strategy, noInputStrategy, checkStrategy, nil
 }

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -3,6 +3,7 @@ package worker_test
 import (
 	"slices"
 
+	"code.cloudfoundry.org/lager/v3/lagertest"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/runtime"
 	"github.com/concourse/concourse/atc/runtime/runtimetest"
@@ -17,9 +18,10 @@ import (
 var _ = Describe("Container Placement Strategies", func() {
 	Describe("Volume Locality", func() {
 		volumeLocalityStrategy := func() worker.PlacementStrategy {
-			strategy, _, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
-				Strategies: []string{"volume-locality"},
-			})
+			strategy, _, _, err := worker.NewPlacementStrategy(lagertest.NewTestLogger("atc"),
+				worker.PlacementOptions{
+					Strategies: []string{"volume-locality"},
+				})
 			Expect(err).ToNot(HaveOccurred())
 			return strategy
 		}
@@ -498,9 +500,10 @@ var _ = Describe("Container Placement Strategies", func() {
 
 	Describe("Fewest Build Containers", func() {
 		fewestBuildContainersStrategy := func() worker.PlacementStrategy {
-			strategy, _, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
-				Strategies: []string{"fewest-build-containers"},
-			})
+			strategy, _, _, err := worker.NewPlacementStrategy(lagertest.NewTestLogger("atc"),
+				worker.PlacementOptions{
+					Strategies: []string{"fewest-build-containers"},
+				})
 			Expect(err).ToNot(HaveOccurred())
 			return strategy
 		}
@@ -534,10 +537,11 @@ var _ = Describe("Container Placement Strategies", func() {
 
 	Describe("Limit Active Tasks", func() {
 		limitActiveTasksStrategy := func(max int) worker.PlacementStrategy {
-			strategy, _, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
-				Strategies:              []string{"limit-active-tasks"},
-				MaxActiveTasksPerWorker: max,
-			})
+			strategy, _, _, err := worker.NewPlacementStrategy(lagertest.NewTestLogger("atc"),
+				worker.PlacementOptions{
+					Strategies:              []string{"limit-active-tasks"},
+					MaxActiveTasksPerWorker: max,
+				})
 			Expect(err).ToNot(HaveOccurred())
 			return strategy
 		}
@@ -611,10 +615,11 @@ var _ = Describe("Container Placement Strategies", func() {
 
 	Describe("Limit Active Containers", func() {
 		limitActiveContainersStrategy := func(max int) worker.PlacementStrategy {
-			strategy, _, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
-				Strategies:                   []string{"limit-active-containers"},
-				MaxActiveContainersPerWorker: max,
-			})
+			strategy, _, _, err := worker.NewPlacementStrategy(lagertest.NewTestLogger("atc"),
+				worker.PlacementOptions{
+					Strategies:                   []string{"limit-active-containers"},
+					MaxActiveContainersPerWorker: max,
+				})
 			Expect(err).ToNot(HaveOccurred())
 			return strategy
 		}
@@ -699,10 +704,11 @@ var _ = Describe("Container Placement Strategies", func() {
 
 	Describe("Limit Active Volumes", func() {
 		limitActiveVolumesStrategy := func(max int) worker.PlacementStrategy {
-			strategy, _, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
-				Strategies:                []string{"limit-active-volumes"},
-				MaxActiveVolumesPerWorker: max,
-			})
+			strategy, _, _, err := worker.NewPlacementStrategy(lagertest.NewTestLogger("atc"),
+				worker.PlacementOptions{
+					Strategies:                []string{"limit-active-volumes"},
+					MaxActiveVolumesPerWorker: max,
+				})
 			Expect(err).ToNot(HaveOccurred())
 			return strategy
 		}

--- a/atc/worker/pool_test.go
+++ b/atc/worker/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/runtime"
@@ -79,9 +80,10 @@ var _ = Describe("Pool", func() {
 				),
 			)
 
-			strategy, _, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
-				Strategies: []string{"fewest-build-containers"},
-			})
+			strategy, _, _, err := worker.NewPlacementStrategy(lagertest.NewTestLogger("atc"),
+				worker.PlacementOptions{
+					Strategies: []string{"fewest-build-containers"},
+				})
 			Expect(err).ToNot(HaveOccurred())
 
 			worker, err := scenario.Pool.FindOrSelectWorker(
@@ -280,10 +282,11 @@ var _ = Describe("Pool", func() {
 				),
 			)
 
-			strategy, _, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
-				Strategies:              []string{"limit-active-tasks"},
-				MaxActiveTasksPerWorker: 1,
-			})
+			strategy, _, _, err := worker.NewPlacementStrategy(lagertest.NewTestLogger("atc"),
+				worker.PlacementOptions{
+					Strategies:              []string{"limit-active-tasks"},
+					MaxActiveTasksPerWorker: 1,
+				})
 			Expect(err).ToNot(HaveOccurred())
 
 			taskSpec := runtime.ContainerSpec{Type: db.ContainerTypeTask}


### PR DESCRIPTION
## Changes proposed by this PR

closes #8836 

Web nodes will print an `info` log listing the passed in container placement strategies. The log will look like this:

```json
{
  "timestamp": "2026-04-18T18:03:40.553877219Z",
  "level": "info",
  "source": "atc",
  "message": "atc.container-placement-strategies",
  "data": {
    "build-strategies": [
      "limit-active-containers",
      "fewest-build-containers"
    ],
    "check-strategies": [
      "limit-active-containers",
      "fewest-build-containers"
    ],
    "no-input-strategies": [
      "limit-active-containers",
      "fewest-build-containers"
    ]
  }
}
```