### PR TITLE
Have lidar check non-triggering input resources that have no versions or errored

### DIFF
--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -53,8 +53,8 @@ type CheckFactory interface {
 	TryCreateCheck(ctx context.Context, checkable Checkable, resourceTypes ResourceTypes, from atc.Version, manuallyTriggered bool, skipIntervalRecursively bool, toDb bool) (Build, bool, error)
 
 	// Returns all resources that are triggers for jobs, excluding those with
-	// passed constraints. Will also return resources that have errored or never
-	// been checked.
+	// passed constraints. Will also return resources that have errored, never
+	// been checked, or are inputs and have no versions in their version history.
 	Resources() ([]Resource, error)
 	ResourceTypesByPipeline() (map[int]ResourceTypes, error)
 	Drain()
@@ -165,14 +165,14 @@ func (c *checkFactory) Resources() ([]Resource, error) {
 	var resources []Resource
 
 	rows, err := resourcesQuery.
-		LeftJoin("(select DISTINCT(resource_id) FROM job_inputs WHERE trigger = true and passed_job_id IS NULL) ji ON ji.resource_id = r.id").
+		LeftJoin("(SELECT resource_id, bool_or(trigger) AS trigger FROM job_inputs WHERE passed_job_id IS NULL GROUP BY resource_id) ji ON ji.resource_id = r.id").
 		Where(sq.And{
 			sq.Eq{"p.paused": false},
 		}).
 		Where(sq.Or{
 			sq.And{
-				// find all resources that are inputs to jobs
-				sq.NotEq{"ji.resource_id": nil},
+				// find all resources that are triggering inputs to jobs
+				sq.Eq{"ji.trigger": true},
 			},
 			sq.And{
 				// find resources that have errored or never been checked
@@ -180,7 +180,20 @@ func (c *checkFactory) Resources() ([]Resource, error) {
 					sq.Eq{"rs.last_check_build_id": nil},
 					sq.Eq{"rs.last_check_succeeded": false},
 				},
-				sq.Eq{"ji.resource_id": nil},
+				// that are put-only or non-triggering resources
+				sq.Or{
+					sq.Eq{"ji.resource_id": nil},
+					sq.Eq{"ji.trigger": false},
+				},
+			},
+			sq.And{
+				// find non-triggering input resources that have no versions in
+				// their version history
+				sq.Eq{"ji.trigger": false},
+				sq.Expr(`NOT EXISTS (SELECT 1
+				          FROM resource_config_versions rcv
+				          WHERE rcv.resource_config_scope_id = r.resource_config_scope_id
+				        )`),
 			},
 		}).
 		OrderBy("r.id ASC").

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -465,8 +465,8 @@ var _ = Describe("CheckFactory", func() {
 		Context("when all resources have been previously checked successfully", func() {
 			BeforeEach(func() {
 				scenario.Run(
-					builder.WithResourceVersions("some-resource", time.Minute),
-					builder.WithResourceVersions("some-resource-trigger", time.Minute),
+					builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"ref": "r1"}),
+					builder.WithResourceVersions("some-resource-trigger", time.Minute, atc.Version{"ref": "r1"}),
 					builder.WithResourceVersions("some-put-only-resource", time.Minute),
 				)
 			})
@@ -503,7 +503,7 @@ var _ = Describe("CheckFactory", func() {
 			Context("has failed its last check", func() {
 				BeforeEach(func() {
 					scenario.Run(
-						builder.WithResourceVersions("some-resource", time.Minute),
+						builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"ref": "r1"}),
 						builder.WithResourceVersions("some-resource-trigger", time.Minute),
 						builder.WithFailingResourceCheck("some-put-only-resource", time.Minute),
 					)
@@ -522,7 +522,7 @@ var _ = Describe("CheckFactory", func() {
 				BeforeEach(func() {
 					By("creating successful builds for all resources")
 					scenario.Run(
-						builder.WithResourceVersions("some-resource", time.Minute),
+						builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"ref": "r1"}),
 						builder.WithResourceVersions("some-resource-trigger", time.Minute),
 						builder.WithResourceVersions("some-put-only-resource", time.Minute),
 					)
@@ -532,6 +532,49 @@ var _ = Describe("CheckFactory", func() {
 					Expect(resources).To(HaveLen(1))
 					Expect(resources[0].Name()).To(Equal("some-resource-trigger"))
 				})
+			})
+		})
+
+		Context("when a resource has been checked successfully but has no versions", func() {
+			BeforeEach(func() {
+				scenario.Run(
+					builder.WithResourceVersions("some-resource-trigger", time.Minute, atc.Version{"ref": "r1"}),
+					builder.WithResourceVersions("some-resource", time.Minute),
+					builder.WithResourceVersions("some-put-only-resource", time.Minute),
+				)
+			})
+
+			It("returns the resource with no versions", func() {
+				Expect(resources).To(HaveLen(2))
+
+				resourceNames := []string{}
+				for _, r := range resources {
+					resourceNames = append(resourceNames, r.Name())
+				}
+
+				Expect(resourceNames).To(ConsistOf("some-resource-trigger", "some-resource"))
+			})
+		})
+
+		Context("when a non-triggering resource fails its last check", func() {
+			BeforeEach(func() {
+				scenario.Run(
+					builder.WithResourceVersions("some-resource-trigger", time.Minute, atc.Version{"ref": "r1"}),
+					builder.WithResourceVersions("some-put-only-resource", time.Minute),
+					builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"ref": "r1"}),
+					builder.WithFailingResourceCheck("some-resource", time.Minute),
+				)
+			})
+
+			It("returns the erroring resource", func() {
+				Expect(resources).To(HaveLen(2))
+
+				resourceNames := []string{}
+				for _, r := range resources {
+					resourceNames = append(resourceNames, r.Name())
+				}
+
+				Expect(resourceNames).To(ConsistOf("some-resource-trigger", "some-resource"))
 			})
 		})
 	})


### PR DESCRIPTION
## Changes proposed by this PR

Related to changes made in https://github.com/concourse/concourse/pull/9492

Edge-case here. I realized a job may never trigger if for some reason one of the non-triggering inputs hadn't found any versions yet. We should continue to automatically check those resources until a version is found.