### PR TITLE
Fix pipeline rendering when resources have no icon

### DIFF
--- a/web/public/index.mjs
+++ b/web/public/index.mjs
@@ -719,6 +719,10 @@ export function addIcon(iconName, nodeId) {
 
   var id = `${nodeId}-svg-icon`;
 
+  if (!iconName) {
+    return;
+  }
+
   if (iconName.startsWith("si/")) {
     simpleIconsModulePromise.then((icons) => {
       if (document.getElementById(id) === null) {


### PR DESCRIPTION
## Changes proposed by this PR

closes #9570 

_Make sure to follow all [PR requirements](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements)._

* Added a guard for null `icon` references in resources.

## Notes to reviewer

@selzoc's test pipeline in #9570 was my test case, and I enhanced it to use one resource with an icon and one without
