### PR TITLE
set spec-level timeout for testflight suite at 6mins

### DIFF
--- a/testflight/across_test.go
+++ b/testflight/across_test.go
@@ -11,7 +11,7 @@ var _ = Describe("A pipeline containing an across step", func() {
 		setAndUnpausePipeline("fixtures/across.yml")
 	})
 
-	It("performs the across steps", func() {
+	It("performs the across steps", func(ctx SpecContext) {
 		watch := fly("trigger-job", "-j", inPipeline("job"), "-w")
 
 		Expect(watch).To(gbytes.Say("running across static1 dynamic1"))
@@ -31,5 +31,5 @@ var _ = Describe("A pipeline containing an across step", func() {
 		Expect(watch).To(gbytes.Say("fetching version: v_dynamic3"))
 		Expect(watch).To(gbytes.Say("pushing version: v_4"))
 		Expect(watch).To(gbytes.Say("fetching version: v_4"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/automatic_archiving_test.go
+++ b/testflight/automatic_archiving_test.go
@@ -40,7 +40,7 @@ var _ = Describe("archive-pipeline", func() {
 	})
 
 	Context("when the step is removed from the parent pipeline config", func() {
-		It("archives the child pipeline", func() {
+		It("archives the child pipeline", func(ctx SpecContext) {
 			execS := fly("get-pipeline", "-p", childPipeline)
 			Expect(execS.Out).To(gbytes.Say("normal-job"))
 
@@ -51,7 +51,7 @@ var _ = Describe("archive-pipeline", func() {
 			Eventually(func() *gbytes.Buffer {
 				return flyUnsafe("get-pipeline", "-p", childPipeline).Err
 			}, timeout, interval).Should(gbytes.Say("pipeline not found"), "the pipeline should be archived")
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when the parent pipeline is deleted", func() {
@@ -59,11 +59,11 @@ var _ = Describe("archive-pipeline", func() {
 			fly("destroy-pipeline", "-n", "-p", parentPipeline)
 		})
 
-		It("archives the child pipeline", func() {
+		It("archives the child pipeline", func(ctx SpecContext) {
 			Eventually(func() *gbytes.Buffer {
 				return flyUnsafe("get-pipeline", "-p", childPipeline).Err
 			}, timeout, interval).Should(gbytes.Say("pipeline not found"), "the pipeline should be archived")
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when the parent pipeline is archived", func() {
@@ -71,15 +71,15 @@ var _ = Describe("archive-pipeline", func() {
 			fly("archive-pipeline", "-n", "-p", parentPipeline)
 		})
 
-		It("archives the child pipeline", func() {
+		It("archives the child pipeline", func(ctx SpecContext) {
 			Eventually(func() *gbytes.Buffer {
 				return flyUnsafe("get-pipeline", "-p", childPipeline).Err
 			}, timeout, interval).Should(gbytes.Say("pipeline not found"), "the pipeline should be archived")
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when the job is removed from the parent pipeline config", func() {
-		It("archives the child pipeline", func() {
+		It("archives the child pipeline", func(ctx SpecContext) {
 			execS := fly("get-pipeline", "-p", childPipeline)
 			Expect(execS.Out).To(gbytes.Say("normal-job"))
 
@@ -88,6 +88,6 @@ var _ = Describe("archive-pipeline", func() {
 			Eventually(func() *gbytes.Buffer {
 				return flyUnsafe("get-pipeline", "-p", childPipeline).Err
 			}, timeout, interval).Should(gbytes.Say("pipeline not found"), "the pipeline should be archived")
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/build_events_test.go
+++ b/testflight/build_events_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var _ = Describe("Build Events", func() {
-	It("across steps log errors from sub-steps", func() {
+	It("across steps log errors from sub-steps", func(ctx SpecContext) {
 		setAndUnpausePipeline("fixtures/erroring_pipeline.yml")
 		sess := spawnFly("trigger-job", "-j", inPipeline("across-step"), "-w")
 		wait(sess, true)
@@ -29,5 +29,5 @@ var _ = Describe("Build Events", func() {
 		buildEvents := sess.Out.Contents()
 		errEvents := strings.Count(string(buildEvents), `"event":"error"`)
 		Expect(errEvents).To(Equal(2))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/caching_test.go
+++ b/testflight/caching_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Resource caching", func() {
 		setAndUnpausePipeline("fixtures/caching.yml")
 	})
 
-	It("does not fetch if there is nothing new", func() {
+	It("does not fetch if there is nothing new", func(ctx SpecContext) {
 		someResourceV1 := newMockVersion("some-resource", "some1")
 		cachedResourceV1 := newMockVersion("cached-resource", "cached1")
 
@@ -31,5 +31,5 @@ var _ = Describe("Resource caching", func() {
 		Expect(watch).NotTo(gbytes.Say("fetching"))
 		Expect(watch).To(gbytes.Say("succeeded"))
 		Expect(watch).To(gexec.Exit(0))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/clear_task_cache_test.go
+++ b/testflight/clear_task_cache_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Clear task cache", func() {
 		setAndUnpausePipeline("fixtures/clear-task-cache.yml")
 	})
 
-	It("clears the task's cache", func() {
+	It("clears the task's cache", func(ctx SpecContext) {
 		By("warming the cache")
 		watch := fly("trigger-job", "-j", inPipeline("clear-task-cache"), "-w")
 		Expect(watch).To(gbytes.Say("created-cache-file"))
@@ -29,5 +29,5 @@ var _ = Describe("Clear task cache", func() {
 		watch = fly("trigger-job", "-j", inPipeline("clear-task-cache"), "-w")
 		Expect(watch).To(gbytes.Say("created-cache-file"))
 		Expect(watch).NotTo(gbytes.Say("the-cached-file-already-exists"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/config_params_test.go
+++ b/testflight/config_params_test.go
@@ -12,14 +12,14 @@ var _ = Describe("Configuring a resource in a pipeline config", func() {
 	})
 
 	Context("when specifying file in task config", func() {
-		It("executes the file with params specified in file", func() {
+		It("executes the file with params specified in file", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("file-test"), "-w")
 			Expect(watch).To(gbytes.Say("file_source"))
-		})
+		}, DefaultSpecTimeout)
 
-		It("executes the file with job params", func() {
+		It("executes the file with job params", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("file-params-test"), "-w")
 			Expect(watch).To(gbytes.Say("job_params_source"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/config_test.go
+++ b/testflight/config_test.go
@@ -11,8 +11,8 @@ var _ = Describe("Configuring a resource with nested configuration", func() {
 		setAndUnpausePipeline("fixtures/nested-config-test.yml")
 	})
 
-	It("works", func() {
+	It("works", func(ctx SpecContext) {
 		watch := fly("trigger-job", "-j", inPipeline("config-test"), "-w")
 		Expect(watch).To(gexec.Exit(0))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/container_hermetic_test.go
+++ b/testflight/container_hermetic_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ = Describe("A job with a task that has hermetic set to true", func() {
-	It("runs the build", func() {
+	It("runs the build", func(ctx SpecContext) {
 
 		setAndUnpausePipeline("fixtures/container_hermetic.yml")
 
@@ -23,5 +23,5 @@ var _ = Describe("A job with a task that has hermetic set to true", func() {
 			Expect(watch).To(gbytes.Say("1 packets transmitted, 1 packets received, 0% packet loss"))
 			Expect(watch.ExitCode()).To(Equal(0))
 		}
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/container_limits_test.go
+++ b/testflight/container_limits_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("A job with a task that has container limits", func() {
-	It("successfully runs the build", func() {
+	It("successfully runs the build", func(ctx SpecContext) {
 		setAndUnpausePipeline("fixtures/container_limits.yml")
 
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-limits-job"), "-w")
@@ -26,9 +26,9 @@ var _ = Describe("A job with a task that has container limits", func() {
 
 		Expect(watch).To(gbytes.Say("initializing"))
 		Expect(watch).To(gbytes.Say("hello"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("sets the correct CPU and memory limits on the container", func() {
+	It("sets the correct CPU and memory limits on the container", func(ctx SpecContext) {
 		if config.Runtime == "guardian" && cgroupsV2Only() {
 			Skip("guardian runtime doesn't mount /sys/fs/cgroup on systems only using cgroup V2. See https://github.com/cloudfoundry/garden-runc-release/issues/384")
 		}
@@ -80,5 +80,5 @@ var _ = Describe("A job with a task that has container limits", func() {
 		// TODO-2025-10: The value returned is now 59. No clue why still and no
 		// time to currently investigate.
 		Expect(interceptS).To(Or(gbytes.Say("512"), gbytes.Say("20"), gbytes.Say("59")))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/containers_scoped_to_team_test.go
+++ b/testflight/containers_scoped_to_team_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Intercepting containers", func() {
 		setAndUnpausePipeline("fixtures/wait-for-intercept.yml")
 	})
 
-	It("is limited to the team that owns the containers", func() {
+	It("is limited to the team that owns the containers", func(ctx SpecContext) {
 		By("triggering the build")
 		wait := spawnFly("trigger-job", "-w", "-j", inPipeline("wait"))
 		Eventually(wait).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
@@ -40,5 +40,5 @@ var _ = Describe("Intercepting containers", func() {
 
 		<-wait.Exited
 		Expect(wait).To(gbytes.Say("done"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/custom_resource_check_test.go
+++ b/testflight/custom_resource_check_test.go
@@ -11,12 +11,12 @@ var _ = Describe("When a resource type depends on another resource type", func()
 		setAndUnpausePipeline("fixtures/recursive-resource-checking.yml")
 	})
 
-	It("can be checked recursively", func() {
+	It("can be checked recursively", func(ctx SpecContext) {
 		check := fly("check-resource", "-r", inPipeline("recursive-custom-resource"))
 		Expect(check).To(gbytes.Say("recursive-custom-resource"))
 		Expect(check).To(gbytes.Say("mock-resource-grandchild"))
 		Expect(check).To(gbytes.Say("mock-resource-child"))
 		Expect(check).To(gbytes.Say("mock-resource-parent"))
 		Expect(check).To(gbytes.Say("succeeded"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/devices_test.go
+++ b/testflight/devices_test.go
@@ -7,18 +7,18 @@ import (
 )
 
 var _ = Describe("Devices", func() {
-	It("mounts the /dev/fuse device to privileged containers", func() {
+	It("mounts the /dev/fuse device to privileged containers", func(ctx SpecContext) {
 		setAndUnpausePipeline("fixtures/devices.yml")
 
 		watch := fly("trigger-job", "-j", inPipeline("check-fuse-privileged"), "-w")
 		Expect(watch).To(gbytes.Say("succeeded"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("does not mount the /dev/fuse device to unprivileged containers", func() {
+	It("does not mount the /dev/fuse device to unprivileged containers", func(ctx SpecContext) {
 		setAndUnpausePipeline("fixtures/devices.yml")
 
 		watch := flyUnsafe("trigger-job", "-j", inPipeline("check-fuse-unprivileged"), "-w")
 		Expect(watch.ExitCode()).ToNot(Equal(0))
 		Expect(watch).To(gbytes.Say("No such file or directory"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/do_test.go
+++ b/testflight/do_test.go
@@ -11,7 +11,7 @@ var _ = Describe("A pipeline containing a do", func() {
 		setAndUnpausePipeline("fixtures/do.yml")
 	})
 
-	It("performs the do steps", func() {
+	It("performs the do steps", func(ctx SpecContext) {
 		watch := fly("trigger-job", "-j", inPipeline("do-job"), "-w")
 
 		By("running the first step")
@@ -22,5 +22,5 @@ var _ = Describe("A pipeline containing a do", func() {
 
 		By("running the third step")
 		Expect(watch).To(gbytes.Say("running do step 3"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/download_cli_test.go
+++ b/testflight/download_cli_test.go
@@ -27,9 +27,9 @@ var _ = Describe("Download Fly CLI", func() {
 		config.FlyBin = beforeFly
 	})
 
-	It("can download fly CLI without issue", func() {
+	It("can download fly CLI without issue", func(ctx SpecContext) {
 		watch := fly("sync", "--force")
 		Expect(watch).ToNot(gbytes.Say("warning: failed to parse Content-Length"))
 		Expect(watch).To(gbytes.Say("done"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/fail_test.go
+++ b/testflight/fail_test.go
@@ -12,11 +12,11 @@ var _ = Describe("A job with a task that always fails", func() {
 		setAndUnpausePipeline("fixtures/fail.yml")
 	})
 
-	It("causes the build to fail", func() {
+	It("causes the build to fail", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("failing-job"), "-w")
 		<-watch.Exited
 		Expect(watch).To(gbytes.Say("initializing"))
 		Expect(watch).To(gbytes.Say("failed"))
 		Expect(watch).To(gexec.Exit(1))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/flying_test.go
+++ b/testflight/flying_test.go
@@ -73,20 +73,20 @@ run:
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("works", func() {
+	It("works", func(ctx SpecContext) {
 		execS := flyIn(tmp, "execute", "-c", "task.yml", "-i", "fixture=./fixture", "-i", "input-1=./input-1", "-i", "input-2=./input-2", "--", "SOME", "ARGS")
 		Expect(execS).To(gbytes.Say("some output"))
 		Expect(execS).To(gbytes.Say("FOO is 1"))
 		Expect(execS).To(gbytes.Say("ARGS are SOME ARGS"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("works in background", func() {
+	It("works in background", func(ctx SpecContext) {
 		execS := flyIn(tmp, "execute", "-c", "task.yml", "-i", "fixture=./fixture", "-i", "input-1=./input-1", "-i", "input-2=./input-2", "--background", "--", "SOME", "ARGS")
 		Eventually(execS).Should(gbytes.Say("executing build"))
-	})
+	}, DefaultSpecTimeout)
 
 	Describe("hijacking", func() {
-		It("executes an interactive command in a running task's container", func() {
+		It("executes an interactive command in a running task's container", func(ctx SpecContext) {
 			err := os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
@@ -114,7 +114,7 @@ cat < /tmp/fifo
 
 			Eventually(execS).Should(gbytes.Say("marco"))
 			Eventually(execS).Should(gexec.Exit(0))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Describe("uploading inputs with and without --include-ignored", func() {
@@ -164,7 +164,7 @@ cp -a input-2/. output-2/
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("uploads git repo input and non git repo input, IGNORING things in the .gitignore for git repo inputs", func() {
+		It("uploads git repo input and non git repo input, IGNORING things in the .gitignore for git repo inputs", func(ctx SpecContext) {
 			flyIn(tmp, "execute", "-c", "task.yml", "-i", "fixture=./fixture", "-i", "input-1=./input-1", "-i", "input-2=./input-2", "-o", "output-1=./output-1", "-o", "output-2=./output-2")
 
 			fileToBeIgnoredPath := filepath.Join(tmp, "output-1", "expect-not-to.exist")
@@ -178,9 +178,9 @@ cp -a input-2/. output-2/
 			Expect(os.ReadFile(fileToBeIncludedPath)).To(Equal([]byte("included file content")))
 			Expect(os.ReadFile(file1)).To(Equal([]byte("file-1 contents")))
 			Expect(os.ReadFile(file2)).To(Equal([]byte("file-2 contents")))
-		})
+		}, DefaultSpecTimeout)
 
-		It("uploads git repo input and non git repo input, INCLUDING things in the .gitignore for git repo inputs", func() {
+		It("uploads git repo input and non git repo input, INCLUDING things in the .gitignore for git repo inputs", func(ctx SpecContext) {
 			flyIn(tmp, "execute", "--include-ignored", "-c", "task.yml", "-i", "fixture=./fixture", "-i", "input-1=./input-1", "-i", "input-2=./input-2", "-o", "output-1=./output-1", "-o", "output-2=./output-2")
 
 			fileToBeIgnoredPath := filepath.Join(tmp, "output-1", "expect-not-to.exist")
@@ -192,11 +192,11 @@ cp -a input-2/. output-2/
 			Expect(os.ReadFile(fileToBeIncludedPath)).To(Equal([]byte("included file content")))
 			Expect(os.ReadFile(file1)).To(Equal([]byte("file-1 contents")))
 			Expect(os.ReadFile(file2)).To(Equal([]byte("file-2 contents")))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Describe("pulling down outputs", func() {
-		It("works", func() {
+		It("works", func(ctx SpecContext) {
 			err := os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
@@ -214,11 +214,11 @@ echo world > output-2/file-2
 
 			Expect(os.ReadFile(file1)).To(Equal([]byte("hello\n")))
 			Expect(os.ReadFile(file2)).To(Equal([]byte("world\n")))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Describe("aborting", func() {
-		It("terminates the running task", func() {
+		It("terminates the running task", func(ctx SpecContext) {
 			err := os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
@@ -242,11 +242,11 @@ wait
 
 			// build should have been aborted
 			Eventually(execS).Should(gexec.Exit(3))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when an optional input is not provided", func() {
-		It("runs the task without error", func() {
+		It("runs the task without error", func(ctx SpecContext) {
 			err := os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
@@ -261,7 +261,7 @@ ls`),
 			Expect(fileList).To(ContainSubstring("fixture"))
 			Expect(fileList).To(ContainSubstring("input-1"))
 			Expect(fileList).NotTo(ContainSubstring("input-2"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when execute with -j inputs-from", func() {
@@ -291,7 +291,7 @@ run:
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("runs the task without error", func() {
+		It("runs the task without error", func(ctx SpecContext) {
 			By("having an initial version")
 			fly("check-resource", "-r", pipelineName+"/some-resource", "-f", "version:first-version")
 
@@ -321,7 +321,7 @@ run:
 			By("now executing using the second version via -j")
 			execS = flyIn(tmp, "execute", "-c", "task.yml", "-j", pipelineName+"/downstream-job")
 			Expect(execS).To(gbytes.Say("second-version"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when execute with -j inputs-from and task has input mapping", func() {
@@ -354,7 +354,7 @@ run:
 			fly("unpause-pipeline", "-p", pipelineName)
 		})
 
-		It("runs the task without error", func() {
+		It("runs the task without error", func(ctx SpecContext) {
 			By("having an initial version")
 			fly("check-resource", "-r", pipelineName+"/some-resource", "-f", "version:first-version")
 
@@ -384,7 +384,7 @@ run:
 			By("now executing using the second version via -j")
 			execS = flyIn(tmp, "execute", "-c", "task.yml", "-j", pipelineName+"/downstream-job", "-m", "mapped-resource=some-resource")
 			Expect(execS).To(gbytes.Say("second-version"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when execute with -j inputs-from and task has no image_resource specified", func() {
@@ -413,7 +413,7 @@ run:
 			fly("unpause-pipeline", "-p", pipelineName)
 		})
 
-		It("runs the task without error", func() {
+		It("runs the task without error", func(ctx SpecContext) {
 			By("having an initial version")
 			fly("check-resource", "-r", pipelineName+"/some-resource", "-f", "version:first-version")
 
@@ -443,7 +443,7 @@ run:
 			By("now executing using the second version via -j")
 			execS = flyIn(tmp, "execute", "-c", "task.yml", "-j", pipelineName+"/downstream-job", "--image", "some-image")
 			Expect(execS).To(gbytes.Say("second-version"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when the input is custom resource", func() {
@@ -478,10 +478,10 @@ run:
 				fly("trigger-job", "-w", "-j", pipelineName+"/input-test")
 			})
 
-			It("runs the task without error by infer the pipeline resource types from -j", func() {
+			It("runs the task without error by infer the pipeline resource types from -j", func(ctx SpecContext) {
 				execS := flyIn(tmp, "execute", "-c", "task.yml", "-j", pipelineName+"/input-test")
 				Expect(execS).To(gbytes.Say("custom-type-version"))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Context("when -j is not specified and local input in custom resource type is provided", func() {
@@ -496,10 +496,10 @@ echo hello from fixture
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("runs the task without error", func() {
+			It("runs the task without error", func(ctx SpecContext) {
 				execS := flyIn(tmp, "execute", "-c", "task.yml", "-i", "some-resource=./fixture")
 				Expect(execS).To(gbytes.Say("hello from fixture"))
-			})
+			}, DefaultSpecTimeout)
 		})
 	})
 })

--- a/testflight/hooks_test.go
+++ b/testflight/hooks_test.go
@@ -12,7 +12,7 @@ var _ = Describe("A pipeline containing jobs with hooks", func() {
 		setAndUnpausePipeline("fixtures/hooks.yml")
 	})
 
-	It("performs hooks under the right conditions", func() {
+	It("performs hooks under the right conditions", func(ctx SpecContext) {
 		By("performing ensure and on_success outputs on success")
 		watch := spawnFly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 		<-watch.Exited
@@ -76,5 +76,5 @@ var _ = Describe("A pipeline containing jobs with hooks", func() {
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("errored job on job failure"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("errored job on abort"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("errored job on job abort"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/idtoken_test.go
+++ b/testflight/idtoken_test.go
@@ -37,7 +37,7 @@ var _ = Describe("A pipeline containing idtoken var sources", Ordered, func() {
 		outputText = watch.Buffer().Contents()
 	})
 
-	It("creates valid default idtoken", func() {
+	It("creates valid default idtoken", func(ctx SpecContext) {
 		D1 := extractIDtokenFromBuffer(outputText, "D1")
 		D2 := extractIDtokenFromBuffer(outputText, "D2")
 		token := D1 + D2
@@ -53,9 +53,9 @@ var _ = Describe("A pipeline containing idtoken var sources", Ordered, func() {
 		Expect(claims.Team).To(Equal(teamName))
 		Expect(claims.Pipeline).To(Equal(testPipelineName))
 		Expect(claims.Subject).To(Equal(teamName + "/" + testPipelineName))
-	})
+	}, DefaultSpecTimeout)
 
-	It("creates valid custom idtoken", func() {
+	It("creates valid custom idtoken", func(ctx SpecContext) {
 		C1 := extractIDtokenFromBuffer(outputText, "C1")
 		C2 := extractIDtokenFromBuffer(outputText, "C2")
 		token := C1 + C2
@@ -73,9 +73,9 @@ var _ = Describe("A pipeline containing idtoken var sources", Ordered, func() {
 
 		Expect(parsed.Headers[0].Algorithm).To(Equal("ES256"))
 		Expect(claims.Subject).To(Equal(teamName))
-	})
+	}, DefaultSpecTimeout)
 
-	It("publishes correct issuer in OpenID configuration", func() {
+	It("publishes correct issuer in OpenID configuration", func(ctx SpecContext) {
 		cfg, err := getOpenIDConfiguration(config.ATCURL)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -86,7 +86,7 @@ var _ = Describe("A pipeline containing idtoken var sources", Ordered, func() {
 		jwksURI, ok := cfg["jwks_uri"].(string)
 		Expect(ok).To(BeTrue())
 		Expect(jwksURI).To(Equal(issuer + "/.well-known/jwks.json"))
-	})
+	}, DefaultSpecTimeout)
 })
 
 func extractIDtokenFromBuffer(buffer []byte, identifier string) string {

--- a/testflight/image_resource_caching_test.go
+++ b/testflight/image_resource_caching_test.go
@@ -26,7 +26,7 @@ var _ = Describe("image resource caching", func() {
 		)
 	})
 
-	It("gets the image resource from the cache based on given params", func() {
+	It("gets the image resource from the cache based on given params", func(ctx SpecContext) {
 		By("triggering the resource get with params")
 		watch := fly("trigger-job", "-j", inPipeline("with-params"), "-w")
 		Expect(watch).To(gbytes.Say(`fetching.*` + version))
@@ -42,5 +42,5 @@ var _ = Describe("image resource caching", func() {
 		By("triggering the resource get without params")
 		watch = fly("trigger-job", "-j", inPipeline("without-params"), "-w")
 		Expect(watch).ToNot(gbytes.Say(`fetching.*` + version))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/image_resource_test.go
+++ b/testflight/image_resource_test.go
@@ -30,7 +30,7 @@ ls /bin
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("propagates the rootfs and metadata to the task", func() {
+	It("propagates the rootfs and metadata to the task", func(ctx SpecContext) {
 		err := os.WriteFile(
 			filepath.Join(fixture, "task.yml"),
 			[]byte(`---
@@ -61,9 +61,9 @@ run:
 		wait(exec, false)
 		Expect(exec).To(gbytes.Say("/opt/resource/check"))
 		Expect(exec).To(gbytes.Say("VERSION=hello-version"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("allows a version to be specified", func() {
+	It("allows a version to be specified", func(ctx SpecContext) {
 		err := os.WriteFile(
 			filepath.Join(fixture, "task.yml"),
 			[]byte(`---
@@ -87,5 +87,5 @@ run:
 		exec := spawnFlyIn(fixture, "execute", "-c", "task.yml")
 		wait(exec, false)
 		Expect(exec).To(gbytes.Say("VERSION=hi-im-a-version"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/input_overriding_test.go
+++ b/testflight/input_overriding_test.go
@@ -74,7 +74,7 @@ run:
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("can have its inputs used as the basis for a one-off build", func() {
+	It("can have its inputs used as the basis for a one-off build", func(ctx SpecContext) {
 		By("waiting for an initial build so the job has inputs")
 		watch := fly("trigger-job", "-j", inPipeline("some-job"), "-w")
 		Expect(watch).To(gbytes.Say("initializing"))
@@ -100,5 +100,5 @@ run:
 		Expect(execute).To(gbytes.Say("a has " + firstVersionA))
 		Expect(execute).To(gbytes.Say("b has some-overridden-version"))
 		Expect(execute).To(gbytes.Say("succeeded"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/intercept_shell_test.go
+++ b/testflight/intercept_shell_test.go
@@ -17,7 +17,7 @@ var _ = Describe("fly intercept default shell", func() {
 	const testBash = `[ -n "$BASH_VERSION" ] && echo "yes bash" || echo "no bash"` + "\n"
 
 	Context("when the container has bash", func() {
-		It("defaults to bash", func() {
+		It("defaults to bash", func(ctx SpecContext) {
 			By("triggering the build")
 			wait := spawnFly("trigger-job", "-w", "-j", inPipeline("wait"))
 			Eventually(wait).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
@@ -31,11 +31,11 @@ var _ = Describe("fly intercept default shell", func() {
 			Eventually(session, 10*time.Second).Should(gbytes.Say("yes bash"))
 
 			session.Kill()
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when the container does not have bash", func() {
-		It("falls back to sh", func() {
+		It("falls back to sh", func(ctx SpecContext) {
 			By("triggering the build")
 			wait := spawnFly("trigger-job", "-w", "-j", inPipeline("wait"))
 			Eventually(wait).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
@@ -53,6 +53,6 @@ var _ = Describe("fly intercept default shell", func() {
 			Eventually(session, 10*time.Second).Should(gbytes.Say("no bash"))
 
 			session.Kill()
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/list_builds_test.go
+++ b/testflight/list_builds_test.go
@@ -60,13 +60,13 @@ var _ = Describe("fly builds command", func() {
 	})
 
 	Context("when no flags passed", func() {
-		It("displays the right info", func() {
+		It("displays the right info", func(ctx SpecContext) {
 			sess := fly("builds", "-p", testflightExposedPipeline)
 			Expect(sess).To(gbytes.Say(testflightExposedPipeline + "/some-passing-job"))
 
 			sess = fly("builds", "-p", testflightHiddenPipeline)
 			Expect(sess).To(gbytes.Say(testflightHiddenPipeline + "/some-passing-job"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when specifying since and until", func() {
@@ -93,7 +93,7 @@ var _ = Describe("fly builds command", func() {
 			})
 		})
 
-		It("displays only builds that happened within that range of time", func() {
+		It("displays only builds that happened within that range of time", func(ctx SpecContext) {
 			var decodedBuilds []decodedBuild
 			withFlyTarget(adminFlyTarget, func() {
 				sess := fly("builds",
@@ -107,17 +107,17 @@ var _ = Describe("fly builds command", func() {
 			})
 
 			Expect(decodedBuilds).To(ConsistOf(allDecodedBuilds[1], allDecodedBuilds[2], allDecodedBuilds[3]))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when specifying values for team flag", func() {
-		It("retrieves only builds for the teams specified", func() {
+		It("retrieves only builds for the teams specified", func(ctx SpecContext) {
 			withFlyTarget(adminFlyTarget, func() {
 				sess := fly("builds", "--team=testflight", "--count=1000")
 				Expect(sess).To(gbytes.Say(testflightExposedPipeline))
 				Expect(sess).To(gbytes.Say("testflight"), "shows the team name")
 				Expect(sess).NotTo(gbytes.Say(mainExposedPipeline))
 			})
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/load_var_step_test.go
+++ b/testflight/load_var_step_test.go
@@ -9,7 +9,7 @@ var _ = Describe("load_var Step", func() {
 		setAndUnpausePipeline("fixtures/load-var-step.yml")
 	})
 
-	It("uses the load_var step build execution", func() {
+	It("uses the load_var step build execution", func(ctx SpecContext) {
 		fly("trigger-job", "-j", inPipeline("use-var"), "-w")
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/matrix_test.go
+++ b/testflight/matrix_test.go
@@ -22,11 +22,11 @@ var _ = Describe("A job with a complicated build plan", func() {
 		)
 	})
 
-	It("executes the build plan correctly", func() {
+	It("executes the build plan correctly", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("fancy-build-matrix"), "-w")
 		<-watch.Exited
 		Expect(watch.ExitCode()).To(Equal(1)) // expect failure
 		Expect(watch).To(gbytes.Say("passing-unit-1/file passing-unit-2/file " + initialVersion))
 		Expect(watch).To(gbytes.Say("failed in_parallel " + initialVersion))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/optional_inputs_test.go
+++ b/testflight/optional_inputs_test.go
@@ -11,11 +11,11 @@ var _ = Describe("A pipeline using optional inputs", func() {
 		setAndUnpausePipeline("fixtures/optional-inputs.yml")
 	})
 
-	It("works ok even if optional inputs are missing", func() {
+	It("works ok even if optional inputs are missing", func(ctx SpecContext) {
 		watch := fly("trigger-job", "-j", inPipeline("job-using-optional-inputs"), "-w")
 		Expect(watch).To(gbytes.Say("step 1 complete"))
 		Expect(watch).To(gbytes.Say("step 2 complete"))
 		Expect(watch).To(gbytes.Say("step 3 complete"))
 		Expect(watch).To(gbytes.Say("SUCCESS"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/pin_resource_test.go
+++ b/testflight/pin_resource_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Pin a resource", func() {
 			someResourceV2 = newMockVersion("some-resource", "bar")
 		})
 
-		It("can pin the resource with given version and comment", func() {
+		It("can pin the resource with given version and comment", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 			Expect(watch).To(gbytes.Say("fetching.*" + someResourceV2))
 			Expect(watch).To(gbytes.Say("succeeded"))
@@ -34,6 +34,6 @@ var _ = Describe("Pin a resource", func() {
 			watch = fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 			Expect(watch).To(gbytes.Say("fetching.*" + someResourceV1))
 			Expect(watch).To(gbytes.Say("succeeded"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/pinned_version_check_test.go
+++ b/testflight/pinned_version_check_test.go
@@ -21,15 +21,15 @@ var _ = Describe("A resource pinned with a version during initial set of the pip
 			)
 		})
 
-		It("should be able to check the resource", func() {
+		It("should be able to check the resource", func(ctx SpecContext) {
 			check := fly("check-resource", "-r", inPipeline("some-resource"))
 			Expect(check).To(gbytes.Say("some-resource"))
 			Expect(check).To(gbytes.Say("succeeded"))
-		})
+		}, DefaultSpecTimeout)
 
-		It("should be able to run a job with the pinned version", func() {
+		It("should be able to run a job with the pinned version", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 			Expect(watch).To(gbytes.Say("v1"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/pipeline_var_sources_test.go
+++ b/testflight/pipeline_var_sources_test.go
@@ -9,7 +9,7 @@ var _ = Describe("Pipeline Var Sources", func() {
 		setAndUnpausePipeline("fixtures/var-sources.yml")
 	})
 
-	It("uses the pipeline var sources for resource checking and build execution", func() {
+	It("uses the pipeline var sources for resource checking and build execution", func(ctx SpecContext) {
 		fly("trigger-job", "-j", inPipeline("use-vars"), "-w")
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/propagation_test.go
+++ b/testflight/propagation_test.go
@@ -12,11 +12,11 @@ var _ = Describe("A pipeline that propagates resources", func() {
 			setAndUnpausePipeline("fixtures/propagation.yml")
 		})
 
-		It("propagates resources via implicit and explicit outputs", func() {
+		It("propagates resources via implicit and explicit outputs", func(ctx SpecContext) {
 			fly("trigger-job", "-j", inPipeline("first-job"), "-w")
 			fly("trigger-job", "-j", inPipeline("pushing-job"), "-w")
 			fly("trigger-job", "-j", inPipeline("downstream-job"), "-w")
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when the input/output are the same resource", func() {
@@ -24,7 +24,7 @@ var _ = Describe("A pipeline that propagates resources", func() {
 			setAndUnpausePipeline("fixtures/inputs_outputs.yml")
 		})
 
-		It("propogates the output version over the input version", func() {
+		It("propogates the output version over the input version", func(ctx SpecContext) {
 			fly("check-resource", "-r", inPipeline("some-resource"), "-f", "version:first-version")
 			fly("check-resource", "-r", inPipeline("some-resource"), "-f", "version:second-version")
 
@@ -34,6 +34,6 @@ var _ = Describe("A pipeline that propagates resources", func() {
 			watch = fly("trigger-job", "-j", inPipeline("downstream-job"), "-w")
 			Expect(watch).ToNot(gbytes.Say("second-version"))
 			Expect(watch).To(gbytes.Say("first-version"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/prototype_test.go
+++ b/testflight/prototype_test.go
@@ -12,12 +12,12 @@ var _ = Describe("Pipeline with prototypes", func() {
 		setAndUnpausePipeline("fixtures/prototype.yml")
 	})
 
-	It("executes the build plan correctly", func() {
+	It("executes the build plan correctly", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("job"), "-w")
 		<-watch.Exited
 		Expect(watch).To(gexec.Exit(0))
 
 		// XXX(prototypes): eventually, this'll need to test the real implementation
 		Expect(watch).To(gbytes.Say("run some-message on prototype some-prototype"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/put_inputs_test.go
+++ b/testflight/put_inputs_test.go
@@ -12,40 +12,40 @@ var _ = Describe("A put step with inputs", func() {
 	})
 
 	Context("when specific inputs are specified", func() {
-		It("attaches only the specified inputs to the put container", func() {
+		It("attaches only the specified inputs to the put container", func(ctx SpecContext) {
 			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-specified-inputs"), "-w")
 			<-watch.Exited
 
 			interceptS := fly("intercept", "-j", inPipeline("job-using-specified-inputs"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 			Expect(interceptS).To(gbytes.Say("specified-input"))
 			Expect(string(interceptS.Out.Contents())).ToNot(ContainSubstring("all-input"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when it uses all inputs", func() {
-		It("attached all inputs to the put container", func() {
+		It("attached all inputs to the put container", func(ctx SpecContext) {
 			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-all-inputs"), "-w")
 			<-watch.Exited
 
 			interceptS := fly("intercept", "-j", inPipeline("job-using-all-inputs"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 			Expect(string(interceptS.Out.Contents())).To(ContainSubstring("all-input"))
 			Expect(string(interceptS.Out.Contents())).To(ContainSubstring("specified-input"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when an empty slice of inputs are specified", func() {
-		It("no inputs are attached to the put container", func() {
+		It("no inputs are attached to the put container", func(ctx SpecContext) {
 			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-empty-inputs"), "-w")
 			<-watch.Exited
 
 			interceptS := fly("intercept", "-j", inPipeline("job-using-empty-inputs"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 			Expect(string(interceptS.Out.Contents())).ToNot(ContainSubstring("all-input"))
 			Expect(string(interceptS.Out.Contents())).ToNot(ContainSubstring("specified-input"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when no inputs are specified", func() {
-		It("attaches only the detected inputs to the put container", func() {
+		It("attaches only the detected inputs to the put container", func(ctx SpecContext) {
 			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-no-inputs"), "-w")
 			<-watch.Exited
 
@@ -53,23 +53,23 @@ var _ = Describe("A put step with inputs", func() {
 			logs := string(interceptS.Out.Contents())
 			Expect(logs).To(ContainSubstring("specified-input"))
 			Expect(logs).ToNot(ContainSubstring("all-input"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when inputs are detected", func() {
 		Context("when params are only strings", func() {
-			It("attaches only the detected inputs to the put container", func() {
+			It("attaches only the detected inputs to the put container", func(ctx SpecContext) {
 				watch := spawnFly("trigger-job", "-j", inPipeline("job-using-detect-inputs-simple"), "-w")
 				<-watch.Exited
 
 				interceptS := fly("intercept", "-j", inPipeline("job-using-detect-inputs-simple"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 				Expect(string(interceptS.Out.Contents())).To(ContainSubstring("specified-input"))
 				Expect(string(interceptS.Out.Contents())).ToNot(ContainSubstring("all-input"))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Context("when params have slices and maps", func() {
-			It("attaches the inputs detected in the slices", func() {
+			It("attaches the inputs detected in the slices", func(ctx SpecContext) {
 				watch := spawnFly("trigger-job", "-j", inPipeline("job-using-detect-inputs-complex"), "-w")
 				<-watch.Exited
 
@@ -80,7 +80,7 @@ var _ = Describe("A put step with inputs", func() {
 				Expect(string(interceptS.Out.Contents())).ToNot(ContainSubstring("does-not-exist"))
 				Expect(string(interceptS.Out.Contents())).ToNot(ContainSubstring("does-not-exist-too"))
 				Expect(string(interceptS.Out.Contents())).ToNot(ContainSubstring("123456"))
-			})
+			}, DefaultSpecTimeout)
 		})
 	})
 })

--- a/testflight/regression_test.go
+++ b/testflight/regression_test.go
@@ -8,11 +8,11 @@ import (
 
 var _ = Describe("Regression tests", func() {
 	Describe("issue 7282", func() {
-		It("does not error when resources emit long metadata strings", func() {
+		It("does not error when resources emit long metadata strings", func(ctx SpecContext) {
 			setAndUnpausePipeline("fixtures/long-metadata.yml")
 
 			watch := fly("trigger-job", "-j", inPipeline("job"), "-w")
 			Expect(watch).To(gexec.Exit(0))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/rename_job_test.go
+++ b/testflight/rename_job_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Renaming a job", func() {
 		setAndUnpausePipeline("fixtures/simple.yml")
 	})
 
-	It("retains job history", func() {
+	It("retains job history", func(ctx SpecContext) {
 		fly("trigger-job", "-j", inPipeline("simple"), "-w")
 		build := fly("builds", "-p", pipelineName)
 		Expect(build).To(gbytes.Say(pipelineName + "/simple"))
@@ -20,5 +20,5 @@ var _ = Describe("Renaming a job", func() {
 
 		build = fly("builds", "-p", pipelineName)
 		Expect(build).To(gbytes.Say(pipelineName + "/rename-simple"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/rename_pipeline_test.go
+++ b/testflight/rename_pipeline_test.go
@@ -11,7 +11,7 @@ var _ = Describe("Renaming a pipeline", func() {
 		setAndUnpausePipeline("fixtures/simple.yml")
 	})
 
-	It("runs scheduled after pipeline is renamed", func() {
+	It("runs scheduled after pipeline is renamed", func(ctx SpecContext) {
 		watch := fly("trigger-job", "-j", inPipeline("simple"), "-w")
 		Expect(watch).To(gbytes.Say("Hello, world!"))
 
@@ -22,5 +22,5 @@ var _ = Describe("Renaming a pipeline", func() {
 
 		watch = fly("trigger-job", "-j", inPipeline("simple"), "-w")
 		Expect(watch).To(gbytes.Say("Hello, world!"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/rename_resource_test.go
+++ b/testflight/rename_resource_test.go
@@ -8,7 +8,7 @@ import (
 
 var _ = Describe("Renaming a resource", func() {
 
-	It("preserves version history", func() {
+	It("preserves version history", func(ctx SpecContext) {
 		setAndUnpausePipeline("fixtures/resource-with-versions.yml")
 
 		guid1 := newMockVersion("some-resource", "guid1")
@@ -29,5 +29,5 @@ var _ = Describe("Renaming a resource", func() {
 		Expect(resourceVersions).To(gbytes.Say(guid3))
 		Expect(resourceVersions).To(gbytes.Say(guid2))
 		Expect(resourceVersions).To(gbytes.Say(guid1))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/rerun_build_test.go
+++ b/testflight/rerun_build_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Rerunning a build", func() {
 				fly("rerun-build", "-j", inPipeline("some-passing-job"), "-b", "1", "-w")
 			})
 
-			It("creates a rerun of the first build", func() {
+			It("creates a rerun of the first build", func(ctx SpecContext) {
 				By("watching the job without specifying a build name")
 				watch := waitForBuildAndWatch("some-passing-job")
 				Eventually(watch).Should(gbytes.Say("second-version"))
@@ -58,14 +58,14 @@ var _ = Describe("Rerunning a build", func() {
 				By("confirming the rerun builds apears in build history")
 				build = fly("builds", "-j", inPipeline("some-passing-job"))
 				Expect(build).To(gbytes.Say(`1\.1`))
-			})
+			}, DefaultSpecTimeout)
 
 			Context("when creating a rerun of the rerun build", func() {
 				BeforeEach(func() {
 					fly("rerun-build", "-j", inPipeline("some-passing-job"), "-b", "1.1", "-w")
 				})
 
-				It("creates a rerun of the first build", func() {
+				It("creates a rerun of the first build", func(ctx SpecContext) {
 					By("watching the job with rerun build's name")
 					watch := waitForBuildAndWatch("some-passing-job", "1.2")
 					Eventually(watch).Should(gbytes.Say("first-version"))
@@ -73,7 +73,7 @@ var _ = Describe("Rerunning a build", func() {
 					By("confirming the rerun builds apears in build history")
 					build = fly("builds", "-j", inPipeline("some-passing-job"))
 					Expect(build).To(gbytes.Say(`1\.2`))
-				})
+				}, DefaultSpecTimeout)
 			})
 		})
 	})

--- a/testflight/resource_cache_test.go
+++ b/testflight/resource_cache_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("Resource caching", func() {
-	It("takes params into account when determining a cache hit", func() {
+	It("takes params into account when determining a cache hit", func(ctx SpecContext) {
 		guid, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -25,5 +25,5 @@ var _ = Describe("Resource caching", func() {
 
 		watch = fly("trigger-job", "-j", inPipeline("with-params"), "-w")
 		Expect(watch).To(gbytes.Say("fetching.*" + guid.String()))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/resource_check_test.go
+++ b/testflight/resource_check_test.go
@@ -27,21 +27,21 @@ var _ = Describe("Checking a resource", func() {
 		)
 	})
 
-	It("saves the versions", func() {
+	It("saves the versions", func(ctx SpecContext) {
 		check := fly("check-resource", "-r", inPipeline("my-resource"))
 		Expect(check).To(gbytes.Say("my-resource"))
 		Expect(check).To(gbytes.Say("succeeded"))
 
 		versions := fly("resource-versions", "-r", inPipeline("my-resource"))
 		Expect(versions).To(gbytes.Say(hash))
-	})
+	}, DefaultSpecTimeout)
 
 	Context("when checking fails", func() {
 		BeforeEach(func() {
 			checkFailure = "super broken"
 		})
 
-		It("shows the check status failed", func() {
+		It("shows the check status failed", func(ctx SpecContext) {
 			check := spawnFly("check-resource", "-r", inPipeline("my-resource"))
 			<-check.Exited
 			Expect(check).To(gexec.Exit(1))
@@ -50,6 +50,6 @@ var _ = Describe("Checking a resource", func() {
 
 			resources := fly("resources", "-p", pipelineName)
 			Expect(resources).To(gbytes.Say("failed"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/resource_check_timeout_test.go
+++ b/testflight/resource_check_timeout_test.go
@@ -28,13 +28,13 @@ var _ = Describe("A resource check which times out", func() {
 			checkDelay = time.Minute
 		})
 
-		It("prints an error and cancels the check", func() {
+		It("prints an error and cancels the check", func(ctx SpecContext) {
 			check := spawnFly("check-resource", "-r", inPipeline("my-resource"))
 			<-check.Exited
 			Expect(check).To(gexec.Exit(1))
 			Expect(check).To(gbytes.Say("timeout exceeded"))
 			Expect(check).To(gbytes.Say("failed"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when check script finishes before timeout", func() {
@@ -42,8 +42,8 @@ var _ = Describe("A resource check which times out", func() {
 			checkDelay = time.Second
 		})
 
-		It("succeeds", func() {
+		It("succeeds", func(ctx SpecContext) {
 			fly("check-resource", "-r", inPipeline("my-resource"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/resource_config_versions_test.go
+++ b/testflight/resource_config_versions_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Resource config versions", func() {
 	// invalidated if the resource config id field on the resource gets updated
 	// due to a new version of the custom resource type that it is using.
 	Describe("build inputs and outputs are not affected by a change in resource config id", func() {
-		It("will run both jobs only once even with a new custom resource type version", func() {
+		It("will run both jobs only once even with a new custom resource type version", func(ctx SpecContext) {
 			By("waiting for a new build when the pipeline is created")
 			fly("trigger-job", "-j", inPipeline("initial-job"), "-w")
 
@@ -38,6 +38,6 @@ var _ = Describe("Resource config versions", func() {
 
 			By("using the version  of 'some-resource' consumed upstream")
 			Expect(flyTable("builds", "-j", inPipeline("initial-job"))).To(HaveLen(1))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/resource_containers_gc_test.go
+++ b/testflight/resource_containers_gc_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Resource container GC", func() {
 			setAndUnpausePipeline("fixtures/resource-gc-removed.yml")
 		})
 
-		It("eventually removes the check container", func() {
+		It("eventually removes the check container", func(ctx SpecContext) {
 			Eventually(func() []string {
 				handles := []string{}
 				for _, container := range flyTable("containers") {
@@ -45,7 +45,7 @@ var _ = Describe("Resource container GC", func() {
 
 				return handles
 			}, 5*time.Minute, 10*time.Second).ShouldNot(ContainElement(checkContainerHandle))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Describe("changing the resource config", func() {
@@ -61,7 +61,7 @@ var _ = Describe("Resource container GC", func() {
 			fly("check-resource", "-r", inPipeline("simple-resource"))
 		})
 
-		It("eventually removes the check container", func() {
+		It("eventually removes the check container", func(ctx SpecContext) {
 			Eventually(func() []string {
 				handles := []string{}
 				for _, container := range flyTable("containers") {
@@ -72,6 +72,6 @@ var _ = Describe("Resource container GC", func() {
 
 				return handles
 			}, 5*time.Minute, 10*time.Second).ShouldNot(ContainElement(checkContainerHandle))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/resource_reconfigure_test.go
+++ b/testflight/resource_reconfigure_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("Reconfiguring a resource", func() {
-	It("picks up the new configuration immediately", func() {
+	It("picks up the new configuration immediately", func(ctx SpecContext) {
 		guid1, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -30,5 +30,5 @@ var _ = Describe("Reconfiguring a resource", func() {
 
 		watch = fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 		Expect(watch).To(gbytes.Say(guid2.String()))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/resource_type_check_test.go
+++ b/testflight/resource_type_check_test.go
@@ -22,10 +22,10 @@ var _ = Describe("Resource-types checks", func() {
 		Eventually(checkS).Should(gbytes.Say("succeeded"))
 	})
 
-	It("can check the resource-type", func() {
+	It("can check the resource-type", func(ctx SpecContext) {
 		checkS := fly("check-resource-type", "-r", inPipeline("custom-resource-type"))
 		Eventually(checkS).Should(gbytes.Say("succeeded"))
-	})
+	}, DefaultSpecTimeout)
 
 	Context("when there is a new version", func() {
 		var newVersion string
@@ -39,17 +39,17 @@ var _ = Describe("Resource-types checks", func() {
 			fly("check-resource-type", "-r", inPipeline("custom-resource-type"), "-f", "version:"+newVersion)
 		})
 
-		It("uses the updated resource type", func() {
+		It("uses the updated resource type", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("resource-imager"), "-w")
 			Expect(watch).To(gbytes.Say("MIRRORED_VERSION=" + newVersion))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when the resource-type check fails", func() {
-		It("fails", func() {
+		It("fails", func(ctx SpecContext) {
 			watch := spawnFly("check-resource-type", "-r", inPipeline("failing-custom-resource-type"))
 			Eventually(watch.Out).Should(gbytes.Say("failed"))
 			Eventually(watch).Should(gexec.Exit(1))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/resource_type_privileged_test.go
+++ b/testflight/resource_type_privileged_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			privileged = "true"
 		})
 
-		It("performs 'check', 'get', and 'put' with privileged containers", func() {
+		It("performs 'check', 'get', and 'put' with privileged containers", func(ctx SpecContext) {
 			By("running 'get' with a privileged container")
 			watch := fly("trigger-job", "-j", inPipeline("resource-getter"), "-w")
 			Expect(watch).To(gbytes.Say("privileged: true"))
@@ -42,7 +42,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			By("running 'put' with a privileged container")
 			watch = fly("trigger-job", "-j", inPipeline("resource-putter"), "-w")
 			Expect(watch).To(gbytes.Say("pushing in a privileged container"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when the custom resource type is not privileged", func() {
@@ -50,7 +50,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			privileged = "false"
 		})
 
-		It("performs 'check', 'get', and 'put' with unprivileged containers", func() {
+		It("performs 'check', 'get', and 'put' with unprivileged containers", func(ctx SpecContext) {
 			By("running 'get' with an unprivileged container")
 			watch := fly("trigger-job", "-j", inPipeline("resource-getter"), "-w")
 			Expect(watch).To(gbytes.Say("privileged: false"))
@@ -62,6 +62,6 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			By("running 'put' with an unprivileged container")
 			watch = fly("trigger-job", "-j", inPipeline("resource-putter"), "-w")
 			Expect(watch).ToNot(gbytes.Say("running in a privileged container"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/resource_type_test.go
+++ b/testflight/resource_type_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			setAndUnpausePipeline("fixtures/resource-types.yml", "-v", "hash="+hash)
 		})
 
-		It("can use custom resource types for 'get', 'put', and task 'image_resource's", func() {
+		It("can use custom resource types for 'get', 'put', and task 'image_resource's", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("resource-getter"), "-w")
 			Expect(watch).To(gbytes.Say("fetched version: " + hash))
 
@@ -31,14 +31,14 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 
 			watch = fly("trigger-job", "-j", inPipeline("resource-image-resourcer"), "-w")
 			Expect(watch).To(gbytes.Say("MIRRORED_VERSION=image-version"))
-		})
+		}, DefaultSpecTimeout)
 
-		It("can check for resources having a custom type recursively", func() {
+		It("can check for resources having a custom type recursively", func(ctx SpecContext) {
 			checkResource := fly("check-resource", "-r", inPipeline("my-resource"))
 			Expect(checkResource).To(gbytes.Say("my-resource"))
 			Expect(checkResource).To(gbytes.Say("custom-resource-type"))
 			Expect(checkResource).To(gbytes.Say("succeeded"))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("with custom resource types that have params", func() {
@@ -46,10 +46,10 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			setAndUnpausePipeline("fixtures/resource-types-with-params.yml", "-v", "hash="+hash)
 		})
 
-		It("can use a custom resource with parameters", func() {
+		It("can use a custom resource with parameters", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("resource-test"), "-w")
 			Expect(watch).To(gbytes.Say(hash))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when resource type named as base resource type", func() {
@@ -57,10 +57,10 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			setAndUnpausePipeline("fixtures/resource-type-named-as-base-type.yml", "-v", "hash="+hash)
 		})
 
-		It("can use custom resource type named as base resource type", func() {
+		It("can use custom resource type named as base resource type", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("resource-getter"), "-w")
 			Expect(watch).To(gbytes.Say("mirror-" + hash))
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when resource type has defaults", func() {
@@ -68,7 +68,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			setAndUnpausePipeline("fixtures/resource-type-defaults.yml", "-v", "hash="+hash)
 		})
 
-		It("applies the defaults for check, get, and put steps", func() {
+		It("applies the defaults for check, get, and put steps", func(ctx SpecContext) {
 			getAndPut := fly("trigger-job", "-j", inPipeline("some-job"), "-w")
 			Expect(getAndPut).To(gbytes.Say("defaulted"))
 			Expect(getAndPut).To(gbytes.Say("fetching version: " + hash))
@@ -76,6 +76,6 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			Expect(getAndPut).To(gbytes.Say("pushing version: put-version"))
 			Expect(getAndPut).To(gbytes.Say("defaulted"))
 			Expect(getAndPut).To(gbytes.Say("fetching version: put-version"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/resource_version_test.go
+++ b/testflight/resource_version_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Resource version", func() {
 				setAndUnpausePipeline("fixtures/resource-version-latest.yml", "-v", "hash="+hash)
 			})
 
-			It("only runs builds with latest version", func() {
+			It("only runs builds with latest version", func(ctx SpecContext) {
 				guid1 := newMockVersion("some-resource", "guid1")
 				watch := fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(guid1))
@@ -34,7 +34,7 @@ var _ = Describe("Resource version", func() {
 
 				watch = fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(guid4))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Describe("version: every", func() {
@@ -42,7 +42,7 @@ var _ = Describe("Resource version", func() {
 				setAndUnpausePipeline("fixtures/resource-version-every.yml", "-v", "hash="+hash)
 			})
 
-			It("runs builds with every version", func() {
+			It("runs builds with every version", func(ctx SpecContext) {
 				guid1 := newMockVersion("some-resource", "guid1")
 				watch := fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(guid1))
@@ -59,7 +59,7 @@ var _ = Describe("Resource version", func() {
 
 				watch = fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(guid4))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Describe("version: pinned", func() {
@@ -67,7 +67,7 @@ var _ = Describe("Resource version", func() {
 				setAndUnpausePipeline("fixtures/resource-version-every.yml", "-v", "hash="+hash)
 			})
 
-			It("only runs builds with the pinned version", func() {
+			It("only runs builds with the pinned version", func(ctx SpecContext) {
 				guid1 := newMockVersion("some-resource", "guid1")
 
 				watch := fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
@@ -81,7 +81,7 @@ var _ = Describe("Resource version", func() {
 
 				watch = fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(guid3))
-			})
+			}, DefaultSpecTimeout)
 		})
 	})
 
@@ -119,10 +119,10 @@ var _ = Describe("Resource version", func() {
 				versionConfig = "latest"
 			})
 
-			It("only runs builds with pinned version", func() {
+			It("only runs builds with pinned version", func(ctx SpecContext) {
 				watch := fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(pinnedGUID))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Describe("version: every", func() {
@@ -130,13 +130,13 @@ var _ = Describe("Resource version", func() {
 				versionConfig = "every"
 			})
 
-			It("only runs builds with pinned version", func() {
+			It("only runs builds with pinned version", func(ctx SpecContext) {
 				watch := fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(pinnedGUID))
 
 				watch = fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(pinnedGUID))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Describe("version: pinned", func() {
@@ -144,10 +144,10 @@ var _ = Describe("Resource version", func() {
 				versionConfig = "version:" + olderGUID
 			})
 
-			It("only runs builds with the pinned version", func() {
+			It("only runs builds with the pinned version", func(ctx SpecContext) {
 				watch := fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 				Expect(watch).To(gbytes.Say(pinnedGUID))
-			})
+			}, DefaultSpecTimeout)
 		})
 	})
 })

--- a/testflight/retry_test.go
+++ b/testflight/retry_test.go
@@ -12,7 +12,7 @@ var _ = Describe("A job with a step that retries", func() {
 		setAndUnpausePipeline("fixtures/retry.yml")
 	})
 
-	It("retries until the step succeeds", func() {
+	It("retries until the step succeeds", func(ctx SpecContext) {
 		watch := fly("trigger-job", "-j", inPipeline("retry-job"), "-w")
 		Expect(watch).To(gbytes.Say("initializing"))
 		Expect(watch).To(gbytes.Say("attempts: 1; failing"))
@@ -20,7 +20,7 @@ var _ = Describe("A job with a step that retries", func() {
 		Expect(watch).To(gbytes.Say("attempts: 3; success!"))
 		Expect(watch).ToNot(gbytes.Say("attempts:"))
 		Expect(watch).To(gbytes.Say("succeeded"))
-	})
+	}, DefaultSpecTimeout)
 
 	Context("hijacking jobs with retry steps", func() {
 		var hijackS *gexec.Session
@@ -32,7 +32,7 @@ var _ = Describe("A job with a step that retries", func() {
 			Expect(watch).To(gexec.Exit(1))
 		})
 
-		It("permits hijacking a specific attempt", func() {
+		It("permits hijacking a specific attempt", func(ctx SpecContext) {
 			fly(
 				"intercept",
 				"-j", pipelineName+"/retry-job-fail-for-hijacking",
@@ -41,15 +41,15 @@ var _ = Describe("A job with a step that retries", func() {
 				"--",
 				"sh", "-c", "[ `cat /tmp/retry_number` -eq 2 ]",
 			)
-		})
+		}, DefaultSpecTimeout)
 
-		It("correctly displays information about attempts", func() {
+		It("correctly displays information about attempts", func(ctx SpecContext) {
 			hijackS = spawnFly("intercept", "-j", pipelineName+"/retry-job-fail-for-hijacking", "--step", "succeed-on-3rd-attempt", "--", "sh", "-c", "exit")
 			Eventually(hijackS).Should(gbytes.Say("step: succeed-on-3rd-attempt, type: task, attempt: [1-3]"))
 			Eventually(hijackS).Should(gbytes.Say("step: succeed-on-3rd-attempt, type: task, attempt: [1-3]"))
 			Eventually(hijackS).Should(gbytes.Say("step: succeed-on-3rd-attempt, type: task, attempt: [1-3]"))
 			hijackS.Interrupt()
 			Eventually(hijackS).Should(gexec.Exit())
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/serial_groups_test.go
+++ b/testflight/serial_groups_test.go
@@ -35,10 +35,10 @@ var _ = Describe("serial groups", func() {
 			<-pendingS.Exited
 		})
 
-		It("runs even when another job in the serial group has a pending build", func() {
+		It("runs even when another job in the serial group has a pending build", func(ctx SpecContext) {
 			fly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
 			Consistently(pendingS, time.Second).ShouldNot(gexec.Exit())
-		})
+		}, DefaultSpecTimeout)
 	})
 
 	Context("when inputs eventually become available for one resource", func() {
@@ -59,7 +59,7 @@ var _ = Describe("serial groups", func() {
 			)
 		})
 
-		It("is able to run second job with latest inputs", func() {
+		It("is able to run second job with latest inputs", func(ctx SpecContext) {
 			By("starting a pending build")
 			pendingS := spawnFly("trigger-job", "-j", inPipeline("some-pending-job"), "-w")
 
@@ -91,6 +91,6 @@ var _ = Describe("serial groups", func() {
 			Expect(pendingS.ExitCode()).To(Equal(0))
 			Expect(pendingS).To(gbytes.Say(guid2))
 			Expect(pendingS).To(gbytes.Say(guid3))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/set-pipeline-step_test.go
+++ b/testflight/set-pipeline-step_test.go
@@ -48,7 +48,7 @@ var _ = Describe("set-pipeline Step", func() {
 			fly("destroy-pipeline", "-n", "-p", createdPipelineName+currentInstanceVars)
 		})
 
-		It("sets the other pipeline", func() {
+		It("sets the other pipeline", func(ctx SpecContext) {
 			By("second pipeline should initially not exist")
 			execS := spawnFly("get-pipeline", "-p", createdPipelineName)
 			<-execS.Exited
@@ -63,14 +63,14 @@ var _ = Describe("set-pipeline Step", func() {
 			By("should trigger the second pipeline job successfully")
 			execS = fly("trigger-job", "-w", "-j", createdPipelineName+"/normal-job")
 			Expect(execS.Out).To(gbytes.Say("hello world"))
-		})
+		}, DefaultSpecTimeout)
 
 		Context("when setting pipeline with instance vars", func() {
 			BeforeEach(func() {
 				currentInstanceVars = "/greetings:instanced-pipeline"
 			})
 
-			It("sets the other pipeline as instanced pipeline", func() {
+			It("sets the other pipeline as instanced pipeline", func(ctx SpecContext) {
 				By("second pipeline should initially not exist")
 				execS := spawnFly("get-pipeline", "-p", createdPipelineName+currentInstanceVars)
 				<-execS.Exited
@@ -85,7 +85,7 @@ var _ = Describe("set-pipeline Step", func() {
 				By("should trigger the second pipeline job successfully")
 				execS = fly("trigger-job", "-w", "-j", createdPipelineName+currentInstanceVars+"/normal-job")
 				Expect(execS.Out).To(gbytes.Say("instanced-pipeline"))
-			})
+			}, DefaultSpecTimeout)
 		})
 	})
 

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -63,6 +63,8 @@ func TestTestflight(t *testing.T) {
 	RunSpecs(t, "TestFlight Suite")
 }
 
+const DefaultSpecTimeout = SpecTimeout(6 * time.Minute)
+
 var _ = SynchronizedBeforeSuite(func() []byte {
 	atcURL := os.Getenv("ATC_URL")
 	if atcURL != "" {

--- a/testflight/task_caches_test.go
+++ b/testflight/task_caches_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ = Describe("Task caching", func() {
-	It("caches directories in the cache list without caching any non-cached directories", func() {
+	It("caches directories in the cache list without caching any non-cached directories", func(ctx SpecContext) {
 		setAndUnpausePipeline("fixtures/task-caches.yml")
 
 		watch := fly("trigger-job", "-j", inPipeline("simple"), "-w")
@@ -31,5 +31,5 @@ var _ = Describe("Task caching", func() {
 		Expect(watch).NotTo(gbytes.Say("blob-contents-from-first-task"))
 		Expect(watch).NotTo(gbytes.Say(`not-cached-from-first-task\s+not-cached-from-first-task`))
 		Expect(watch).NotTo(gbytes.Say(`not-cached-from-second-task\s+not-cached-from-second-task`))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/task_missing_outputs_test.go
+++ b/testflight/task_missing_outputs_test.go
@@ -12,10 +12,10 @@ var _ = Describe("A task with no outputs declared", func() {
 		setAndUnpausePipeline("fixtures/task-missing-outputs.yml")
 	})
 
-	It("doesn't mount its file system into the next task", func() {
+	It("doesn't mount its file system into the next task", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("missing-outputs-job"), "-w")
 		<-watch.Exited
 		Expect(watch).To(gexec.Exit(2))
 		Expect(watch).To(gbytes.Say("missing inputs: missing-outputs"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/task_outputs_test.go
+++ b/testflight/task_outputs_test.go
@@ -12,12 +12,12 @@ var _ = Describe("A job with a task that produces outputs", func() {
 			setAndUnpausePipeline("fixtures/task-outputs.yml")
 		})
 
-		It("propagates the outputs from one task to another", func() {
+		It("propagates the outputs from one task to another", func(ctx SpecContext) {
 			watch := fly("trigger-job", "-j", inPipeline("some-job"), "-w")
 			Expect(watch).To(gbytes.Say("initializing"))
 
 			Expect(watch.Out.Contents()).To(ContainSubstring("./output-1/file-1"))
 			Expect(watch.Out.Contents()).To(ContainSubstring("./output-2/file-2"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/task_vars_test.go
+++ b/testflight/task_vars_test.go
@@ -82,30 +82,30 @@ run:
 		})
 
 		Context("when required vars are passed from the pipeline", func() {
-			It("successfully runs pipeline job with external task", func() {
+			It("successfully runs pipeline job with external task", func(ctx SpecContext) {
 				execS := fly("trigger-job", "-w", "-j", pipelineName+"/external-task-success")
 				Expect(execS).To(gbytes.Say("Hello World"))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Context("when not all required vars are passed from the pipeline", func() {
-			It("fails pipeline job with external task due to an uninterpolated variable", func() {
+			It("fails pipeline job with external task due to an uninterpolated variable", func(ctx SpecContext) {
 				execS := spawnFly("trigger-job", "-w", "-j", pipelineName+"/external-task-failure")
 				<-execS.Exited
 				Expect(execS).To(gexec.Exit(2))
 				Expect(execS.Out).To(gbytes.Say("undefined vars: echo_text"))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Context("when required vars are passed from command line using -v", func() {
-			It("successfully runs external task via fly execute", func() {
+			It("successfully runs external task via fly execute", func(ctx SpecContext) {
 				execS := flyIn(fixture, "execute", "-c", "task.yml", "-v", "image_resource_type=mock", "-v", "echo_text=Hello World From Command Line")
 				Expect(execS).To(gbytes.Say("Hello World From Command Line"))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Context("when required vars are passed from command line using -v", func() {
-			It("successfully runs external task via fly execute", func() {
+			It("successfully runs external task via fly execute", func(ctx SpecContext) {
 				varsContents := `
 image_resource_type: mock
 echo_text: Hello World From Command Line
@@ -118,23 +118,23 @@ echo_text: Hello World From Command Line
 				Expect(err).NotTo(HaveOccurred())
 				execS := flyIn(fixture, "execute", "-c", "task.yml", "-l", "vars.yml")
 				Expect(execS).To(gbytes.Say("Hello World From Command Line"))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Context("when not all required vars are passed from command line", func() {
-			It("fails external task via fly execute due to an uninterpolated variable", func() {
+			It("fails external task via fly execute due to an uninterpolated variable", func(ctx SpecContext) {
 				execS := spawnFlyIn(fixture, "execute", "-c", "task.yml", "-v", "image_resource_type=mock")
 				<-execS.Exited
 				Expect(execS).To(gexec.Exit(2))
 				Expect(execS.Out).To(gbytes.Say("undefined vars: echo_text"))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Context("when vars are from load_var", func() {
-			It("successfully runs pipeline job with external task", func() {
+			It("successfully runs pipeline job with external task", func(ctx SpecContext) {
 				execS := fly("trigger-job", "-w", "-j", pipelineName+"/external-task-vars-from-load-var")
 				Expect(execS).To(gbytes.Say("bar"))
-			})
+			}, DefaultSpecTimeout)
 		})
 
 		Context("when task vars are not used, task should get vars from var_sources", func() {
@@ -156,12 +156,12 @@ run:
     echo ${text:9:20}
 `
 			})
-			It("successfully runs pipeline job with external task", func() {
+			It("successfully runs pipeline job with external task", func(ctx SpecContext) {
 				execS := fly("trigger-job", "-w", "-j", pipelineName+"/task-var-is-defined-but-task-also-needs-vars-from-var-sources")
 				Expect(execS).To(gbytes.Say("((redacted))"), "((vs:echo_test)) should be redacted and not leak")
 				Expect(execS).To(gbytes.Say("text-from"))
 				Expect(execS).To(gbytes.Say("-var-source"))
-			})
+			}, DefaultSpecTimeout)
 		})
 	})
 

--- a/testflight/timeout_hooks_test.go
+++ b/testflight/timeout_hooks_test.go
@@ -12,12 +12,12 @@ var _ = Describe("A pipeline containing a job with a timeout and hooks", func() 
 		setAndUnpausePipeline("fixtures/timeout_hooks.yml")
 	})
 
-	It("runs the failure and ensure hooks", func() {
+	It("runs the failure and ensure hooks", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("duration-fail-job"), "-w")
 		<-watch.Exited
 		Expect(watch).To(gbytes.Say("duration fail job on failure"))
 		Expect(watch).To(gbytes.Say("duration fail job ensure"))
 		Expect(watch).To(gexec.Exit(1))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("duration fail job on success"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/timeout_test.go
+++ b/testflight/timeout_test.go
@@ -12,7 +12,7 @@ var _ = Describe("A job with a task with a timeout", func() {
 		setAndUnpausePipeline("fixtures/timeout.yml")
 	})
 
-	It("enforces the timeout", func() {
+	It("enforces the timeout", func(ctx SpecContext) {
 		successWatch := spawnFly("trigger-job", "-j", inPipeline("duration-successful-job"), "-w")
 		failedWatch := spawnFly("trigger-job", "-j", inPipeline("duration-fail-job"), "-w")
 
@@ -27,5 +27,5 @@ var _ = Describe("A job with a task with a timeout", func() {
 		Expect(failedWatch).To(gbytes.Say("initializing"))
 		Expect(failedWatch).To(gbytes.Say("timeout exceeded"))
 		Expect(failedWatch).To(gexec.Exit(1))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/trigger_test.go
+++ b/testflight/trigger_test.go
@@ -21,7 +21,7 @@ var _ = Describe("A job with an input with trigger: true", func() {
 		setAndUnpausePipeline("fixtures/simple-trigger.yml", "-v", "hash="+hash)
 	})
 
-	It("triggers when the resource changes", func() {
+	It("triggers when the resource changes", func(ctx SpecContext) {
 		By("running on the initial version")
 		fly("check-resource", "-r", inPipeline("some-resource"), "-f", "version:first-version")
 		watch := waitForBuildAndWatch("some-passing-job")
@@ -31,5 +31,5 @@ var _ = Describe("A job with an input with trigger: true", func() {
 		fly("check-resource", "-r", inPipeline("some-resource"), "-f", "version:second-version")
 		watch = waitForBuildAndWatch("some-passing-job", "2")
 		Eventually(watch).Should(gbytes.Say("second-version"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/try_test.go
+++ b/testflight/try_test.go
@@ -11,9 +11,9 @@ var _ = Describe("A job with a try step", func() {
 		setAndUnpausePipeline("fixtures/try.yml")
 	})
 
-	It("proceeds through the plan even if the step fails", func() {
+	It("proceeds through the plan even if the step fails", func(ctx SpecContext) {
 		watch := fly("trigger-job", "-j", inPipeline("try-job"), "-w")
 		Expect(watch).To(gbytes.Say("initializing"))
 		Expect(watch).To(gbytes.Say("passing-task succeeded"))
-	})
+	}, DefaultSpecTimeout)
 })

--- a/testflight/user_lookup_test.go
+++ b/testflight/user_lookup_test.go
@@ -8,12 +8,12 @@ import (
 
 var _ = Describe("user lookup", func() {
 	Context("when no username is specified and the image has no /etc/passwd file", func() {
-		It("runs as root", func() {
+		It("runs as root", func(ctx SpecContext) {
 			// clearlinux doesn't have an /etc/passwd file
 			session := fly("execute", "-c", "fixtures/clearlinux.yml")
 			<-session.Exited
 			Expect(session.ExitCode()).To(Equal(0))
 			Expect(session.Out).To(gbytes.Say("running as root"))
-		})
+		}, DefaultSpecTimeout)
 	})
 })

--- a/testflight/volume_mounting_test.go
+++ b/testflight/volume_mounting_test.go
@@ -12,38 +12,38 @@ var _ = Describe("A job with nested volume mounts", func() {
 		setAndUnpausePipeline("fixtures/volume-mounting.yml")
 	})
 
-	It("procceds through the plan with input under output mounts", func() {
+	It("procceds through the plan with input under output mounts", func(ctx SpecContext) {
 		watch := fly("trigger-job", "-j", inPipeline("input-under-output"), "-w")
 		Expect(watch).To(gexec.Exit(0))
 		Expect(watch).To(gbytes.Say("some-resource"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("procceds through the plan with input under input mounts", func() {
+	It("procceds through the plan with input under input mounts", func(ctx SpecContext) {
 		sess := fly("trigger-job", "-j", inPipeline("input-under-input"), "-w")
 		Expect(sess).To(gexec.Exit(0))
 		Expect(sess).To(gbytes.Say("helloworld"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("procceds through the plan having output being mapped to dot and input within", func() {
+	It("procceds through the plan having output being mapped to dot and input within", func(ctx SpecContext) {
 		sess := fly("trigger-job", "-j", inPipeline("output-with-dot-with-input-within"), "-w")
 		Expect(sess).To(gexec.Exit(0))
 		Expect(sess).To(gbytes.Say("bar"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("procceds through the plan with output under input mounts", func() {
+	It("procceds through the plan with output under input mounts", func(ctx SpecContext) {
 		sess := fly("trigger-job", "-j", inPipeline("output-under-input"), "-w")
 		Expect(sess).To(gexec.Exit(0))
 		Expect(sess).To(gbytes.Say("hello"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("procceds through the plan with input same as output mounts", func() {
+	It("procceds through the plan with input same as output mounts", func(ctx SpecContext) {
 		sess := fly("trigger-job", "-j", inPipeline("input-same-output"), "-w")
 		Expect(sess).To(gexec.Exit(0))
 		Expect(sess).To(gbytes.Say("hello"))
-	})
+	}, DefaultSpecTimeout)
 
-	It("procceds through the plan with input and output having the same path but a different name", func() {
+	It("procceds through the plan with input and output having the same path but a different name", func(ctx SpecContext) {
 		sess := fly("trigger-job", "-j", inPipeline("input-output-same-path-diff-name"), "-w")
 		Expect(sess).To(gexec.Exit(0))
-	})
+	}, DefaultSpecTimeout)
 })


### PR DESCRIPTION
## Changes proposed by this PR

There are a few tests that appear to hang during some interactions. This seems to rarely happen, but when it does it causes the entire test suite to timeout at 1hr (Ginkgo's default).

This PR adds a spec-level timeout of 6mins. This plus the `--flake-attempts` that we set in CI should ensure the entire test suite fails in <1hr.