### PR TITLE
Ensure resources that have never been checked are looked up by manually triggered builds

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -525,9 +525,9 @@ func (b *build) ResourcesChecked() (bool, error) {
 			SELECT 1
 			FROM resources r
 			JOIN job_inputs ji ON ji.resource_id = r.id
-			JOIN resource_config_scopes rs ON r.resource_config_scope_id = rs.id
+			LEFT JOIN resource_config_scopes rs ON r.resource_config_scope_id = rs.id
 			WHERE ji.job_id = $1 AND ji.passed_job_id IS NULL
-			AND rs.last_check_end_time < $2
+			AND (rs.last_check_end_time < $2 OR rs.id IS NULL)
 			AND NOT EXISTS (
 				SELECT
 				FROM resource_pins

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -2336,8 +2336,6 @@ var _ = Describe("Build", func() {
 
 			scenario = dbtest.Setup(
 				builder.WithPipeline(pipelineConfig),
-				builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"some": "version"}),
-				builder.WithResourceVersions("some-other-resource", time.Minute, atc.Version{"some": "other-version"}),
 				builder.WithPendingJobBuild(&build, "some-job"),
 			)
 		})
@@ -2345,8 +2343,8 @@ var _ = Describe("Build", func() {
 		Context("when all the resources in the build have been checked", func() {
 			BeforeEach(func() {
 				scenario.Run(
-					builder.WithResourceVersions("some-resource", time.Minute),
-					builder.WithResourceVersions("some-other-resource", time.Minute),
+					builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"some": "version"}),
+					builder.WithResourceVersions("some-other-resource", time.Minute, atc.Version{"some": "other-version"}),
 				)
 			})
 
@@ -2359,9 +2357,9 @@ var _ = Describe("Build", func() {
 
 		Context("when a resource in the build has not been checked", func() {
 			BeforeEach(func() {
-				By("not checking some-other-resource")
+				By("not checking 'some-other-resource'")
 				scenario.Run(
-					builder.WithResourceVersions("some-resource", time.Minute),
+					builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"some": "version"}),
 				)
 			})
 			It("returns false", func() {
@@ -2374,7 +2372,8 @@ var _ = Describe("Build", func() {
 		Context("when a pinned resource in the build has not been checked", func() {
 			BeforeEach(func() {
 				scenario.Run(
-					builder.WithResourceVersions("some-resource", time.Minute),
+					builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"some": "version"}),
+					builder.WithResourceVersions("some-other-resource", time.Minute, atc.Version{"some": "other-version"}),
 				)
 
 				rcv := scenario.ResourceVersion("some-other-resource", atc.Version{"some": "other-version"})


### PR DESCRIPTION
## Changes proposed by this PR

closes #9573

Resources that have never been checked don't have resource config scopes
created. The query in `build.ResourcesChecked()` wouldn't catch this
because we did a JOIN which dropped any resources that had not been
checked yet. Converting it to a LEFT JOIN now includes resources like
that and we look for them with the `rs.id IS NULL` check.