### PR TITLE
Enable operators to pause/unpause web components

### DIFF
--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -65,6 +65,7 @@ var (
 	dbCheckFactory          *dbfakes.FakeCheckFactory
 	dbTeam                  *dbfakes.FakeTeam
 	dbWall                  *dbfakes.FakeWall
+	dbComponentFactory      *dbfakes.FakeComponentFactory
 	fakeSecretManager       *credsfakes.FakeSecrets
 	fakeVarSourcePool       *credsfakes.FakeVarSourcePool
 	fakePolicyChecker       *policycheckerfakes.FakePolicyChecker
@@ -114,6 +115,7 @@ var _ = BeforeEach(func() {
 	dbUserFactory = new(dbfakes.FakeUserFactory)
 	dbCheckFactory = new(dbfakes.FakeCheckFactory)
 	dbWall = new(dbfakes.FakeWall)
+	dbComponentFactory = new(dbfakes.FakeComponentFactory)
 	dbSigningKeyFactory = new(dbfakes.FakeSigningKeyFactory)
 
 	interceptTimeoutFactory = new(containerserverfakes.FakeInterceptTimeoutFactory)
@@ -206,6 +208,7 @@ var _ = BeforeEach(func() {
 		dbCheckFactory,
 		dbResourceConfigFactory,
 		dbUserFactory,
+		dbComponentFactory,
 
 		constructedEventHandler.Construct,
 

--- a/atc/api/components_test.go
+++ b/atc/api/components_test.go
@@ -1,0 +1,434 @@
+package api_test
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbfakes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Components API", func() {
+	var response *http.Response
+
+	Describe("GET /api/v1/components", func() {
+		JustBeforeEach(func() {
+			req, err := http.NewRequest("GET", server.URL+"/api/v1/components", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when not authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(false)
+			})
+
+			It("returns 401", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+		})
+
+		Context("when authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+			})
+
+			Context("and is not admin", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(false)
+				})
+
+				It("returns 403", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+				})
+			})
+
+			Context("and is admin", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(true)
+				})
+
+				Context("when getting all components succeeds", func() {
+					var fakeComponent *dbfakes.FakeComponent
+
+					BeforeEach(func() {
+						fakeComponent = new(dbfakes.FakeComponent)
+						fakeComponent.NameReturns("scheduler")
+						fakeComponent.IntervalReturns(10 * time.Second)
+						fakeComponent.LastRanReturns(time.Now())
+						fakeComponent.PausedReturns(false)
+
+						dbComponentFactory.AllReturns([]db.Component{fakeComponent}, nil)
+					})
+
+					It("returns 200", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
+					})
+
+					It("returns the components as JSON", func() {
+						body, err := io.ReadAll(response.Body)
+						Expect(err).NotTo(HaveOccurred())
+
+						var components []atc.Component
+						err = json.Unmarshal(body, &components)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(components).To(HaveLen(1))
+						Expect(components[0].Name).To(Equal("scheduler"))
+						Expect(components[0].Interval).To(Equal(10 * time.Second))
+						Expect(components[0].Paused).To(BeFalse())
+					})
+				})
+
+				Context("when getting all components fails", func() {
+					BeforeEach(func() {
+						dbComponentFactory.AllReturns(nil, errors.New("disaster"))
+					})
+
+					It("returns 500", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+				})
+			})
+		})
+	})
+
+	Describe("PUT /api/v1/components/pause", func() {
+		JustBeforeEach(func() {
+			req, err := http.NewRequest("PUT", server.URL+"/api/v1/components/pause", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when not authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(false)
+			})
+
+			It("returns 401", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+		})
+
+		Context("when authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+			})
+
+			Context("and is not admin", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(false)
+				})
+
+				It("returns 403", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+				})
+			})
+
+			Context("and is admin", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(true)
+				})
+
+				Context("when pausing all succeeds", func() {
+					BeforeEach(func() {
+						dbComponentFactory.PauseAllReturns(nil)
+					})
+
+					It("returns 200", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
+					})
+
+					It("calls PauseAll", func() {
+						Expect(dbComponentFactory.PauseAllCallCount()).To(Equal(1))
+					})
+				})
+
+				Context("when pausing all fails", func() {
+					BeforeEach(func() {
+						dbComponentFactory.PauseAllReturns(errors.New("disaster"))
+					})
+
+					It("returns 500", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+				})
+			})
+		})
+	})
+
+	Describe("PUT /api/v1/components/unpause", func() {
+		JustBeforeEach(func() {
+			req, err := http.NewRequest("PUT", server.URL+"/api/v1/components/unpause", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when not authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(false)
+			})
+
+			It("returns 401", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+		})
+
+		Context("when authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+			})
+
+			Context("and is not admin", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(false)
+				})
+
+				It("returns 403", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+				})
+			})
+
+			Context("and is admin", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(true)
+				})
+
+				Context("when unpausing all succeeds", func() {
+					BeforeEach(func() {
+						dbComponentFactory.UnpauseAllReturns(nil)
+					})
+
+					It("returns 200", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
+					})
+
+					It("calls UnpauseAll", func() {
+						Expect(dbComponentFactory.UnpauseAllCallCount()).To(Equal(1))
+					})
+				})
+
+				Context("when unpausing all fails", func() {
+					BeforeEach(func() {
+						dbComponentFactory.UnpauseAllReturns(errors.New("disaster"))
+					})
+
+					It("returns 500", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+				})
+			})
+		})
+	})
+
+	Describe("PUT /api/v1/components/:component_name/pause", func() {
+		JustBeforeEach(func() {
+			req, err := http.NewRequest("PUT", server.URL+"/api/v1/components/some-component/pause", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when not authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(false)
+			})
+
+			It("returns 401", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+		})
+
+		Context("when authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+			})
+
+			Context("and is not admin", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(false)
+				})
+
+				It("returns 403", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+				})
+			})
+
+			Context("and is admin", func() {
+				var fakeComponent *dbfakes.FakeComponent
+
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(true)
+				})
+
+				Context("when the component is found", func() {
+					BeforeEach(func() {
+						fakeComponent = new(dbfakes.FakeComponent)
+						dbComponentFactory.FindReturns(fakeComponent, true, nil)
+					})
+
+					Context("and pausing succeeds", func() {
+						BeforeEach(func() {
+							fakeComponent.PauseReturns(nil)
+						})
+
+						It("returns 200", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusOK))
+						})
+
+						It("finds the component by name", func() {
+							Expect(dbComponentFactory.FindArgsForCall(0)).To(Equal("some-component"))
+						})
+
+						It("calls Pause", func() {
+							Expect(fakeComponent.PauseCallCount()).To(Equal(1))
+						})
+					})
+
+					Context("and pausing fails", func() {
+						BeforeEach(func() {
+							fakeComponent.PauseReturns(errors.New("disaster"))
+						})
+
+						It("returns 500", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+						})
+					})
+				})
+
+				Context("when the component is not found", func() {
+					BeforeEach(func() {
+						dbComponentFactory.FindReturns(nil, false, nil)
+					})
+
+					It("returns 404", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+					})
+				})
+
+				Context("when finding the component fails", func() {
+					BeforeEach(func() {
+						dbComponentFactory.FindReturns(nil, false, errors.New("disaster"))
+					})
+
+					It("returns 500", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+				})
+			})
+		})
+	})
+
+	Describe("PUT /api/v1/components/:component_name/unpause", func() {
+		JustBeforeEach(func() {
+			req, err := http.NewRequest("PUT", server.URL+"/api/v1/components/some-component/unpause", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when not authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(false)
+			})
+
+			It("returns 401", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+		})
+
+		Context("when authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+			})
+
+			Context("and is not admin", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(false)
+				})
+
+				It("returns 403", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+				})
+			})
+
+			Context("and is admin", func() {
+				var fakeComponent *dbfakes.FakeComponent
+
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(true)
+				})
+
+				Context("when the component is found", func() {
+					BeforeEach(func() {
+						fakeComponent = new(dbfakes.FakeComponent)
+						dbComponentFactory.FindReturns(fakeComponent, true, nil)
+					})
+
+					Context("and unpausing succeeds", func() {
+						BeforeEach(func() {
+							fakeComponent.UnpauseReturns(nil)
+						})
+
+						It("returns 200", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusOK))
+						})
+
+						It("finds the component by name", func() {
+							Expect(dbComponentFactory.FindArgsForCall(0)).To(Equal("some-component"))
+						})
+
+						It("calls Unpause", func() {
+							Expect(fakeComponent.UnpauseCallCount()).To(Equal(1))
+						})
+					})
+
+					Context("and unpausing fails", func() {
+						BeforeEach(func() {
+							fakeComponent.UnpauseReturns(errors.New("disaster"))
+						})
+
+						It("returns 500", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+						})
+					})
+				})
+
+				Context("when the component is not found", func() {
+					BeforeEach(func() {
+						dbComponentFactory.FindReturns(nil, false, nil)
+					})
+
+					It("returns 404", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+					})
+				})
+
+				Context("when finding the component fails", func() {
+					BeforeEach(func() {
+						dbComponentFactory.FindReturns(nil, false, errors.New("disaster"))
+					})
+
+					It("returns 500", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+				})
+			})
+		})
+	})
+})

--- a/atc/api/componentsserver/component.go
+++ b/atc/api/componentsserver/component.go
@@ -1,0 +1,55 @@
+package componentsserver
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/lager/v3"
+)
+
+func (s *Server) Pause(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get(":component_name")
+	logger := s.logger.Session("pause-component", lager.Data{"name": name})
+
+	c, found, err := s.componentFactory.Find(name)
+	if err != nil {
+		logger.Error("failed-to-find", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	err = c.Pause()
+	if err != nil {
+		logger.Error("failed-to-pause", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *Server) Unpause(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get(":component_name")
+	logger := s.logger.Session("unpause-component", lager.Data{"name": name})
+
+	c, found, err := s.componentFactory.Find(name)
+	if err != nil {
+		logger.Error("failed-to-find", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	err = c.Unpause()
+	if err != nil {
+		logger.Error("failed-to-unpause", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}

--- a/atc/api/componentsserver/components.go
+++ b/atc/api/componentsserver/components.go
@@ -1,0 +1,52 @@
+package componentsserver
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/api/present"
+)
+
+func (s *Server) GetComponents(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.Session("get-components")
+	comps, err := s.componentFactory.All()
+	if err != nil {
+		logger.Error("failed-to-get-all", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	atcComponents := make([]atc.Component, len(comps))
+	for i, c := range comps {
+		atcComponents[i] = present.Component(c)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(atcComponents)
+	if err != nil {
+		logger.Error("failed-to-encode-components", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *Server) PauseAll(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.Session("pause-all-components")
+	err := s.componentFactory.PauseAll()
+	if err != nil {
+		logger.Error("error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *Server) UnpauseAll(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.Session("unpause-all-components")
+	err := s.componentFactory.UnpauseAll()
+	if err != nil {
+		logger.Error("error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}

--- a/atc/api/componentsserver/server.go
+++ b/atc/api/componentsserver/server.go
@@ -1,0 +1,21 @@
+package componentsserver
+
+import (
+	"code.cloudfoundry.org/lager/v3"
+	"github.com/concourse/concourse/atc/db"
+)
+
+type Server struct {
+	logger           lager.Logger
+	componentFactory db.ComponentFactory
+}
+
+func NewServer(
+	logger lager.Logger,
+	comp db.ComponentFactory,
+) *Server {
+	return &Server{
+		logger:           logger,
+		componentFactory: comp,
+	}
+}

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/concourse/concourse/atc/api/artifactserver"
 	"github.com/concourse/concourse/atc/api/buildserver"
 	"github.com/concourse/concourse/atc/api/ccserver"
+	"github.com/concourse/concourse/atc/api/componentsserver"
 	"github.com/concourse/concourse/atc/api/cliserver"
 	"github.com/concourse/concourse/atc/api/configserver"
 	"github.com/concourse/concourse/atc/api/containerserver"
@@ -64,6 +65,7 @@ func NewHandler(
 	dbCheckFactory db.CheckFactory,
 	dbResourceConfigFactory db.ResourceConfigFactory,
 	dbUserFactory db.UserFactory,
+	dbComponentFactory db.ComponentFactory,
 
 	eventHandlerFactory buildserver.EventHandlerFactory,
 
@@ -113,6 +115,7 @@ func NewHandler(
 	artifactServer := artifactserver.NewServer(logger, workerPool)
 	usersServer := usersserver.NewServer(logger, dbUserFactory)
 	wallServer := wallserver.NewServer(dbWall, logger)
+	componentServer := componentsserver.NewServer(logger, dbComponentFactory)
 	if oidcIssuer == "" {
 		oidcIssuer = externalURL
 	}
@@ -241,6 +244,12 @@ func NewHandler(
 
 		atc.GetOpenIDConfiguration: http.HandlerFunc(idTokenServer.OpenIDConfiguration),
 		atc.GetSigningKeys:         http.HandlerFunc(idTokenServer.SigningKeys),
+
+		atc.GetComponents:        http.HandlerFunc(componentServer.GetComponents),
+		atc.PauseAllComponents:   http.HandlerFunc(componentServer.PauseAll),
+		atc.UnpauseAllComponents: http.HandlerFunc(componentServer.UnpauseAll),
+		atc.PauseComponent:       http.HandlerFunc(componentServer.Pause),
+		atc.UnpauseComponent:     http.HandlerFunc(componentServer.Unpause),
 	}
 
 	return rata.NewRouter(atc.Routes, wrapper.Wrap(handlers))

--- a/atc/api/present/component.go
+++ b/atc/api/present/component.go
@@ -1,0 +1,15 @@
+package present
+
+import (
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+)
+
+func Component(component db.Component) atc.Component {
+	return atc.Component{
+		Name:     component.Name(),
+		Interval: component.Interval(),
+		LastRan:  component.LastRan(),
+		Paused:   component.Paused(),
+	}
+}

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -906,6 +906,7 @@ func (cmd *RunCommand) constructAPIMembers(
 	dbSigningKeyFactory := db.NewSigningKeyFactory(dbConn)
 	dbClock := db.NewClock()
 	dbWall := db.NewWall(dbConn, &dbClock)
+	dbComponentFactory := db.NewComponentFactory(dbConn, cmd.NumGoroutineThreshold, rander{}, clock.NewClock(), db.RealGoroutineCounter{})
 
 	MiB := 1024 * 1024
 	claimsCacher := accessor.NewClaimsCacher(dbAccessTokenFactory, 1*MiB)
@@ -950,6 +951,7 @@ func (cmd *RunCommand) constructAPIMembers(
 		dbCheckFactory,
 		dbResourceConfigFactory,
 		userFactory,
+		dbComponentFactory,
 		pool,
 		secretManager,
 		credsManagers,
@@ -2072,6 +2074,7 @@ func (cmd *RunCommand) constructAPIHandler(
 	dbCheckFactory db.CheckFactory,
 	resourceConfigFactory db.ResourceConfigFactory,
 	dbUserFactory db.UserFactory,
+	dbComponentFactory db.ComponentFactory,
 	workerPool worker.Pool,
 	secretManager creds.Secrets,
 	credsManagers creds.Managers,
@@ -2150,6 +2153,7 @@ func (cmd *RunCommand) constructAPIHandler(
 		dbCheckFactory,
 		resourceConfigFactory,
 		dbUserFactory,
+		dbComponentFactory,
 
 		buildserver.NewEventHandler,
 

--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -145,7 +145,12 @@ func (a *auditor) ValidateAction(action string) bool {
 		atc.GetUser,
 		atc.GetWall,
 		atc.SetWall,
-		atc.ClearWall:
+		atc.ClearWall,
+		atc.GetComponents,
+		atc.PauseAllComponents,
+		atc.UnpauseAllComponents,
+		atc.PauseComponent,
+		atc.UnpauseComponent:
 		return a.EnableSystemAuditLog
 	case atc.ListTeams,
 		atc.SetTeam,
@@ -169,7 +174,7 @@ func (a *auditor) ValidateAction(action string) bool {
 		atc.ReportWorkerVolumes:
 		return a.EnableVolumeAuditLog
 	default:
-		panic(fmt.Sprintf("unhandled action: %s", action))
+		panic(fmt.Sprintf("auditor unhandled action: %s", action))
 	}
 }
 

--- a/atc/component.go
+++ b/atc/component.go
@@ -27,6 +27,8 @@ const (
 )
 
 type Component struct {
-	Name     string
-	Interval time.Duration
+	Name     string        `json:"name"`
+	Interval time.Duration `json:"interval"`
+	LastRan  time.Time     `json:"last_ran"`
+	Paused   bool          `json:"paused"`
 }

--- a/atc/component.go
+++ b/atc/component.go
@@ -26,6 +26,33 @@ const (
 	ComponentSigningKeyLifecycler       = "signing_key_lifecycler"
 )
 
+var (
+	// These components control starting and running builds
+	ComponentsRuntime = [...]string{
+		ComponentBuildTracker,
+		ComponentLidarScanner,
+		ComponentScheduler,
+	}
+
+	// These components GC data in the database, and artifacts (containers, volumes) on Workers.
+	ComponentsGarbageCollection = [...]string{
+		ComponentBuildReaper,
+		ComponentCollectorArtifacts,
+		ComponentCollectorBuilds,
+		ComponentCollectorCheckSessions,
+		ComponentCollectorChecks,
+		ComponentCollectorContainers,
+		ComponentCollectorResourceCacheUses,
+		ComponentCollectorResourceCaches,
+		ComponentCollectorTaskCaches,
+		ComponentCollectorResourceConfigs,
+		ComponentCollectorVolumes,
+		ComponentCollectorWorkers,
+		ComponentCollectorPipelines,
+		ComponentPipelinePauser,
+	}
+)
+
 type Component struct {
 	Name     string        `json:"name"`
 	Interval time.Duration `json:"interval"`

--- a/atc/db/component.go
+++ b/atc/db/component.go
@@ -20,6 +20,8 @@ type Component interface {
 	Interval() time.Duration
 	LastRan() time.Time
 	Paused() bool
+	Pause() error
+	Unpause() error
 
 	Reload() (bool, error)
 	IntervalElapsed() bool
@@ -42,6 +44,8 @@ func (r RealGoroutineCounter) NumGoroutine() int {
 	return runtime.NumGoroutine()
 }
 
+var _ Component = (*component)(nil)
+
 type component struct {
 	id       int
 	name     string
@@ -62,6 +66,32 @@ func (c *component) Name() string            { return c.name }
 func (c *component) Interval() time.Duration { return c.interval }
 func (c *component) LastRan() time.Time      { return c.lastRan }
 func (c *component) Paused() bool            { return c.paused }
+
+func (c *component) Pause() error {
+	_, err := psql.Update("components").
+		Set("paused", true).
+		Where(sq.Eq{"id": c.id}).
+		RunWith(c.conn).
+		Exec()
+	if err != nil {
+		return err
+	}
+	c.paused = true
+	return nil
+}
+
+func (c *component) Unpause() error {
+	_, err := psql.Update("components").
+		Set("paused", false).
+		Where(sq.Eq{"id": c.id}).
+		RunWith(c.conn).
+		Exec()
+	if err != nil {
+		return err
+	}
+	c.paused = false
+	return nil
+}
 
 func (c *component) Reload() (bool, error) {
 	row := componentsQuery.Where(sq.Eq{"c.id": c.id}).

--- a/atc/db/component_factory.go
+++ b/atc/db/component_factory.go
@@ -12,7 +12,18 @@ import (
 type ComponentFactory interface {
 	CreateOrUpdate(atc.Component) (Component, error)
 	Find(string) (Component, bool, error)
+
+	// Returns all components
+	All() ([]Component, error)
+
+	// Pauses all components
+	PauseAll() error
+
+	// Unpauses all components
+	UnpauseAll() error
 }
+
+var _ ComponentFactory = (*componentFactory)(nil)
 
 type componentFactory struct {
 	conn                  DbConn
@@ -94,4 +105,48 @@ func (f *componentFactory) CreateOrUpdate(c atc.Component) (Component, error) {
 	}
 
 	return obj, nil
+}
+
+func (f *componentFactory) All() ([]Component, error) {
+	rows, err := componentsQuery.
+		RunWith(f.conn).
+		Query()
+	if err != nil {
+		return nil, err
+	}
+	defer Close(rows)
+
+	var components []Component
+	for rows.Next() {
+		c := &component{
+			conn:                  f.conn,
+			numGoroutineThreshold: f.numGoroutineThreshold,
+			rander:                f.rander,
+			clock:                 f.clock,
+			goRoutineCounter:      f.goRoutineCounter,
+		}
+		err = scanComponent(c, rows)
+		if err != nil {
+			return nil, err
+		}
+		components = append(components, c)
+	}
+
+	return components, nil
+}
+
+func (f *componentFactory) PauseAll() error {
+	_, err := psql.Update("components").
+		Set("paused", true).
+		RunWith(f.conn).
+		Exec()
+	return err
+}
+
+func (f *componentFactory) UnpauseAll() error {
+	_, err := psql.Update("components").
+		Set("paused", false).
+		RunWith(f.conn).
+		Exec()
+	return err
 }

--- a/atc/db/component_factory_test.go
+++ b/atc/db/component_factory_test.go
@@ -67,4 +67,72 @@ var _ = Describe("ComponentFactory", func() {
 			Expect(foundComponent.Interval()).To(Equal(interval + 1))
 		})
 	})
+
+	Describe("All", func() {
+		BeforeEach(func() {
+			_, err := dbConn.Exec("INSERT INTO components (name, interval) VALUES ('comp-a', '100ms') ON CONFLICT (name) DO UPDATE SET interval = EXCLUDED.interval")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = dbConn.Exec("INSERT INTO components (name, interval) VALUES ('comp-b', '200ms') ON CONFLICT (name) DO UPDATE SET interval = EXCLUDED.interval")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns all components", func() {
+			components, err := componentFactory.All()
+			Expect(err).NotTo(HaveOccurred())
+
+			names := []string{}
+			for _, c := range components {
+				names = append(names, c.Name())
+			}
+			Expect(names).To(ContainElements("comp-a", "comp-b"))
+		})
+	})
+
+	Describe("PauseAll", func() {
+		BeforeEach(func() {
+			_, err := dbConn.Exec("INSERT INTO components (name, interval) VALUES ('comp-a', '100ms') ON CONFLICT (name) DO UPDATE SET interval = EXCLUDED.interval")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = dbConn.Exec("INSERT INTO components (name, interval) VALUES ('comp-b', '200ms') ON CONFLICT (name) DO UPDATE SET interval = EXCLUDED.interval")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("pauses all components", func() {
+			err := componentFactory.PauseAll()
+			Expect(err).NotTo(HaveOccurred())
+
+			compA, found, err := componentFactory.Find("comp-a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(compA.Paused()).To(BeTrue())
+
+			compB, found, err := componentFactory.Find("comp-b")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(compB.Paused()).To(BeTrue())
+		})
+	})
+
+	Describe("UnpauseAll", func() {
+		BeforeEach(func() {
+			_, err := dbConn.Exec("INSERT INTO components (name, interval, paused) VALUES ('comp-a', '100ms', true) ON CONFLICT (name) DO UPDATE SET interval = EXCLUDED.interval, paused = EXCLUDED.paused")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = dbConn.Exec("INSERT INTO components (name, interval, paused) VALUES ('comp-b', '200ms', true) ON CONFLICT (name) DO UPDATE SET interval = EXCLUDED.interval, paused = EXCLUDED.paused")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("unpauses all components", func() {
+			err := componentFactory.UnpauseAll()
+			Expect(err).NotTo(HaveOccurred())
+
+			compA, found, err := componentFactory.Find("comp-a")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(compA.Paused()).To(BeFalse())
+
+			compB, found, err := componentFactory.Find("comp-b")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(compB.Paused()).To(BeFalse())
+		})
+	})
 })

--- a/atc/db/component_test.go
+++ b/atc/db/component_test.go
@@ -259,4 +259,42 @@ var _ = Describe("Component", func() {
 			Expect(lastRan).To(BeTemporally("~", time.Now(), time.Second))
 		})
 	})
+
+	Describe("Pause", func() {
+		It("pauses the component", func() {
+			Expect(component.Paused()).To(BeFalse())
+
+			err := component.Pause()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(component.Paused()).To(BeTrue())
+
+			reloaded, err := component.Reload()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reloaded).To(BeTrue())
+			Expect(component.Paused()).To(BeTrue())
+		})
+	})
+
+	Describe("Unpause", func() {
+		BeforeEach(func() {
+			_, err = dbConn.Exec("UPDATE components SET paused = true WHERE name = 'scheduler'")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("unpauses the component", func() {
+			reloaded, err := component.Reload()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reloaded).To(BeTrue())
+			Expect(component.Paused()).To(BeTrue())
+
+			err = component.Unpause()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(component.Paused()).To(BeFalse())
+
+			reloaded, err = component.Reload()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reloaded).To(BeTrue())
+			Expect(component.Paused()).To(BeFalse())
+		})
+	})
 })

--- a/atc/db/dbfakes/fake_component.go
+++ b/atc/db/dbfakes/fake_component.go
@@ -59,6 +59,16 @@ type FakeComponent struct {
 	nameReturnsOnCall map[int]struct {
 		result1 string
 	}
+	PauseStub        func() error
+	pauseMutex       sync.RWMutex
+	pauseArgsForCall []struct {
+	}
+	pauseReturns struct {
+		result1 error
+	}
+	pauseReturnsOnCall map[int]struct {
+		result1 error
+	}
 	PausedStub        func() bool
 	pausedMutex       sync.RWMutex
 	pausedArgsForCall []struct {
@@ -80,6 +90,16 @@ type FakeComponent struct {
 	reloadReturnsOnCall map[int]struct {
 		result1 bool
 		result2 error
+	}
+	UnpauseStub        func() error
+	unpauseMutex       sync.RWMutex
+	unpauseArgsForCall []struct {
+	}
+	unpauseReturns struct {
+		result1 error
+	}
+	unpauseReturnsOnCall map[int]struct {
+		result1 error
 	}
 	UpdateLastRanStub        func() error
 	updateLastRanMutex       sync.RWMutex
@@ -360,6 +380,59 @@ func (fake *FakeComponent) NameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeComponent) Pause() error {
+	fake.pauseMutex.Lock()
+	ret, specificReturn := fake.pauseReturnsOnCall[len(fake.pauseArgsForCall)]
+	fake.pauseArgsForCall = append(fake.pauseArgsForCall, struct {
+	}{})
+	stub := fake.PauseStub
+	fakeReturns := fake.pauseReturns
+	fake.recordInvocation("Pause", []interface{}{})
+	fake.pauseMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeComponent) PauseCallCount() int {
+	fake.pauseMutex.RLock()
+	defer fake.pauseMutex.RUnlock()
+	return len(fake.pauseArgsForCall)
+}
+
+func (fake *FakeComponent) PauseCalls(stub func() error) {
+	fake.pauseMutex.Lock()
+	defer fake.pauseMutex.Unlock()
+	fake.PauseStub = stub
+}
+
+func (fake *FakeComponent) PauseReturns(result1 error) {
+	fake.pauseMutex.Lock()
+	defer fake.pauseMutex.Unlock()
+	fake.PauseStub = nil
+	fake.pauseReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeComponent) PauseReturnsOnCall(i int, result1 error) {
+	fake.pauseMutex.Lock()
+	defer fake.pauseMutex.Unlock()
+	fake.PauseStub = nil
+	if fake.pauseReturnsOnCall == nil {
+		fake.pauseReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pauseReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeComponent) Paused() bool {
 	fake.pausedMutex.Lock()
 	ret, specificReturn := fake.pausedReturnsOnCall[len(fake.pausedArgsForCall)]
@@ -467,6 +540,59 @@ func (fake *FakeComponent) ReloadReturnsOnCall(i int, result1 bool, result2 erro
 		result1 bool
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeComponent) Unpause() error {
+	fake.unpauseMutex.Lock()
+	ret, specificReturn := fake.unpauseReturnsOnCall[len(fake.unpauseArgsForCall)]
+	fake.unpauseArgsForCall = append(fake.unpauseArgsForCall, struct {
+	}{})
+	stub := fake.UnpauseStub
+	fakeReturns := fake.unpauseReturns
+	fake.recordInvocation("Unpause", []interface{}{})
+	fake.unpauseMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeComponent) UnpauseCallCount() int {
+	fake.unpauseMutex.RLock()
+	defer fake.unpauseMutex.RUnlock()
+	return len(fake.unpauseArgsForCall)
+}
+
+func (fake *FakeComponent) UnpauseCalls(stub func() error) {
+	fake.unpauseMutex.Lock()
+	defer fake.unpauseMutex.Unlock()
+	fake.UnpauseStub = stub
+}
+
+func (fake *FakeComponent) UnpauseReturns(result1 error) {
+	fake.unpauseMutex.Lock()
+	defer fake.unpauseMutex.Unlock()
+	fake.UnpauseStub = nil
+	fake.unpauseReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeComponent) UnpauseReturnsOnCall(i int, result1 error) {
+	fake.unpauseMutex.Lock()
+	defer fake.unpauseMutex.Unlock()
+	fake.UnpauseStub = nil
+	if fake.unpauseReturnsOnCall == nil {
+		fake.unpauseReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.unpauseReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeComponent) UpdateLastRan() error {

--- a/atc/db/dbfakes/fake_component_factory.go
+++ b/atc/db/dbfakes/fake_component_factory.go
@@ -9,6 +9,18 @@ import (
 )
 
 type FakeComponentFactory struct {
+	AllStub        func() ([]db.Component, error)
+	allMutex       sync.RWMutex
+	allArgsForCall []struct {
+	}
+	allReturns struct {
+		result1 []db.Component
+		result2 error
+	}
+	allReturnsOnCall map[int]struct {
+		result1 []db.Component
+		result2 error
+	}
 	CreateOrUpdateStub        func(atc.Component) (db.Component, error)
 	createOrUpdateMutex       sync.RWMutex
 	createOrUpdateArgsForCall []struct {
@@ -37,8 +49,84 @@ type FakeComponentFactory struct {
 		result2 bool
 		result3 error
 	}
+	PauseAllStub        func() error
+	pauseAllMutex       sync.RWMutex
+	pauseAllArgsForCall []struct {
+	}
+	pauseAllReturns struct {
+		result1 error
+	}
+	pauseAllReturnsOnCall map[int]struct {
+		result1 error
+	}
+	UnpauseAllStub        func() error
+	unpauseAllMutex       sync.RWMutex
+	unpauseAllArgsForCall []struct {
+	}
+	unpauseAllReturns struct {
+		result1 error
+	}
+	unpauseAllReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeComponentFactory) All() ([]db.Component, error) {
+	fake.allMutex.Lock()
+	ret, specificReturn := fake.allReturnsOnCall[len(fake.allArgsForCall)]
+	fake.allArgsForCall = append(fake.allArgsForCall, struct {
+	}{})
+	stub := fake.AllStub
+	fakeReturns := fake.allReturns
+	fake.recordInvocation("All", []interface{}{})
+	fake.allMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeComponentFactory) AllCallCount() int {
+	fake.allMutex.RLock()
+	defer fake.allMutex.RUnlock()
+	return len(fake.allArgsForCall)
+}
+
+func (fake *FakeComponentFactory) AllCalls(stub func() ([]db.Component, error)) {
+	fake.allMutex.Lock()
+	defer fake.allMutex.Unlock()
+	fake.AllStub = stub
+}
+
+func (fake *FakeComponentFactory) AllReturns(result1 []db.Component, result2 error) {
+	fake.allMutex.Lock()
+	defer fake.allMutex.Unlock()
+	fake.AllStub = nil
+	fake.allReturns = struct {
+		result1 []db.Component
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeComponentFactory) AllReturnsOnCall(i int, result1 []db.Component, result2 error) {
+	fake.allMutex.Lock()
+	defer fake.allMutex.Unlock()
+	fake.AllStub = nil
+	if fake.allReturnsOnCall == nil {
+		fake.allReturnsOnCall = make(map[int]struct {
+			result1 []db.Component
+			result2 error
+		})
+	}
+	fake.allReturnsOnCall[i] = struct {
+		result1 []db.Component
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeComponentFactory) CreateOrUpdate(arg1 atc.Component) (db.Component, error) {
@@ -170,6 +258,112 @@ func (fake *FakeComponentFactory) FindReturnsOnCall(i int, result1 db.Component,
 		result2 bool
 		result3 error
 	}{result1, result2, result3}
+}
+
+func (fake *FakeComponentFactory) PauseAll() error {
+	fake.pauseAllMutex.Lock()
+	ret, specificReturn := fake.pauseAllReturnsOnCall[len(fake.pauseAllArgsForCall)]
+	fake.pauseAllArgsForCall = append(fake.pauseAllArgsForCall, struct {
+	}{})
+	stub := fake.PauseAllStub
+	fakeReturns := fake.pauseAllReturns
+	fake.recordInvocation("PauseAll", []interface{}{})
+	fake.pauseAllMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeComponentFactory) PauseAllCallCount() int {
+	fake.pauseAllMutex.RLock()
+	defer fake.pauseAllMutex.RUnlock()
+	return len(fake.pauseAllArgsForCall)
+}
+
+func (fake *FakeComponentFactory) PauseAllCalls(stub func() error) {
+	fake.pauseAllMutex.Lock()
+	defer fake.pauseAllMutex.Unlock()
+	fake.PauseAllStub = stub
+}
+
+func (fake *FakeComponentFactory) PauseAllReturns(result1 error) {
+	fake.pauseAllMutex.Lock()
+	defer fake.pauseAllMutex.Unlock()
+	fake.PauseAllStub = nil
+	fake.pauseAllReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeComponentFactory) PauseAllReturnsOnCall(i int, result1 error) {
+	fake.pauseAllMutex.Lock()
+	defer fake.pauseAllMutex.Unlock()
+	fake.PauseAllStub = nil
+	if fake.pauseAllReturnsOnCall == nil {
+		fake.pauseAllReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pauseAllReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeComponentFactory) UnpauseAll() error {
+	fake.unpauseAllMutex.Lock()
+	ret, specificReturn := fake.unpauseAllReturnsOnCall[len(fake.unpauseAllArgsForCall)]
+	fake.unpauseAllArgsForCall = append(fake.unpauseAllArgsForCall, struct {
+	}{})
+	stub := fake.UnpauseAllStub
+	fakeReturns := fake.unpauseAllReturns
+	fake.recordInvocation("UnpauseAll", []interface{}{})
+	fake.unpauseAllMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeComponentFactory) UnpauseAllCallCount() int {
+	fake.unpauseAllMutex.RLock()
+	defer fake.unpauseAllMutex.RUnlock()
+	return len(fake.unpauseAllArgsForCall)
+}
+
+func (fake *FakeComponentFactory) UnpauseAllCalls(stub func() error) {
+	fake.unpauseAllMutex.Lock()
+	defer fake.unpauseAllMutex.Unlock()
+	fake.UnpauseAllStub = stub
+}
+
+func (fake *FakeComponentFactory) UnpauseAllReturns(result1 error) {
+	fake.unpauseAllMutex.Lock()
+	defer fake.unpauseAllMutex.Unlock()
+	fake.UnpauseAllStub = nil
+	fake.unpauseAllReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeComponentFactory) UnpauseAllReturnsOnCall(i int, result1 error) {
+	fake.unpauseAllMutex.Lock()
+	defer fake.unpauseAllMutex.Unlock()
+	fake.UnpauseAllStub = nil
+	if fake.unpauseAllReturnsOnCall == nil {
+		fake.unpauseAllReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.unpauseAllReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeComponentFactory) Invocations() map[string][][]interface{} {

--- a/atc/routes.go
+++ b/atc/routes.go
@@ -122,6 +122,12 @@ const (
 
 	GetOpenIDConfiguration = "GetOpenIDConfiguration"
 	GetSigningKeys         = "GetSigningKeys"
+
+	GetComponents        = "GetComponents"
+	PauseComponent       = "PauseComponent"
+	UnpauseComponent     = "UnpauseComponent"
+	PauseAllComponents   = "PauseAllComponents"
+	UnpauseAllComponents = "UnpauseAllComponents"
 )
 
 const (
@@ -251,4 +257,10 @@ var Routes = rata.Routes([]rata.Route{
 
 	{Path: "/.well-known/openid-configuration", Method: "GET", Name: GetOpenIDConfiguration},
 	{Path: "/.well-known/jwks.json", Method: "GET", Name: GetSigningKeys},
+
+	{Path: "/api/v1/components", Method: "GET", Name: GetComponents},
+	{Path: "/api/v1/components/pause", Method: "PUT", Name: PauseAllComponents},
+	{Path: "/api/v1/components/unpause", Method: "PUT", Name: UnpauseAllComponents},
+	{Path: "/api/v1/components/:component_name/pause", Method: "PUT", Name: PauseComponent},
+	{Path: "/api/v1/components/:component_name/unpause", Method: "PUT", Name: UnpauseComponent},
 })

--- a/atc/wrappa/api_auth_wrappa.go
+++ b/atc/wrappa/api_auth_wrappa.go
@@ -122,7 +122,12 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.ClearResourceVersions,
 			atc.ClearResourceTypeVersions,
 			atc.ListSharedForResource,
-			atc.ListSharedForResourceType:
+			atc.ListSharedForResourceType,
+			atc.GetComponents,
+			atc.PauseComponent,
+			atc.UnpauseComponent,
+			atc.PauseAllComponents,
+			atc.UnpauseAllComponents:
 			newHandler = auth.CheckAdminHandler(handler, rejector)
 
 		// authorized (requested team matches resource team and has required role, or is admin)

--- a/atc/wrappa/reject_archived_wrappa.go
+++ b/atc/wrappa/reject_archived_wrappa.go
@@ -130,7 +130,12 @@ func (rw *RejectArchivedWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.ClearResourceVersions,
 			atc.ClearResourceTypeVersions,
 			atc.GetOpenIDConfiguration,
-			atc.GetSigningKeys:
+			atc.GetSigningKeys,
+			atc.GetComponents,
+			atc.PauseAllComponents,
+			atc.UnpauseAllComponents,
+			atc.PauseComponent,
+			atc.UnpauseComponent:
 
 		default:
 			panic("how do archived pipelines affect your endpoint?")

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -94,6 +94,10 @@ type FlyCommand struct {
 	SetWall   SetWallCommand   `command:"set-wall" alias:"sw" description:"Set a wall message"`
 	ClearWall ClearWallCommand `command:"clear-wall" alias:"cw" description:"Clear the wall message"`
 
+	GetComponents    GetComponentsCommand    `command:"get-components" alias:"gc" description:"Get details about all web components"`
+	PauseComponent   PauseComponentCommand   `command:"pause-component" alias:"pc" description:"Pause one or more web components"`
+	UnpauseComponent UnpauseComponentCommand `command:"unpause-component" alias:"uc" description:"Unpause one or more web components"`
+
 	Completion CompletionCommand `command:"completion" description:"generate shell completion code"`
 }
 

--- a/fly/commands/get_components.go
+++ b/fly/commands/get_components.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/fly/ui"
+	"github.com/fatih/color"
+)
+
+type GetComponentsCommand struct {
+	Json bool `long:"json" description:"Print command result as JSON"`
+}
+
+func (command *GetComponentsCommand) Execute(args []string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	components, err := target.Client().ListComponents()
+	if err != nil {
+		return err
+	}
+
+	slices.SortFunc(components, func(a, b atc.Component) int {
+		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
+
+	if command.Json {
+		err = displayhelpers.JsonPrint(components)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	err = command.tableFor(components).Render(os.Stdout, Fly.PrintTableHeaders)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (command *GetComponentsCommand) tableFor(components []atc.Component) ui.Table {
+	headers := ui.TableRow{
+		{Contents: "name", Color: color.New(color.Bold)},
+		{Contents: "interval", Color: color.New(color.Bold)},
+		{Contents: "last ran", Color: color.New(color.Bold)},
+		{Contents: "paused", Color: color.New(color.Bold)},
+	}
+
+	table := ui.Table{Headers: headers}
+
+	for _, c := range components {
+		row := ui.TableRow{
+			{Contents: c.Name},
+			{Contents: c.Interval.String()},
+			{Contents: c.LastRan.Local().Format(time.DateTime)},
+			{Contents: fmt.Sprintf("%t", c.Paused)},
+		}
+		table.Data = append(table.Data, row)
+	}
+
+	return table
+}

--- a/fly/commands/pause_component.go
+++ b/fly/commands/pause_component.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/rc"
 )
 
 type PauseComponentCommand struct {
-	All  bool     `long:"all" short:"a" description:"Pauses all components"`
-	Name []string `long:"name" short:"n" description:"Name of the component(s) to unpause. Can specify multiple times to pause multiple components"`
+	All               bool     `long:"all" short:"a" description:"Pauses all components"`
+	Name              []string `long:"name" short:"n" description:"Name of the component(s) to unpause. Can specify multiple times to pause multiple components"`
+	RuntimeComponents bool     `long:"runtime-components" description:"Pauses all components related to starting and running pipelines. Pause these before upgrading Concoure."`
+	GCComponents      bool     `long:"gc-components" description:"Pauses all components related to garbage collection of data in the database, and artifacts (container, volumes) on Workers."`
 }
 
 func (command *PauseComponentCommand) Execute(args []string) error {
@@ -30,6 +33,14 @@ func (command *PauseComponentCommand) Execute(args []string) error {
 		}
 		fmt.Println("all components paused")
 		return nil
+	}
+
+	if command.RuntimeComponents {
+		command.Name = append(command.Name, atc.ComponentsRuntime[:]...)
+	}
+
+	if command.GCComponents {
+		command.Name = append(command.Name, atc.ComponentsGarbageCollection[:]...)
 	}
 
 	if len(command.Name) == 0 {

--- a/fly/commands/pause_component.go
+++ b/fly/commands/pause_component.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/concourse/concourse/fly/rc"
+)
+
+type PauseComponentCommand struct {
+	All  bool     `long:"all" short:"a" description:"Pauses all components"`
+	Name []string `long:"name" short:"n" description:"Name of the component(s) to unpause. Can specify multiple times to pause multiple components"`
+}
+
+func (command *PauseComponentCommand) Execute(args []string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	if command.All {
+		err = target.Client().PauseAllComponents()
+		if err != nil {
+			return err
+		}
+		fmt.Println("all components paused")
+		return nil
+	}
+
+	if len(command.Name) == 0 {
+		return errors.New("--name or --all must be provided")
+	}
+
+	for _, name := range command.Name {
+		err = target.Client().PauseComponent(name)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("paused '%s'\n", name)
+	}
+
+	return nil
+}

--- a/fly/commands/unpause_component.go
+++ b/fly/commands/unpause_component.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/concourse/concourse/fly/rc"
+)
+
+type UnpauseComponentCommand struct {
+	All  bool     `long:"all" short:"a" description:"Unpauses all components"`
+	Name []string `long:"name" short:"n" description:"Name of the component(s) to unpause. Can specify multiple times to unpause multiple components"`
+}
+
+func (command *UnpauseComponentCommand) Execute(args []string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	if command.All {
+		err = target.Client().UnpauseAllComponents()
+		if err != nil {
+			return err
+		}
+		fmt.Println("all components unpaused")
+		return nil
+	}
+
+	if len(command.Name) == 0 {
+		return errors.New("--name or --all must be provided")
+	}
+
+	for _, name := range command.Name {
+		err = target.Client().UnpauseComponent(name)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("unpaused '%s'\n", name)
+	}
+
+	return nil
+}

--- a/fly/commands/unpause_component.go
+++ b/fly/commands/unpause_component.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/rc"
 )
 
 type UnpauseComponentCommand struct {
-	All  bool     `long:"all" short:"a" description:"Unpauses all components"`
-	Name []string `long:"name" short:"n" description:"Name of the component(s) to unpause. Can specify multiple times to unpause multiple components"`
+	All               bool     `long:"all" short:"a" description:"Unpauses all components"`
+	Name              []string `long:"name" short:"n" description:"Name of the component(s) to unpause. Can specify multiple times to unpause multiple components"`
+	RuntimeComponents bool     `long:"runtime-components" description:"Unpauses all components related to starting and running pipelines"`
+	GCComponents      bool     `long:"gc-components" description:"Unpauses all components related to garbage collection of data in the database, and artifacts (container, volumes) on Workers."`
 }
 
 func (command *UnpauseComponentCommand) Execute(args []string) error {
@@ -30,6 +33,14 @@ func (command *UnpauseComponentCommand) Execute(args []string) error {
 		}
 		fmt.Println("all components unpaused")
 		return nil
+	}
+
+	if command.RuntimeComponents {
+		command.Name = append(command.Name, atc.ComponentsRuntime[:]...)
+	}
+
+	if command.GCComponents {
+		command.Name = append(command.Name, atc.ComponentsGarbageCollection[:]...)
 	}
 
 	if len(command.Name) == 0 {

--- a/fly/integration/get_components_test.go
+++ b/fly/integration/get_components_test.go
@@ -1,0 +1,142 @@
+package integration_test
+
+import (
+	"net/http"
+	"os/exec"
+	"time"
+
+	"github.com/fatih/color"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/ui"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("get-components", func() {
+	var (
+		path string
+		err  error
+	)
+
+	BeforeEach(func() {
+		path, err = atc.Routes.CreatePathForRoute(atc.GetComponents, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when components are returned", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", path),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, []atc.Component{
+						{
+							Name:     "tracker",
+							Interval: 30 * time.Second,
+							LastRan:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+							Paused:   true,
+						},
+						{
+							Name:     "scheduler",
+							Interval: 10 * time.Second,
+							LastRan:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+							Paused:   false,
+						},
+					}),
+				),
+			)
+		})
+
+		It("prints components in a table sorted by name", func() {
+			Expect(func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "get-components")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gbytes.Say("scheduler"))
+				Eventually(sess).Should(gbytes.Say("tracker"))
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+			}).To(Change(func() int {
+				return len(atcServer.ReceivedRequests())
+			}).By(2))
+		})
+
+		It("prints components as json with --json flag", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "get-components", "--json")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gexec.Exit(0))
+			Expect(sess.Out.Contents()).To(MatchJSON(`[
+		{
+          "name": "scheduler",
+          "interval": 10000000000,
+          "last_ran": "2026-01-01T00:00:00Z",
+          "paused": false
+        },
+        {
+          "name": "tracker",
+          "interval": 30000000000,
+          "last_ran": "2026-01-02T00:00:00Z",
+          "paused": true
+        }]`))
+		})
+	})
+
+	Context("when there are no components", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", path),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, []atc.Component{}),
+				),
+			)
+		})
+
+		It("prints an empty table", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "get-components")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gexec.Exit(0))
+			Expect(sess.Out).To(PrintTable(ui.Table{
+				Headers: ui.TableRow{
+					{Contents: "name", Color: color.New(color.Bold)},
+					{Contents: "interval", Color: color.New(color.Bold)},
+					{Contents: "last ran", Color: color.New(color.Bold)},
+					{Contents: "paused", Color: color.New(color.Bold)},
+				},
+				Data: []ui.TableRow{},
+			}))
+		})
+	})
+
+	Context("when the user is forbidden", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", path),
+					ghttp.RespondWith(http.StatusForbidden, nil),
+				),
+			)
+		})
+
+		It("returns an error about needing owner role", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "get-components")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess.Err).Should(gbytes.Say("must be an owner of the 'main' team to interact with components"))
+			Eventually(sess).Should(gexec.Exit(1))
+		})
+	})
+})

--- a/fly/integration/pause_component_test.go
+++ b/fly/integration/pause_component_test.go
@@ -1,0 +1,171 @@
+package integration_test
+
+import (
+	"net/http"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/tedsuo/rata"
+)
+
+var _ = Describe("pause-component", func() {
+	Context("when a component name is specified", func() {
+		var (
+			path string
+			err  error
+		)
+
+		BeforeEach(func() {
+			path, err = atc.Routes.CreatePathForRoute(atc.PauseComponent, rata.Params{"component_name": "scheduler"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when the component exists", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", path),
+						ghttp.RespondWith(http.StatusOK, nil),
+					),
+				)
+			})
+
+			It("pauses the component", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "pause-component", "-n", "scheduler")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gbytes.Say("paused 'scheduler'"))
+				Eventually(sess).Should(gexec.Exit(0))
+			})
+		})
+
+		Context("when the component does not exist", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", path),
+						ghttp.RespondWith(http.StatusNotFound, nil),
+					),
+				)
+			})
+
+			It("prints an error message", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "pause-component", "-n", "scheduler")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess.Err).Should(gbytes.Say("component 'scheduler' not found"))
+				Eventually(sess).Should(gexec.Exit(1))
+			})
+		})
+
+		Context("when the user is forbidden", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", path),
+						ghttp.RespondWith(http.StatusForbidden, nil),
+					),
+				)
+			})
+
+			It("returns an error about needing owner role", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "pause-component", "-n", "scheduler")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess.Err).Should(gbytes.Say("must be an owner of the 'main' team to interact with components"))
+				Eventually(sess).Should(gexec.Exit(1))
+			})
+		})
+	})
+
+	Context("when multiple component names are specified", func() {
+		var (
+			schedulerPath string
+			trackerPath   string
+			err           error
+		)
+
+		BeforeEach(func() {
+			schedulerPath, err = atc.Routes.CreatePathForRoute(atc.PauseComponent, rata.Params{"component_name": "scheduler"})
+			Expect(err).NotTo(HaveOccurred())
+
+			trackerPath, err = atc.Routes.CreatePathForRoute(atc.PauseComponent, rata.Params{"component_name": "tracker"})
+			Expect(err).NotTo(HaveOccurred())
+
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", schedulerPath),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", trackerPath),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("pauses each component", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "pause-component", "-n", "scheduler", "-n", "tracker")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gbytes.Say("paused 'scheduler'"))
+			Eventually(sess).Should(gbytes.Say("paused 'tracker'"))
+			Eventually(sess).Should(gexec.Exit(0))
+		})
+	})
+
+	Context("when --all is specified", func() {
+		var (
+			path string
+			err  error
+		)
+
+		BeforeEach(func() {
+			path, err = atc.Routes.CreatePathForRoute(atc.PauseAllComponents, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", path),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("pauses all components", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "pause-component", "--all")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gbytes.Say("all components paused"))
+			Eventually(sess).Should(gexec.Exit(0))
+		})
+	})
+
+	Context("when neither --name or --all is specified", func() {
+		It("errors", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "pause-component")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess.Err).Should(gbytes.Say("--name or --all must be provided"))
+			Eventually(sess).Should(gexec.Exit(1))
+		})
+	})
+})

--- a/fly/integration/unpause_component_test.go
+++ b/fly/integration/unpause_component_test.go
@@ -1,0 +1,170 @@
+package integration_test
+
+import (
+	"net/http"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/tedsuo/rata"
+)
+
+var _ = Describe("unpause-component", func() {
+	Context("when a component name is specified", func() {
+		var (
+			path string
+			err  error
+		)
+
+		BeforeEach(func() {
+			path, err = atc.Routes.CreatePathForRoute(atc.UnpauseComponent, rata.Params{"component_name": "scheduler"})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when the component exists", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", path),
+						ghttp.RespondWith(http.StatusOK, nil),
+					),
+				)
+			})
+
+			It("unpauses the component", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "unpause-component", "-n", "scheduler")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gbytes.Say("unpaused 'scheduler'"))
+				Eventually(sess).Should(gexec.Exit(0))
+			})
+		})
+
+		Context("when the component does not exist", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", path),
+						ghttp.RespondWith(http.StatusNotFound, nil),
+					),
+				)
+			})
+
+			It("prints an error message", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "unpause-component", "-n", "scheduler")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess.Err).Should(gbytes.Say("component 'scheduler' not found"))
+				Eventually(sess).Should(gexec.Exit(1))
+			})
+		})
+
+		Context("when the user is forbidden", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", path),
+						ghttp.RespondWith(http.StatusForbidden, nil),
+					),
+				)
+			})
+
+			It("returns an error about needing owner role", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "unpause-component", "-n", "scheduler")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess.Err).Should(gbytes.Say("must be an owner of the 'main' team to interact with components"))
+				Eventually(sess).Should(gexec.Exit(1))
+			})
+		})
+	})
+
+	Context("when multiple component names are specified", func() {
+		var (
+			schedulerPath string
+			trackerPath   string
+			err           error
+		)
+
+		BeforeEach(func() {
+			schedulerPath, err = atc.Routes.CreatePathForRoute(atc.UnpauseComponent, rata.Params{"component_name": "scheduler"})
+			Expect(err).NotTo(HaveOccurred())
+
+			trackerPath, err = atc.Routes.CreatePathForRoute(atc.UnpauseComponent, rata.Params{"component_name": "tracker"})
+			Expect(err).NotTo(HaveOccurred())
+
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", schedulerPath),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", trackerPath),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("unpauses each component", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "unpause-component", "-n", "scheduler", "-n", "tracker")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gbytes.Say("unpaused 'scheduler'"))
+			Eventually(sess).Should(gbytes.Say("unpaused 'tracker'"))
+			Eventually(sess).Should(gexec.Exit(0))
+		})
+	})
+
+	Context("when --all is specified", func() {
+		var (
+			path string
+			err  error
+		)
+
+		BeforeEach(func() {
+			path, err = atc.Routes.CreatePathForRoute(atc.UnpauseAllComponents, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", path),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("unpauses all components", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "unpause-component", "--all")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(gbytes.Say("all components unpaused"))
+			Eventually(sess).Should(gexec.Exit(0))
+		})
+	})
+
+	Context("when neither --name nor --all is specified", func() {
+		It("errors", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "unpause-component")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess.Err).Should(gbytes.Say("--name or --all must be provided"))
+			Eventually(sess).Should(gexec.Exit(1))
+		})
+	})
+})

--- a/go-concourse/concourse/client.go
+++ b/go-concourse/concourse/client.go
@@ -38,10 +38,16 @@ type Client interface {
 	GetWall() (atc.Wall, error)
 	SetWall(atc.Wall) error
 	ClearWall() error
+	ListComponents() ([]atc.Component, error)
+	PauseComponent(componentName string) error
+	UnpauseComponent(componentName string) error
+	PauseAllComponents() error
+	UnpauseAllComponents() error
 }
 
 type client struct {
-	connection internal.Connection //Deprecated
+	//Deprecated. Use httpAgent instead
+	connection internal.Connection
 	httpAgent  internal.HTTPAgent
 }
 

--- a/go-concourse/concourse/components.go
+++ b/go-concourse/concourse/components.go
@@ -1,0 +1,97 @@
+package concourse
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/go-concourse/concourse/internal"
+	"github.com/tedsuo/rata"
+)
+
+func (client *client) ListComponents() ([]atc.Component, error) {
+	var components []atc.Component
+	resp, err := client.httpAgent.Send(internal.Request{
+		RequestName: atc.GetComponents,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		err = json.NewDecoder(resp.Body).Decode(&components)
+		if err != nil {
+			return nil, err
+		}
+		return components, nil
+
+	case http.StatusForbidden:
+		return nil, errors.New("must be an owner of the 'main' team to interact with components")
+
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return nil, internal.UnexpectedResponseError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       string(body),
+		}
+	}
+}
+
+func (client *client) PauseComponent(componentName string) error {
+	return client.manageComponent(componentName, atc.PauseComponent)
+}
+
+func (client *client) UnpauseComponent(componentName string) error {
+	return client.manageComponent(componentName, atc.UnpauseComponent)
+}
+
+func (client *client) manageComponent(componentName string, endpoint string) error {
+	params := rata.Params{
+		"component_name": componentName,
+	}
+	resp, err := client.httpAgent.Send(internal.Request{
+		RequestName: endpoint,
+		Params:      params,
+	})
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+
+	case http.StatusNotFound:
+		return fmt.Errorf("component '%s' not found", componentName)
+
+	case http.StatusForbidden:
+		return errors.New("must be an owner of the 'main' team to interact with components")
+
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return internal.UnexpectedResponseError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       string(body),
+		}
+	}
+}
+
+func (client *client) PauseAllComponents() error {
+	_, err := client.httpAgent.Send(internal.Request{
+		RequestName: atc.PauseAllComponents,
+	})
+	return err
+}
+
+func (client *client) UnpauseAllComponents() error {
+	_, err := client.httpAgent.Send(internal.Request{
+		RequestName: atc.UnpauseAllComponents,
+	})
+	return err
+}

--- a/go-concourse/concourse/components_test.go
+++ b/go-concourse/concourse/components_test.go
@@ -1,0 +1,187 @@
+package concourse_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/concourse/concourse/atc"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Components", func() {
+	Describe("ListComponents", func() {
+		var expectedComponents []atc.Component
+
+		BeforeEach(func() {
+			expectedComponents = []atc.Component{
+				{Name: "scheduler", Paused: false},
+				{Name: "tracker", Paused: true},
+			}
+
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/components"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, expectedComponents),
+				),
+			)
+		})
+
+		It("returns all the components", func() {
+			components, err := client.ListComponents()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(components).To(Equal(expectedComponents))
+		})
+
+		Context("when the user is forbidden", func() {
+			BeforeEach(func() {
+				atcServer.Reset()
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/components"),
+						ghttp.RespondWith(http.StatusForbidden, nil),
+					),
+				)
+			})
+
+			It("returns a forbidden error", func() {
+				_, err := client.ListComponents()
+				Expect(err).To(MatchError("must be an owner of the 'main' team to interact with components"))
+			})
+		})
+	})
+
+	Describe("PauseComponent", func() {
+		var (
+			expectedStatus int
+			componentName  = "scheduler"
+			expectedURL    = fmt.Sprintf("/api/v1/components/%s/pause", componentName)
+		)
+
+		JustBeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", expectedURL),
+					ghttp.RespondWith(expectedStatus, nil),
+				),
+			)
+		})
+
+		Context("when the component exists", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusOK
+			})
+
+			It("returns no error", func() {
+				err := client.PauseComponent(componentName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the component does not exist", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusNotFound
+			})
+
+			It("returns an error", func() {
+				err := client.PauseComponent(componentName)
+				Expect(err).To(MatchError("component 'scheduler' not found"))
+			})
+		})
+
+		Context("when the user is forbidden", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusForbidden
+			})
+
+			It("returns a forbidden error", func() {
+				err := client.PauseComponent(componentName)
+				Expect(err).To(MatchError("must be an owner of the 'main' team to interact with components"))
+			})
+		})
+	})
+
+	Describe("UnpauseComponent", func() {
+		var (
+			expectedStatus int
+			componentName  = "scheduler"
+			expectedURL    = fmt.Sprintf("/api/v1/components/%s/unpause", componentName)
+		)
+
+		JustBeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", expectedURL),
+					ghttp.RespondWith(expectedStatus, nil),
+				),
+			)
+		})
+
+		Context("when the component exists", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusOK
+			})
+
+			It("returns no error", func() {
+				err := client.UnpauseComponent(componentName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the component does not exist", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusNotFound
+			})
+
+			It("returns an error", func() {
+				err := client.UnpauseComponent(componentName)
+				Expect(err).To(MatchError("component 'scheduler' not found"))
+			})
+		})
+
+		Context("when the user is forbidden", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusForbidden
+			})
+
+			It("returns a forbidden error", func() {
+				err := client.UnpauseComponent(componentName)
+				Expect(err).To(MatchError("must be an owner of the 'main' team to interact with components"))
+			})
+		})
+	})
+
+	Describe("PauseAllComponents", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", "/api/v1/components/pause"),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("returns no error", func() {
+			err := client.PauseAllComponents()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("UnpauseAllComponents", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", "/api/v1/components/unpause"),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("returns no error", func() {
+			err := client.UnpauseAllComponents()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/go-concourse/concourse/concoursefakes/fake_client.go
+++ b/go-concourse/concourse/concoursefakes/fake_client.go
@@ -218,6 +218,18 @@ type FakeClient struct {
 		result1 []atc.WorkerArtifact
 		result2 error
 	}
+	ListComponentsStub        func() ([]atc.Component, error)
+	listComponentsMutex       sync.RWMutex
+	listComponentsArgsForCall []struct {
+	}
+	listComponentsReturns struct {
+		result1 []atc.Component
+		result2 error
+	}
+	listComponentsReturnsOnCall map[int]struct {
+		result1 []atc.Component
+		result2 error
+	}
 	ListPipelinesStub        func() ([]atc.Pipeline, error)
 	listPipelinesMutex       sync.RWMutex
 	listPipelinesArgsForCall []struct {
@@ -253,6 +265,27 @@ type FakeClient struct {
 	listWorkersReturnsOnCall map[int]struct {
 		result1 []atc.Worker
 		result2 error
+	}
+	PauseAllComponentsStub        func() error
+	pauseAllComponentsMutex       sync.RWMutex
+	pauseAllComponentsArgsForCall []struct {
+	}
+	pauseAllComponentsReturns struct {
+		result1 error
+	}
+	pauseAllComponentsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	PauseComponentStub        func(string) error
+	pauseComponentMutex       sync.RWMutex
+	pauseComponentArgsForCall []struct {
+		arg1 string
+	}
+	pauseComponentReturns struct {
+		result1 error
+	}
+	pauseComponentReturnsOnCall map[int]struct {
+		result1 error
 	}
 	PruneWorkerStub        func(string) error
 	pruneWorkerMutex       sync.RWMutex
@@ -310,6 +343,27 @@ type FakeClient struct {
 	}
 	uRLReturnsOnCall map[int]struct {
 		result1 string
+	}
+	UnpauseAllComponentsStub        func() error
+	unpauseAllComponentsMutex       sync.RWMutex
+	unpauseAllComponentsArgsForCall []struct {
+	}
+	unpauseAllComponentsReturns struct {
+		result1 error
+	}
+	unpauseAllComponentsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	UnpauseComponentStub        func(string) error
+	unpauseComponentMutex       sync.RWMutex
+	unpauseComponentArgsForCall []struct {
+		arg1 string
+	}
+	unpauseComponentReturns struct {
+		result1 error
+	}
+	unpauseComponentReturnsOnCall map[int]struct {
+		result1 error
 	}
 	UserInfoStub        func() (atc.UserInfo, error)
 	userInfoMutex       sync.RWMutex
@@ -1315,6 +1369,62 @@ func (fake *FakeClient) ListBuildArtifactsReturnsOnCall(i int, result1 []atc.Wor
 	}{result1, result2}
 }
 
+func (fake *FakeClient) ListComponents() ([]atc.Component, error) {
+	fake.listComponentsMutex.Lock()
+	ret, specificReturn := fake.listComponentsReturnsOnCall[len(fake.listComponentsArgsForCall)]
+	fake.listComponentsArgsForCall = append(fake.listComponentsArgsForCall, struct {
+	}{})
+	stub := fake.ListComponentsStub
+	fakeReturns := fake.listComponentsReturns
+	fake.recordInvocation("ListComponents", []interface{}{})
+	fake.listComponentsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListComponentsCallCount() int {
+	fake.listComponentsMutex.RLock()
+	defer fake.listComponentsMutex.RUnlock()
+	return len(fake.listComponentsArgsForCall)
+}
+
+func (fake *FakeClient) ListComponentsCalls(stub func() ([]atc.Component, error)) {
+	fake.listComponentsMutex.Lock()
+	defer fake.listComponentsMutex.Unlock()
+	fake.ListComponentsStub = stub
+}
+
+func (fake *FakeClient) ListComponentsReturns(result1 []atc.Component, result2 error) {
+	fake.listComponentsMutex.Lock()
+	defer fake.listComponentsMutex.Unlock()
+	fake.ListComponentsStub = nil
+	fake.listComponentsReturns = struct {
+		result1 []atc.Component
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListComponentsReturnsOnCall(i int, result1 []atc.Component, result2 error) {
+	fake.listComponentsMutex.Lock()
+	defer fake.listComponentsMutex.Unlock()
+	fake.ListComponentsStub = nil
+	if fake.listComponentsReturnsOnCall == nil {
+		fake.listComponentsReturnsOnCall = make(map[int]struct {
+			result1 []atc.Component
+			result2 error
+		})
+	}
+	fake.listComponentsReturnsOnCall[i] = struct {
+		result1 []atc.Component
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) ListPipelines() ([]atc.Pipeline, error) {
 	fake.listPipelinesMutex.Lock()
 	ret, specificReturn := fake.listPipelinesReturnsOnCall[len(fake.listPipelinesArgsForCall)]
@@ -1481,6 +1591,120 @@ func (fake *FakeClient) ListWorkersReturnsOnCall(i int, result1 []atc.Worker, re
 		result1 []atc.Worker
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeClient) PauseAllComponents() error {
+	fake.pauseAllComponentsMutex.Lock()
+	ret, specificReturn := fake.pauseAllComponentsReturnsOnCall[len(fake.pauseAllComponentsArgsForCall)]
+	fake.pauseAllComponentsArgsForCall = append(fake.pauseAllComponentsArgsForCall, struct {
+	}{})
+	stub := fake.PauseAllComponentsStub
+	fakeReturns := fake.pauseAllComponentsReturns
+	fake.recordInvocation("PauseAllComponents", []interface{}{})
+	fake.pauseAllComponentsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) PauseAllComponentsCallCount() int {
+	fake.pauseAllComponentsMutex.RLock()
+	defer fake.pauseAllComponentsMutex.RUnlock()
+	return len(fake.pauseAllComponentsArgsForCall)
+}
+
+func (fake *FakeClient) PauseAllComponentsCalls(stub func() error) {
+	fake.pauseAllComponentsMutex.Lock()
+	defer fake.pauseAllComponentsMutex.Unlock()
+	fake.PauseAllComponentsStub = stub
+}
+
+func (fake *FakeClient) PauseAllComponentsReturns(result1 error) {
+	fake.pauseAllComponentsMutex.Lock()
+	defer fake.pauseAllComponentsMutex.Unlock()
+	fake.PauseAllComponentsStub = nil
+	fake.pauseAllComponentsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) PauseAllComponentsReturnsOnCall(i int, result1 error) {
+	fake.pauseAllComponentsMutex.Lock()
+	defer fake.pauseAllComponentsMutex.Unlock()
+	fake.PauseAllComponentsStub = nil
+	if fake.pauseAllComponentsReturnsOnCall == nil {
+		fake.pauseAllComponentsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pauseAllComponentsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) PauseComponent(arg1 string) error {
+	fake.pauseComponentMutex.Lock()
+	ret, specificReturn := fake.pauseComponentReturnsOnCall[len(fake.pauseComponentArgsForCall)]
+	fake.pauseComponentArgsForCall = append(fake.pauseComponentArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.PauseComponentStub
+	fakeReturns := fake.pauseComponentReturns
+	fake.recordInvocation("PauseComponent", []interface{}{arg1})
+	fake.pauseComponentMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) PauseComponentCallCount() int {
+	fake.pauseComponentMutex.RLock()
+	defer fake.pauseComponentMutex.RUnlock()
+	return len(fake.pauseComponentArgsForCall)
+}
+
+func (fake *FakeClient) PauseComponentCalls(stub func(string) error) {
+	fake.pauseComponentMutex.Lock()
+	defer fake.pauseComponentMutex.Unlock()
+	fake.PauseComponentStub = stub
+}
+
+func (fake *FakeClient) PauseComponentArgsForCall(i int) string {
+	fake.pauseComponentMutex.RLock()
+	defer fake.pauseComponentMutex.RUnlock()
+	argsForCall := fake.pauseComponentArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) PauseComponentReturns(result1 error) {
+	fake.pauseComponentMutex.Lock()
+	defer fake.pauseComponentMutex.Unlock()
+	fake.PauseComponentStub = nil
+	fake.pauseComponentReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) PauseComponentReturnsOnCall(i int, result1 error) {
+	fake.pauseComponentMutex.Lock()
+	defer fake.pauseComponentMutex.Unlock()
+	fake.PauseComponentStub = nil
+	if fake.pauseComponentReturnsOnCall == nil {
+		fake.pauseComponentReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pauseComponentReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeClient) PruneWorker(arg1 string) error {
@@ -1781,6 +2005,120 @@ func (fake *FakeClient) URLReturnsOnCall(i int, result1 string) {
 	}
 	fake.uRLReturnsOnCall[i] = struct {
 		result1 string
+	}{result1}
+}
+
+func (fake *FakeClient) UnpauseAllComponents() error {
+	fake.unpauseAllComponentsMutex.Lock()
+	ret, specificReturn := fake.unpauseAllComponentsReturnsOnCall[len(fake.unpauseAllComponentsArgsForCall)]
+	fake.unpauseAllComponentsArgsForCall = append(fake.unpauseAllComponentsArgsForCall, struct {
+	}{})
+	stub := fake.UnpauseAllComponentsStub
+	fakeReturns := fake.unpauseAllComponentsReturns
+	fake.recordInvocation("UnpauseAllComponents", []interface{}{})
+	fake.unpauseAllComponentsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) UnpauseAllComponentsCallCount() int {
+	fake.unpauseAllComponentsMutex.RLock()
+	defer fake.unpauseAllComponentsMutex.RUnlock()
+	return len(fake.unpauseAllComponentsArgsForCall)
+}
+
+func (fake *FakeClient) UnpauseAllComponentsCalls(stub func() error) {
+	fake.unpauseAllComponentsMutex.Lock()
+	defer fake.unpauseAllComponentsMutex.Unlock()
+	fake.UnpauseAllComponentsStub = stub
+}
+
+func (fake *FakeClient) UnpauseAllComponentsReturns(result1 error) {
+	fake.unpauseAllComponentsMutex.Lock()
+	defer fake.unpauseAllComponentsMutex.Unlock()
+	fake.UnpauseAllComponentsStub = nil
+	fake.unpauseAllComponentsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) UnpauseAllComponentsReturnsOnCall(i int, result1 error) {
+	fake.unpauseAllComponentsMutex.Lock()
+	defer fake.unpauseAllComponentsMutex.Unlock()
+	fake.UnpauseAllComponentsStub = nil
+	if fake.unpauseAllComponentsReturnsOnCall == nil {
+		fake.unpauseAllComponentsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.unpauseAllComponentsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) UnpauseComponent(arg1 string) error {
+	fake.unpauseComponentMutex.Lock()
+	ret, specificReturn := fake.unpauseComponentReturnsOnCall[len(fake.unpauseComponentArgsForCall)]
+	fake.unpauseComponentArgsForCall = append(fake.unpauseComponentArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.UnpauseComponentStub
+	fakeReturns := fake.unpauseComponentReturns
+	fake.recordInvocation("UnpauseComponent", []interface{}{arg1})
+	fake.unpauseComponentMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) UnpauseComponentCallCount() int {
+	fake.unpauseComponentMutex.RLock()
+	defer fake.unpauseComponentMutex.RUnlock()
+	return len(fake.unpauseComponentArgsForCall)
+}
+
+func (fake *FakeClient) UnpauseComponentCalls(stub func(string) error) {
+	fake.unpauseComponentMutex.Lock()
+	defer fake.unpauseComponentMutex.Unlock()
+	fake.UnpauseComponentStub = stub
+}
+
+func (fake *FakeClient) UnpauseComponentArgsForCall(i int) string {
+	fake.unpauseComponentMutex.RLock()
+	defer fake.unpauseComponentMutex.RUnlock()
+	argsForCall := fake.unpauseComponentArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) UnpauseComponentReturns(result1 error) {
+	fake.unpauseComponentMutex.Lock()
+	defer fake.unpauseComponentMutex.Unlock()
+	fake.UnpauseComponentStub = nil
+	fake.unpauseComponentReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) UnpauseComponentReturnsOnCall(i int, result1 error) {
+	fake.unpauseComponentMutex.Lock()
+	defer fake.unpauseComponentMutex.Unlock()
+	fake.UnpauseComponentStub = nil
+	if fake.unpauseComponentReturnsOnCall == nil {
+		fake.unpauseComponentReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.unpauseComponentReturnsOnCall[i] = struct {
+		result1 error
 	}{result1}
 }
 

--- a/go-concourse/concourse/configs.go
+++ b/go-concourse/concourse/configs.go
@@ -128,11 +128,9 @@ func (team *team) CreateOrUpdatePipelineConfig(pipelineRef atc.PipelineRef, conf
 }
 
 func merge(base, extra url.Values) url.Values {
-	if extra != nil {
-		for key, values := range extra {
-			for _, value := range values {
-				base.Add(key, value)
-			}
+	for key, values := range extra {
+		for _, value := range values {
+			base.Add(key, value)
 		}
 	}
 	return base


### PR DESCRIPTION
## Changes proposed by this PR

Implements #6820 

Internally on Concourse web nodes, everything runs as a "component". The build tracker, scheduler, garbage collection, etc., are all made up of multiple "components". It's always been technically possible to pause components, but the only way was to go into the database and run:

```sql
UPDATE components
SET paused = true;
```

This PR adds some fly commands that only admins (Owner role on `main` team) can use to manage components. The new commands are:

- `fly get-components` - Prints all components, showing when they last run, their interval, and paused status
- `fly [pause/unpause]-component` - Allows operators to pause/unpause one or more components. Can specify a `--name` flag one or more times. Has a `--all`, `--runtime-components`, and `--gc-component` flags for convenience.

In https://github.com/concourse/concourse/issues/6820#issuecomment-814184520 a concern was raised about how to inform operators about what each component does. I added the `--[runtime/gc]-components` flags since these will probably be the main components someone would want to pause. We can also document some of this in the docs.

Pausing everything also shouldn't be an issue. As noted in that issue, any builds currently running will finish running, new one just won't be started.


