### PR TITLE
fix: handle all IPv4 loopback resolvers

### DIFF
--- a/worker/runtime/resolvconf_parser.go
+++ b/worker/runtime/resolvconf_parser.go
@@ -18,7 +18,7 @@ var (
 	localIPFn                     = localip.LocalIP
 
 	// Regular expressions used for DNS resolution parsing
-	loopbackNameserverRegexp = regexp.MustCompile(`(?m)^\s*nameserver\s+(?:127\.0\.0\.\d+|::1)\s*$`)
+	loopbackNameserverRegexp = regexp.MustCompile(`(?m)^\s*nameserver\s+(?:127\.\d{1,3}\.\d{1,3}\.\d{1,3}|::1)\s*$`)
 	loopbackIPRegexp         = regexp.MustCompile(`(?:127\.\d{1,3}\.\d{1,3}\.\d{1,3}|::1)`)
 )
 

--- a/worker/runtime/resolvconf_parser_internal_test.go
+++ b/worker/runtime/resolvconf_parser_internal_test.go
@@ -64,3 +64,24 @@ func TestParseHostResolveConf_FallsBackToLocalIPWhenSystemdResolvedUnavailable(t
 	require.NoError(t, err)
 	require.Equal(t, []string{"nameserver 10.5.6.11"}, entries)
 }
+
+func TestParseHostResolveConf_FallsBackToLocalIPForAnyIPv4LoopbackNameserver(t *testing.T) {
+	oldReadFileFn := readFileFn
+	oldLocalIPFn := localIPFn
+	defer func() {
+		readFileFn = oldReadFileFn
+		localIPFn = oldLocalIPFn
+	}()
+
+	readFileFn = func(path string) ([]byte, error) {
+		return []byte("nameserver 127.1.2.3\n"), nil
+	}
+
+	localIPFn = func() (string, error) {
+		return "10.5.6.11", nil
+	}
+
+	entries, err := ParseHostResolveConf("/tmp/resolv.conf")
+	require.NoError(t, err)
+	require.Equal(t, []string{"nameserver 10.5.6.11"}, entries)
+}


### PR DESCRIPTION
Small follow-up to #9565. The parser already drops any `127.x.x.x` nameserver from container resolv.conf, but the fallback check only noticed `127.0.0.x`. So `127.1.2.3` got dropped and then... no nameserver. tiny DNS papercut, imo.

Repro, before this patch:
```sh
go test ./worker/runtime -run TestParseHostResolveConf_FallsBackToLocalIPForAnyIPv4LoopbackNameserver -count=1
```

It failed with `actual: []string(nil)`, because fallback never kicked in.

Fix is just making the loopback detector match the same IPv4 loopback range the parser already filters: `127.0.0.0/8`.

Checked:
```sh
go test ./worker/runtime -count=1
git diff origin/master...HEAD --check
```