### PR TITLE
Emit a more useful error if we get the "rootfs empty" error

### DIFF
--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -301,6 +301,12 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 
 	container, volumeMounts, err := worker.FindOrCreateContainer(ctx, owner, step.containerMetadata, containerSpec, delegate)
 	if err != nil {
+		if strings.Contains(err.Error(), "rootfs must not be empty") {
+			return false, errors.Join(
+				err,
+				errors.New(`No image specified for task? Make sure to specify "image" on your task step or "image_resource" in your task config. The image must be in rootfs format.`),
+			)
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
## Changes proposed by this PR

If a user doesn't specify `image` or `image_resource`, the containerd runtime will return "rootfs must not be empty" as the error. This PR emits the error from containerd still, but appends a useful message suggesting the user check their job or task config for an image. The most common cause of this error is a user no specifying an image for the task.

An image is not required for all tasks. For workers using the houdini runtime, not image is required. That's why we can't just error if no image is specified or even do validation of the step/task config.