### PR TITLE
Use session signing key to derive state signing key

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -2,8 +2,8 @@ package atccmd
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
+	"crypto/hkdf"
+	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
@@ -2020,6 +2020,16 @@ func (cmd *RunCommand) constructSkyHandler(
 		Scopes:       []string{"openid", "profile", "email", "federated:id", "groups"},
 	}
 
+	marshaledKey, err := x509.MarshalPKCS8PrivateKey(cmd.Auth.AuthFlags.SigningKey.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("sky server reading session signing key: %w", err)
+	}
+
+	stateKey, err := hkdf.Key(sha512.New, marshaledKey, nil, "concourse sky server state signing key", 64)
+	if err != nil {
+		return nil, fmt.Errorf("sky server generating state signing key: %w", err)
+	}
+
 	skyServer, err := skyserver.NewSkyServer(&skyserver.SkyConfig{
 		Logger:             logger.Session("sky"),
 		TokenMiddleware:    middleware,
@@ -2028,25 +2038,13 @@ func (cmd *RunCommand) constructSkyHandler(
 		HTTPClient:         httpClient,
 		ClaimsCacher:       claimsCacher,
 		AccessTokenFactory: accessTokenFactory,
-		StateSigningKey: deriveStateSigningKey(
-			oauth2Config.ClientID,
-			oauth2Config.ClientSecret,
-			cmd.Postgres.User,
-			cmd.Postgres.Password),
+		StateSigningKey:    stateKey,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return skyserver.NewSkyHandler(skyServer), nil
-}
-
-func deriveStateSigningKey(clientID, clientSecret, dbUser, dbPassword string) []byte {
-	mac := hmac.New(sha256.New, []byte(clientSecret))
-	mac.Write([]byte(clientID))
-	mac.Write([]byte(dbUser))
-	mac.Write([]byte(dbPassword))
-	return mac.Sum(nil)
 }
 
 func (cmd *RunCommand) constructTokenVerifier(claimsCacher accessor.AccessTokenFetcher) accessor.TokenVerifier {


### PR DESCRIPTION
## Changes proposed by this PR

closes #9578

Previous key derivation method caused issues for operators where each web node got unique database credentials. This resulted in each web node having a different state signing key and users getting auth errors when they inevitably hit a different web node.

Using hkdf, we derive a state signing key 64 bytes in length from the already provided session signing RSA key. It's important to note that we're not using the RSA key as the state signing key; we are using it to derive a NEW key that will be used as the state signing key. Since all web nodes have to have the same session signing key, this ensures all web nodes derive the same state signing key.

This setup avoids us having to add another config option to Concourse and increasing operator complexity.