### PR TITLE
fix: DNS resolution for Ubuntu 24 stemcells

### DIFF
--- a/worker/runtime/resolvconf_parser.go
+++ b/worker/runtime/resolvconf_parser.go
@@ -12,30 +12,77 @@ import (
 )
 
 var (
+	defaultHostResolvConfPath     = "/etc/resolv.conf"
+	systemdResolvedResolvConfPath = "/run/systemd/resolve/resolv.conf"
+	readFileFn                    = os.ReadFile
+	localIPFn                     = localip.LocalIP
+
 	// Regular expressions used for DNS resolution parsing
-	loopbackNameserverRegexp = regexp.MustCompile(`^\s*nameserver\s+127\.0\.0\.\d+\s*$`)
-	loopbackIPRegexp         = regexp.MustCompile(`127\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
+	loopbackNameserverRegexp = regexp.MustCompile(`(?m)^\s*nameserver\s+(?:127\.0\.0\.\d+|::1)\s*$`)
+	loopbackIPRegexp         = regexp.MustCompile(`(?:127\.\d{1,3}\.\d{1,3}\.\d{1,3}|::1)`)
 )
 
 // Parse resolve.conf file from the provided path.
 // implementation is based on guardian's implementation
 // here: https://github.com/cloudfoundry/guardian/blob/master/kawasaki/dns/resolv_compiler.go
 func ParseHostResolveConf(path string) ([]string, error) {
-	resolvConf, err := os.ReadFile(path)
+	resolvContents, err := readResolvConf(path)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read host's resolv.conf: %w", err)
+		return nil, err
 	}
 
-	resolvContents := string(resolvConf)
+	entries := parseResolvEntries(resolvContents)
+	if hasNameserverEntry(entries) {
+		return entries, nil
+	}
 
 	if loopbackNameserverRegexp.MatchString(resolvContents) {
-		ip, err := localip.LocalIP()
+		if path == defaultHostResolvConfPath {
+			entries, err := parseResolvConf(systemdResolvedResolvConfPath)
+			if err == nil && hasNameserverEntry(entries) {
+				return entries, nil
+			}
+		}
+
+		ip, err := localIPFn()
 		if err != nil {
 			return nil, err
 		}
 		return []string{"nameserver " + ip}, nil
 	}
 
+	return entries, nil
+}
+
+func readResolvConf(path string) (string, error) {
+	resolvConf, err := readFileFn(path)
+	if err != nil {
+		return "", fmt.Errorf("unable to read host's resolv.conf: %w", err)
+	}
+
+	return string(resolvConf), nil
+}
+
+func parseResolvConf(path string) ([]string, error) {
+	resolvContents, err := readResolvConf(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseResolvEntries(resolvContents), nil
+}
+
+func hasNameserverEntry(entries []string) bool {
+	for _, entry := range entries {
+		if strings.HasPrefix(entry, "nameserver ") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseResolvEntries(resolvContents string) []string {
 	var entries []string
 
 	for resolvEntry := range strings.SplitSeq(strings.TrimSpace(resolvContents), "\n") {
@@ -57,5 +104,5 @@ func ParseHostResolveConf(path string) ([]string, error) {
 		}
 	}
 
-	return entries, nil
+	return entries
 }

--- a/worker/runtime/resolvconf_parser_internal_test.go
+++ b/worker/runtime/resolvconf_parser_internal_test.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package runtime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHostResolveConf_UsesSystemdResolvedWhenHostResolvConfIsLoopback(t *testing.T) {
+	oldReadFileFn := readFileFn
+	oldLocalIPFn := localIPFn
+	defer func() {
+		readFileFn = oldReadFileFn
+		localIPFn = oldLocalIPFn
+	}()
+
+	readFileFn = func(path string) ([]byte, error) {
+		switch path {
+		case defaultHostResolvConfPath:
+			return []byte("nameserver 127.0.0.53\noptions edns0 trust-ad\nsearch .\n"), nil
+		case systemdResolvedResolvConfPath:
+			return []byte("nameserver 169.254.0.2\nsearch .\n"), nil
+		default:
+			return nil, fmt.Errorf("unexpected path: %s", path)
+		}
+	}
+
+	localIPFn = func() (string, error) {
+		return "10.5.6.11", nil
+	}
+
+	entries, err := ParseHostResolveConf(defaultHostResolvConfPath)
+	require.NoError(t, err)
+	require.Equal(t, []string{"nameserver 169.254.0.2", "search ."}, entries)
+}
+
+func TestParseHostResolveConf_FallsBackToLocalIPWhenSystemdResolvedUnavailable(t *testing.T) {
+	oldReadFileFn := readFileFn
+	oldLocalIPFn := localIPFn
+	defer func() {
+		readFileFn = oldReadFileFn
+		localIPFn = oldLocalIPFn
+	}()
+
+	readFileFn = func(path string) ([]byte, error) {
+		switch path {
+		case defaultHostResolvConfPath:
+			return []byte("nameserver 127.0.0.53\noptions edns0 trust-ad\nsearch .\n"), nil
+		case systemdResolvedResolvConfPath:
+			return nil, fmt.Errorf("not found")
+		default:
+			return nil, fmt.Errorf("unexpected path: %s", path)
+		}
+	}
+
+	localIPFn = func() (string, error) {
+		return "10.5.6.11", nil
+	}
+
+	entries, err := ParseHostResolveConf(defaultHostResolvConfPath)
+	require.NoError(t, err)
+	require.Equal(t, []string{"nameserver 10.5.6.11"}, entries)
+}


### PR DESCRIPTION
# Fix DNS resolution on Ubuntu 24 (Noble) stemcells

## Problem

On Concourse workers with Ubuntu Noble (24.04) stemcells, container DNS resolution was failing with:
```
dial tcp: lookup some.address.com on [::1]:53: read udp [::1]:58930->[::1]:53: read: connection refused
```

### Root Cause

**Upstream resolv.conf behavior changed between Ubuntu Jammy and Noble:**

- **Jammy** (22.04LTS): `/etc/resolv.conf` directly contained a routable DNS IP (e.g., `nameserver 172.18.96.9`)
- **Noble** (24.04LTS): `/etc/resolv.conf` is now a systemd-resolved stub resolver symlink with only loopback nameservers:
  ```
  nameserver 127.0.0.53
  nameserver ::1
  ```

**Concourse's DNS parser issue:**

The regex patterns in `worker/runtime/resolvconf_parser.go` only matched IPv4 loopback (`127.0.0.x`), not IPv6 loopback (`::1`). When systemd-resolved's stub was detected as loopback-only, the parser would:
1. Fall back to `localip.LocalIP()` (the worker VM IP)
2. Write that to the container's `/etc/resolv.conf`
3. Containers then tried to query that VM IP, which was unreachable from the container network namespace
4. This cascaded to DNS defaulting to `[::1]:53`, which didn't exist, causing connection refused

## Solution

Updated `worker/runtime/resolvconf_parser.go` to:

1. **Add IPv6 loopback to regex patterns** — both `127.0.0.x` and `::1` are now recognized as loopback and handled uniformly
2. **Implement systemd-resolved upstream fallback** — when host `/etc/resolv.conf` is loopback-only on Noble, parser now:
   - Attempts to read upstream resolvers from `/run/systemd/resolve/resolv.conf` 
   - Uses those if available (correct for Noble)
   - Falls back to worker IP only if upstream file is unavailable (backward compatibility for older/edge cases)
3. **Preserve non-loopback passthrough** — if `/etc/resolv.conf` contains any usable non-loopback nameserver, it passes through unchanged (Jammy behavior preserved)

## Changes

### Modified Files

- **`worker/runtime/resolvconf_parser.go`**
  - Updated `loopbackNameserverRegexp` to match both `127.0.0.x` and `::1` with multiline mode
  - Updated `loopbackIPRegexp` to strip both IPv4 and IPv6 loopback
  - Added `systemdResolvedResolvConfPath` constant pointing to systemd upstream resolv.conf
  - Refactored logic to:
    - Parse entries first, return immediately if any valid nameserver exists
    - Only attempt fallbacks when all nameservers are loopback
    - Try systemd-resolved upstream file before falling back to worker IP
  - Added testable hooks (`readFileFn`, `localIPFn`) for deterministic testing without exporting test-only APIs

- **`worker/runtime/resolvconf_parser_internal_test.go`** (new file)
  - Tests systemd-resolved upstream fallback behavior (Noble scenario)
  - Tests local IP fallback when upstream is unavailable (backward compatibility)
  - Uses internal package scope to access unexported test helpers

### Why Separate Test File?

The internal tests need access to unexported helpers (`readFileFn`, `localIPFn`, default path constants) to stub I/O deterministically. Placing them in package `runtime` (not `runtime_test`) allows this without polluting the public API. The existing `resolvconf_parser_test.go` remains in package `runtime_test` for black-box behavior validation.

## Testing

- ✅ Validated with manually built binary on **Ubuntu Noble (24.04)** stemcell — containers now resolve DNS correctly
- ✅ Validated backward compatibility on **Ubuntu Jammy (22.04)** stemcell — existing behavior unchanged
- ✅ All existing runtime tests pass: `ginkgo -r ./worker/runtime`
- ✅ New internal tests confirm both fallback paths work correctly

## Behavior Summary

| Scenario | Before | After |
|----------|--------|-------|
| **Jammy** with upstream DNS in `/etc/resolv.conf` | ✓ Passes through | ✓ Passes through |
| **Noble** with systemd stub only | ✗ Tries `[::1]:53` → connection refused | ✓ Uses systemd upstream resolvers |
| **Edge case**: No upstream available | Uses worker IP | Uses worker IP (fallback) |

## Backward Compatibility

- Jammy and older stemcells with routable DNS IPs in `/etc/resolv.conf` are unaffected
- If systemd upstream file is missing (legacy/custom setups), behavior reverts to worker IP (same as before)
- No configuration changes required; this is fully transparent

## Related Issue

This fixes DNS resolution failures introduced by Ubuntu 24's systemd-resolved stub resolver changes for Concourse workers on Noble stemcells.
