### PR TITLE
atc: add base64 and hex encryption key flags

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -150,7 +150,7 @@ type RunCommand struct {
 	EncryptionKey          flag.Cipher       `long:"encryption-key"            description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
 	EncryptionKeyBase64    flag.CipherBase64 `long:"encryption-key-base64"     description:"A base64-encoded 16 or 32 byte key used to encrypt sensitive information before storing it in the database."`
 	EncryptionKeyHex       flag.CipherHex    `long:"encryption-key-hex"        description:"A hex-encoded 16 or 32 byte key used to encrypt sensitive information before storing it in the database."`
-	OldEncryptionKey       flag.Cipher       `long:"old-encryption-key"        description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is encrypted. If provided with a new key, data is re-encrypted."`
+	OldEncryptionKey       flag.Cipher       `long:"old-encryption-key"        description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
 	OldEncryptionKeyBase64 flag.CipherBase64 `long:"old-encryption-key-base64" description:"Base64-encoded encryption key previously used. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
 	OldEncryptionKeyHex    flag.CipherHex    `long:"old-encryption-key-hex"    description:"Hex-encoded encryption key previously used. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
 
@@ -385,8 +385,14 @@ func (cmd *Migration) supportedDBVersion() error {
 func (cmd *Migration) migrateDBToVersion() error {
 	version := cmd.MigrateDBToVersion
 
-	newKey := cmd.resolveNewKey()
-	oldKey := cmd.resolveOldKey()
+	newKey, err := cmd.newKey()
+	if err != nil {
+		return err
+	}
+	oldKey, err := cmd.oldKey()
+	if err != nil {
+		return err
+	}
 
 	helper := migration.NewOpenHelper(
 		defaultDriverName,
@@ -396,7 +402,7 @@ func (cmd *Migration) migrateDBToVersion() error {
 		oldKey,
 	)
 
-	err := helper.MigrateToVersion(version)
+	err = helper.MigrateToVersion(version)
 	if err != nil {
 		return fmt.Errorf("could not migrate to version: %d Reason: %s", version, err.Error())
 	}
@@ -406,8 +412,14 @@ func (cmd *Migration) migrateDBToVersion() error {
 }
 
 func (cmd *Migration) rotateEncryptionKey() error {
-	newKey := cmd.resolveNewKey()
-	oldKey := cmd.resolveOldKey()
+	newKey, err := cmd.newKey()
+	if err != nil {
+		return err
+	}
+	oldKey, err := cmd.oldKey()
+	if err != nil {
+		return err
+	}
 
 	helper := migration.NewOpenHelper(
 		defaultDriverName,
@@ -425,32 +437,12 @@ func (cmd *Migration) rotateEncryptionKey() error {
 	return helper.MigrateToVersion(version)
 }
 
-func (cmd *Migration) resolveNewKey() *encryption.Key {
-	aead := cmd.EncryptionKey.AEAD
-	if aead == nil {
-		aead = cmd.EncryptionKeyBase64.AEAD
-	}
-	if aead == nil {
-		aead = cmd.EncryptionKeyHex.AEAD
-	}
-	if aead != nil {
-		return encryption.NewKey(aead)
-	}
-	return nil
+func (cmd *Migration) newKey() (*encryption.Key, error) {
+	return encryption.ResolveKey(cmd.EncryptionKey.AEAD, cmd.EncryptionKeyBase64.AEAD, cmd.EncryptionKeyHex.AEAD)
 }
 
-func (cmd *Migration) resolveOldKey() *encryption.Key {
-	aead := cmd.OldEncryptionKey.AEAD
-	if aead == nil {
-		aead = cmd.OldEncryptionKeyBase64.AEAD
-	}
-	if aead == nil {
-		aead = cmd.OldEncryptionKeyHex.AEAD
-	}
-	if aead != nil {
-		return encryption.NewKey(aead)
-	}
-	return nil
+func (cmd *Migration) oldKey() (*encryption.Key, error) {
+	return encryption.ResolveKey(cmd.OldEncryptionKey.AEAD, cmd.OldEncryptionKeyBase64.AEAD, cmd.OldEncryptionKeyHex.AEAD)
 }
 
 func (cmd *Migration) migrateToLatestVersion() error {
@@ -1526,34 +1518,12 @@ func (cmd *RunCommand) secretManager(logger lager.Logger) (creds.Secrets, error)
 	return cmd.CredentialManagement.NewSecrets(secretsFactory), nil
 }
 
-func (cmd *RunCommand) newKey() *encryption.Key {
-	var newKey *encryption.Key
-	aead := cmd.EncryptionKey.AEAD
-	if aead == nil {
-		aead = cmd.EncryptionKeyBase64.AEAD
-	}
-	if aead == nil {
-		aead = cmd.EncryptionKeyHex.AEAD
-	}
-	if aead != nil {
-		newKey = encryption.NewKey(aead)
-	}
-	return newKey
+func (cmd *RunCommand) newKey() (*encryption.Key, error) {
+	return encryption.ResolveKey(cmd.EncryptionKey.AEAD, cmd.EncryptionKeyBase64.AEAD, cmd.EncryptionKeyHex.AEAD)
 }
 
-func (cmd *RunCommand) oldKey() *encryption.Key {
-	var oldKey *encryption.Key
-	aead := cmd.OldEncryptionKey.AEAD
-	if aead == nil {
-		aead = cmd.OldEncryptionKeyBase64.AEAD
-	}
-	if aead == nil {
-		aead = cmd.OldEncryptionKeyHex.AEAD
-	}
-	if aead != nil {
-		oldKey = encryption.NewKey(aead)
-	}
-	return oldKey
+func (cmd *RunCommand) oldKey() (*encryption.Key, error) {
+	return encryption.ResolveKey(cmd.OldEncryptionKey.AEAD, cmd.OldEncryptionKeyBase64.AEAD, cmd.OldEncryptionKeyHex.AEAD)
 }
 
 func (cmd *RunCommand) constructWebHandler(logger lager.Logger) (http.Handler, error) {
@@ -1801,7 +1771,16 @@ func (cmd *RunCommand) constructDBConn(
 	connectionName string,
 	lockFactory lock.LockFactory,
 ) (db.DbConn, error) {
-	dbConn, err := db.Open(logger.Session("db"), driverName, cmd.Postgres.ConnectionString(), cmd.newKey(), cmd.oldKey(), connectionName, lockFactory)
+	newKey, err := cmd.newKey()
+	if err != nil {
+		return nil, err
+	}
+	oldKey, err := cmd.oldKey()
+	if err != nil {
+		return nil, err
+	}
+
+	dbConn, err := db.Open(logger.Session("db"), driverName, cmd.Postgres.ConnectionString(), newKey, oldKey, connectionName, lockFactory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %s", err)
 	}

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -147,8 +147,12 @@ type RunCommand struct {
 		GracePeriod    time.Duration `long:"grace-period" default:"24h" description:"How long a key should still be published for the idtoken secrets provider after a new key has been generated"`
 	} `group:"Pipeline Identity Tokens" namespace:"signing-key"`
 
-	EncryptionKey    flag.Cipher `long:"encryption-key"     description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
-	OldEncryptionKey flag.Cipher `long:"old-encryption-key" description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is encrypted. If provided with a new key, data is re-encrypted."`
+	EncryptionKey          flag.Cipher       `long:"encryption-key"            description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
+	EncryptionKeyBase64    flag.CipherBase64 `long:"encryption-key-base64"     description:"A base64-encoded 16 or 32 byte key used to encrypt sensitive information before storing it in the database."`
+	EncryptionKeyHex       flag.CipherHex    `long:"encryption-key-hex"        description:"A hex-encoded 16 or 32 byte key used to encrypt sensitive information before storing it in the database."`
+	OldEncryptionKey       flag.Cipher       `long:"old-encryption-key"        description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is encrypted. If provided with a new key, data is re-encrypted."`
+	OldEncryptionKeyBase64 flag.CipherBase64 `long:"old-encryption-key-base64" description:"Base64-encoded encryption key previously used. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
+	OldEncryptionKeyHex    flag.CipherHex    `long:"old-encryption-key-hex"    description:"Hex-encoded encryption key previously used. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
 
 	DebugBindIP   flag.IP `long:"debug-bind-ip"   default:"127.0.0.1" description:"IP address on which to listen for the pprof debugger endpoints."`
 	DebugBindPort uint16  `long:"debug-bind-port" default:"8079"      description:"Port on which to listen for the pprof debugger endpoints."`
@@ -293,8 +297,12 @@ type Migration struct {
 	lockFactory lock.LockFactory
 
 	Postgres               flag.PostgresConfig `group:"PostgreSQL Configuration" namespace:"postgres"`
-	EncryptionKey          flag.Cipher         `long:"encryption-key"     description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
-	OldEncryptionKey       flag.Cipher         `long:"old-encryption-key" description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
+	EncryptionKey          flag.Cipher         `long:"encryption-key"            description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
+	EncryptionKeyBase64    flag.CipherBase64   `long:"encryption-key-base64"     description:"A base64-encoded 16 or 32 byte key used to encrypt sensitive information before storing it in the database."`
+	EncryptionKeyHex       flag.CipherHex      `long:"encryption-key-hex"        description:"A hex-encoded 16 or 32 byte key used to encrypt sensitive information before storing it in the database."`
+	OldEncryptionKey       flag.Cipher         `long:"old-encryption-key"        description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
+	OldEncryptionKeyBase64 flag.CipherBase64   `long:"old-encryption-key-base64" description:"Base64-encoded encryption key previously used. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
+	OldEncryptionKeyHex    flag.CipherHex      `long:"old-encryption-key-hex"    description:"Hex-encoded encryption key previously used. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
 	CurrentDBVersion       bool                `long:"current-db-version" description:"Print the current database version and exit"`
 	SupportedDBVersion     bool                `long:"supported-db-version" description:"Print the max supported database version and exit"`
 	MigrateDBToVersion     int                 `long:"migrate-db-to-version" description:"Migrate to the specified database version and exit"`
@@ -377,15 +385,8 @@ func (cmd *Migration) supportedDBVersion() error {
 func (cmd *Migration) migrateDBToVersion() error {
 	version := cmd.MigrateDBToVersion
 
-	var newKey *encryption.Key
-	var oldKey *encryption.Key
-
-	if cmd.EncryptionKey.AEAD != nil {
-		newKey = encryption.NewKey(cmd.EncryptionKey.AEAD)
-	}
-	if cmd.OldEncryptionKey.AEAD != nil {
-		oldKey = encryption.NewKey(cmd.OldEncryptionKey.AEAD)
-	}
+	newKey := cmd.resolveNewKey()
+	oldKey := cmd.resolveOldKey()
 
 	helper := migration.NewOpenHelper(
 		defaultDriverName,
@@ -405,15 +406,8 @@ func (cmd *Migration) migrateDBToVersion() error {
 }
 
 func (cmd *Migration) rotateEncryptionKey() error {
-	var newKey *encryption.Key
-	var oldKey *encryption.Key
-
-	if cmd.EncryptionKey.AEAD != nil {
-		newKey = encryption.NewKey(cmd.EncryptionKey.AEAD)
-	}
-	if cmd.OldEncryptionKey.AEAD != nil {
-		oldKey = encryption.NewKey(cmd.OldEncryptionKey.AEAD)
-	}
+	newKey := cmd.resolveNewKey()
+	oldKey := cmd.resolveOldKey()
 
 	helper := migration.NewOpenHelper(
 		defaultDriverName,
@@ -429,6 +423,34 @@ func (cmd *Migration) rotateEncryptionKey() error {
 	}
 
 	return helper.MigrateToVersion(version)
+}
+
+func (cmd *Migration) resolveNewKey() *encryption.Key {
+	aead := cmd.EncryptionKey.AEAD
+	if aead == nil {
+		aead = cmd.EncryptionKeyBase64.AEAD
+	}
+	if aead == nil {
+		aead = cmd.EncryptionKeyHex.AEAD
+	}
+	if aead != nil {
+		return encryption.NewKey(aead)
+	}
+	return nil
+}
+
+func (cmd *Migration) resolveOldKey() *encryption.Key {
+	aead := cmd.OldEncryptionKey.AEAD
+	if aead == nil {
+		aead = cmd.OldEncryptionKeyBase64.AEAD
+	}
+	if aead == nil {
+		aead = cmd.OldEncryptionKeyHex.AEAD
+	}
+	if aead != nil {
+		return encryption.NewKey(aead)
+	}
+	return nil
 }
 
 func (cmd *Migration) migrateToLatestVersion() error {
@@ -1506,16 +1528,30 @@ func (cmd *RunCommand) secretManager(logger lager.Logger) (creds.Secrets, error)
 
 func (cmd *RunCommand) newKey() *encryption.Key {
 	var newKey *encryption.Key
-	if cmd.EncryptionKey.AEAD != nil {
-		newKey = encryption.NewKey(cmd.EncryptionKey.AEAD)
+	aead := cmd.EncryptionKey.AEAD
+	if aead == nil {
+		aead = cmd.EncryptionKeyBase64.AEAD
+	}
+	if aead == nil {
+		aead = cmd.EncryptionKeyHex.AEAD
+	}
+	if aead != nil {
+		newKey = encryption.NewKey(aead)
 	}
 	return newKey
 }
 
 func (cmd *RunCommand) oldKey() *encryption.Key {
 	var oldKey *encryption.Key
-	if cmd.OldEncryptionKey.AEAD != nil {
-		oldKey = encryption.NewKey(cmd.OldEncryptionKey.AEAD)
+	aead := cmd.OldEncryptionKey.AEAD
+	if aead == nil {
+		aead = cmd.OldEncryptionKeyBase64.AEAD
+	}
+	if aead == nil {
+		aead = cmd.OldEncryptionKeyHex.AEAD
+	}
+	if aead != nil {
+		oldKey = encryption.NewKey(aead)
 	}
 	return oldKey
 }

--- a/atc/db/encryption/encryption_key.go
+++ b/atc/db/encryption/encryption_key.go
@@ -4,6 +4,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"io"
 )
 
@@ -15,6 +16,24 @@ func NewKey(a cipher.AEAD) *Key {
 	return &Key{
 		aesgcm: a,
 	}
+}
+
+// ResolveKey returns an encryption key from the first non-nil AEAD provided,
+// or nil if all are nil. It returns an error if more than one AEAD is non-nil.
+func ResolveKey(aeads ...cipher.AEAD) (*Key, error) {
+	var result cipher.AEAD
+	for _, a := range aeads {
+		if a != nil {
+			if result != nil {
+				return nil, errors.New("only one encryption key format may be specified")
+			}
+			result = a
+		}
+	}
+	if result != nil {
+		return NewKey(result), nil
+	}
+	return nil, nil
 }
 
 func (e Key) Encrypt(plaintext []byte) (string, *string, error) {

--- a/atc/db/encryption/encryption_key_test.go
+++ b/atc/db/encryption/encryption_key_test.go
@@ -83,3 +83,45 @@ var _ = Describe("Encryption Key", func() {
 		})
 	})
 })
+
+var _ = Describe("ResolveKey", func() {
+	var aesgcm cipher.AEAD
+
+	BeforeEach(func() {
+		block, err := aes.NewCipher([]byte("AES256Key-32Characters1234567890"))
+		Expect(err).ToNot(HaveOccurred())
+
+		aesgcm, err = cipher.NewGCM(block)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("returns nil when no arguments are provided", func() {
+		key, err := encryption.ResolveKey()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(key).To(BeNil())
+	})
+
+	It("returns nil when all arguments are nil", func() {
+		key, err := encryption.ResolveKey(nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(key).To(BeNil())
+	})
+
+	It("returns a key when exactly one argument is non-nil", func() {
+		key, err := encryption.ResolveKey(nil, aesgcm, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(key).ToNot(BeNil())
+	})
+
+	It("returns an error when multiple arguments are non-nil", func() {
+		block2, err := aes.NewCipher([]byte("AES256Key-32Characters9564567123"))
+		Expect(err).ToNot(HaveOccurred())
+
+		aesgcm2, err := cipher.NewGCM(block2)
+		Expect(err).ToNot(HaveOccurred())
+
+		key, err := encryption.ResolveKey(aesgcm, aesgcm2)
+		Expect(err).To(MatchError("only one encryption key format may be specified"))
+		Expect(key).To(BeNil())
+	})
+})

--- a/atc/scripts/db_decrypt.go
+++ b/atc/scripts/db_decrypt.go
@@ -9,9 +9,11 @@ import (
 )
 
 type ConcryptCommand struct {
-	Key        flag.Cipher `long:"encryption-key"     description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
-	Ciphertext string      `long:"ciphertext"         description:"the ciphertext to decrypt."`
-	Nonce      string      `long:"nonce"              description:"Nonce for decryption."`
+	Key        flag.Cipher       `long:"encryption-key"            description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
+	KeyBase64  flag.CipherBase64 `long:"encryption-key-base64"     description:"A base64-encoded 16 or 32 byte key used to encrypt sensitive information before storing it in the database."`
+	KeyHex     flag.CipherHex    `long:"encryption-key-hex"        description:"A hex-encoded 16 or 32 byte key used to encrypt sensitive information before storing it in the database."`
+	Ciphertext string            `long:"ciphertext"                description:"the ciphertext to decrypt."`
+	Nonce      string            `long:"nonce"                     description:"Nonce for decryption."`
 }
 
 func main() {
@@ -20,7 +22,19 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	plaintext, err := encryption.NewKey(command.Key.AEAD).Decrypt(command.Ciphertext, &command.Nonce)
+
+	aead := command.Key.AEAD
+	if aead == nil {
+		aead = command.KeyBase64.AEAD
+	}
+	if aead == nil {
+		aead = command.KeyHex.AEAD
+	}
+	if aead == nil {
+		panic("one of --encryption-key, --encryption-key-base64, or --encryption-key-hex must be provided")
+	}
+
+	plaintext, err := encryption.NewKey(aead).Decrypt(command.Ciphertext, &command.Nonce)
 	if err != nil {
 		panic(err)
 	}

--- a/atc/scripts/db_decrypt.go
+++ b/atc/scripts/db_decrypt.go
@@ -23,18 +23,15 @@ func main() {
 		panic(err)
 	}
 
-	aead := command.Key.AEAD
-	if aead == nil {
-		aead = command.KeyBase64.AEAD
+	key, err := encryption.ResolveKey(command.Key.AEAD, command.KeyBase64.AEAD, command.KeyHex.AEAD)
+	if err != nil {
+		panic(err)
 	}
-	if aead == nil {
-		aead = command.KeyHex.AEAD
-	}
-	if aead == nil {
+	if key == nil {
 		panic("one of --encryption-key, --encryption-key-base64, or --encryption-key-hex must be provided")
 	}
 
-	plaintext, err := encryption.NewKey(aead).Decrypt(command.Ciphertext, &command.Nonce)
+	plaintext, err := key.Decrypt(command.Ciphertext, &command.Nonce)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Changes proposed by this PR

closes #1410

- [x] Added `--encryption-key-base64` and `--encryption-key-hex` flags to `RunCommand` struct
- [x] Added `--old-encryption-key-base64` and `--old-encryption-key-hex` flags to `RunCommand` struct
- [x] Added the same flags to `Migration` struct
- [x] Updated `RunCommand.newKey()` and `RunCommand.oldKey()` to resolve keys from all three formats (raw → base64 → hex)
- [x] Added `Migration.resolveNewKey()` and `Migration.resolveOldKey()` helper functions
- [x] Updated `atc/scripts/db_decrypt.go` to support the new key formats

**Reasoning:** The existing `--encryption-key` flag interprets the key as raw bytes (`[]byte(val)`), limiting entropy to ~95 printable ASCII characters per byte. A nominally 256-bit key only provides ~208 bits of entropy. The new flags allow users to supply keys encoded in base64 or hex, enabling the full byte range (0x00-0xFF) and full 256-bit entropy.

The `CipherBase64` and `CipherHex` types used by these flags were already merged into `flag/cipher.go` via #9541.

## Notes to reviewer

- Backward compatible: the existing `--encryption-key` and `--old-encryption-key` flags are unchanged
- Key resolution priority: raw → base64 → hex (first non-nil wins)
- Only one format should be provided at a time; if multiple are set, ~the priority order above applies~ an error is returned
- Validated locally via `docker compose up --build` — new flags appear in `concourse web --help`

## Release Note

Added `--encryption-key-base64`, `--encryption-key-hex`, `--old-encryption-key-base64`, and `--old-encryption-key-hex` flags, allowing encryption keys to be provided in base64 or hex encoding for full 256-bit entropy support.
