### PR TITLE
web: add next steps to download fly page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/web/assets/css/download-fly.less
+++ b/web/assets/css/download-fly.less
@@ -55,7 +55,8 @@
             background-color: rgb(50, 48, 48);
             color: rgb(230, 231, 232);
             white-space: nowrap;
-            overflow: scroll;
+            overflow-y: hidden;
+            overflow-x: scroll;
 
             pre {
                 margin: 0;

--- a/web/elm/src/DownloadFly/DownloadFly.elm
+++ b/web/elm/src/DownloadFly/DownloadFly.elm
@@ -190,6 +190,7 @@ mv ./fly /usr/local/bin/"""
                 ]
             ]
         , directDownloadLink url
+        , nextSteps baseUrl
         ]
 
 
@@ -214,6 +215,7 @@ mv ./fly /usr/local/bin/"""
                 ]
             ]
         , directDownloadLink url
+        , nextSteps baseUrl
         ]
 
 
@@ -240,6 +242,61 @@ Invoke-WebRequest $concourseURL -OutFile "${concoursePath}\\fly.exe\""""
                 ]
             ]
         , directDownloadLink url
+        , nextSteps baseUrl
+        ]
+
+
+nextSteps : String -> Html msg
+nextSteps baseUrl =
+    Html.div
+        [ style "margin-top" "24px" ]
+        [ Html.div [] [ Html.text "Next, log in and set up your first pipeline:" ]
+        , Html.code
+            []
+            [ Html.pre []
+                [ Html.text <|
+                    "fly -t ci login -c "
+                        ++ baseUrl
+                ]
+            ]
+        , Html.div
+            [ style "margin-top" "16px" ]
+            [ Html.text "Save this as pipeline.yml to get started:" ]
+        , Html.code
+            []
+            [ Html.pre []
+                [ Html.text <|
+                    """jobs:
+- name: hello
+  plan:
+  - task: say-hello
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: { repository: alpine }
+      run:
+        path: echo
+        args: ["hello world"]"""
+                ]
+            ]
+        , Html.code
+            []
+            [ Html.pre []
+                [ Html.text
+                    ("fly -t ci set-pipeline -p hello -c pipeline.yml"
+                        ++ "\nfly -t ci unpause-pipeline -p hello"
+                        ++ "\nfly -t ci trigger-job -j hello/hello --watch"
+                    )
+                ]
+            ]
+        , Html.div
+            [ style "margin-top" "8px" ]
+            [ Html.text "More examples at "
+            , Html.a
+                [ href "https://github.com/concourse/examples" ]
+                [ Html.text "concourse/examples" ]
+            ]
         ]
 
 

--- a/web/elm/src/DownloadFly/DownloadFly.elm
+++ b/web/elm/src/DownloadFly/DownloadFly.elm
@@ -26,7 +26,7 @@ import DownloadFly.Model
         )
 import EffectTransformer exposing (ET)
 import Html exposing (Html)
-import Html.Attributes exposing (class, href, id, style)
+import Html.Attributes exposing (class, href, id, rel, style, target)
 import Html.Events exposing (onFocus, onInput)
 import Login.Login as Login
 import Message.Effects exposing (Effect(..))
@@ -292,9 +292,16 @@ nextSteps baseUrl =
             ]
         , Html.div
             [ style "margin-top" "8px" ]
-            [ Html.text "More examples at "
+            [ Html.text "To learn more, read our "
             , Html.a
-                [ href "https://github.com/concourse/examples" ]
+                [ href "https://concourse-ci.org/docs/getting-started/", target "_blank", rel "noopener noreferrer" ]
+                [ Html.text "Getting Started guide" ]
+            ]
+        , Html.div
+            [ style "margin-top" "8px" ]
+            [ Html.text "or examples at "
+            , Html.a
+                [ href "https://github.com/concourse/examples", target "_blank", rel "noopener noreferrer" ]
                 [ Html.text "concourse/examples" ]
             ]
         ]

--- a/web/elm/tests/DownloadFlyTests.elm
+++ b/web/elm/tests/DownloadFlyTests.elm
@@ -145,4 +145,36 @@ all =
                     installSteps
                         |> Query.contains [ expectedInstructions ]
             ]
+        , describe "next steps"
+            (let
+                viewAfterSelect =
+                    Common.initRoute Routes.DownloadFly
+                        |> Application.update (Msgs.Update <| Message.PlatformSelected "linux-amd64")
+                        |> Tuple.first
+                        |> queryView
+             in
+             [ test "shows fly login command" <|
+                \_ ->
+                    viewAfterSelect
+                        |> Query.has [ text ("fly -t ci login -c " ++ DownloadFly.defaultHostname) ]
+             , test "shows example pipeline YAML" <|
+                \_ ->
+                    viewAfterSelect
+                        |> Query.has [ text "jobs:" ]
+             , test "shows fly set-pipeline commands" <|
+                \_ ->
+                    viewAfterSelect
+                        |> Query.has [ text "fly -t ci set-pipeline -p hello -c pipeline.yml" ]
+             , test "shows Getting Started guide link" <|
+                \_ ->
+                    viewAfterSelect
+                        |> Query.find [ Selector.tag "a", attribute <| Attr.href "https://concourse-ci.org/docs/getting-started/" ]
+                        |> Query.has [ text "Getting Started guide" ]
+             , test "shows concourse/examples link" <|
+                \_ ->
+                    viewAfterSelect
+                        |> Query.find [ Selector.tag "a", attribute <| Attr.href "https://github.com/concourse/examples" ]
+                        |> Query.has [ text "concourse/examples" ]
+             ]
+            )
         ]


### PR DESCRIPTION

## Changes proposed by this PR

closes #9008

-  Added "Next steps" section to the Download Fly page after installation instructions
-  Shows `fly login` command with the Concourse URL auto-filled from browser hostname
-  Includes a ready-to-use hello world `pipeline.yml` example
-  Shows the `fly set-pipeline` command to run it
-  Links to Getting Started guide and concourse/examples for more pipeline examples
-  Displays for all platforms (Linux amd64/arm64, macOS amd64/arm64, Windows)

First-time users install fly but don't know what to do next. This adds the missing guidance right where they need it.

<img width="1380" height="525" alt="Image" src="https://github.com/user-attachments/assets/f0892724-1f29-4488-852e-0b9c16ef2036" />

<img width="1019" height="505" alt="Image" src="https://github.com/user-attachments/assets/568709b2-eed2-423f-bbc0-85c8f7d39e0d" />

<img width="834" height="885" alt="Image" src="https://github.com/user-attachments/assets/5a06a0b7-1307-4eff-b9af-8744ca00b719" />

<img width="784" height="679" alt="Image" src="https://github.com/user-attachments/assets/87f0855b-06db-48a2-88fc-34052663cdc3" />

<img width="1919" height="399" alt="Image" src="https://github.com/user-attachments/assets/3cdd2ec0-4abb-42db-a548-6739cd9f2fa3" />


## Notes to reviewer

- Only `web/elm/src/DownloadFly/DownloadFly.elm` was changed
- Uses the same `Html.code`/`Html.pre` styling already used by the install steps — no new CSS
- The hostname was already available in the model via `GetHostname` — no new plumbing needed
- No changes to the dashboard welcome card

## Release Note

The Download Fly page now shows next steps after installation: how to log in, a hello world pipeline example, and the set-pipeline command.
