### PR TITLE
Remove legacy `X-XSS-Protection` response header

### DIFF
--- a/atc/wrappa/security_handler.go
+++ b/atc/wrappa/security_handler.go
@@ -19,7 +19,6 @@ func (handler SecurityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	if handler.StrictTransportSecurity != "" {
 		w.Header().Set("Strict-Transport-Security", handler.StrictTransportSecurity)
 	}
-	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Download-Options", "noopen")
 	w.Header().Set("Cache-Control", "no-store, private")

--- a/atc/wrappa/security_handler_test.go
+++ b/atc/wrappa/security_handler_test.go
@@ -37,7 +37,6 @@ var _ = Describe("SecurityHandler", func() {
 	})
 
 	It("sets the correct security headers", func() {
-		Expect(rw.Header().Get("X-XSS-Protection")).To(Equal("1; mode=block"))
 		Expect(rw.Header().Get("X-Content-Type-Options")).To(Equal("nosniff"))
 		Expect(rw.Header().Get("X-Download-Options")).To(Equal("noopen"))
 		Expect(rw.Header().Get("Cache-Control")).To(Equal("no-store, private"))


### PR DESCRIPTION
## Changes proposed by this PR

* Removes the deprecated `X-XSS-Protection` header from ATC responses.
* Updates tests to reflect the header removal.
* Aligns Concourse with current browser guidance by dropping a non-standard legacy header that is no longer recommended - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection

## Notes to reviewer

`X-XSS-Protection` is a legacy header that modern browsers do not meaningfully rely on. Removing it should not change behavior for supported modern browsers.

## Release Note

* Concourse no longer sends the deprecated `X-XSS-Protection` response header.