### PR TITLE
atc: behaviour: add origin_pipeline to OPA payload

### DIFF
--- a/atc/engine/set_pipeline_delegate.go
+++ b/atc/engine/set_pipeline_delegate.go
@@ -50,15 +50,16 @@ func (delegate *setPipelineStepDelegate) SetPipelineChanged(logger lager.Logger,
 	logger.Debug("set pipeline changed")
 }
 
-func (delegate *setPipelineStepDelegate) CheckRunSetPipelinePolicy(atcConfig *atc.Config) error {
+func (delegate *setPipelineStepDelegate) CheckRunSetPipelinePolicy(targetPipeline string, atcConfig *atc.Config) error {
 	if !delegate.policyChecker.ShouldCheckAction(policy.ActionRunSetPipeline) {
 		return nil
 	}
 
 	return delegate.checkPolicy(policy.PolicyCheckInput{
-		Action:   policy.ActionRunSetPipeline,
-		Team:     delegate.build.TeamName(),
-		Pipeline: delegate.build.PipelineName(),
-		Data:     atcConfig,
+		Action:         policy.ActionRunSetPipeline,
+		Team:           delegate.build.TeamName(),
+		Pipeline:       targetPipeline,
+		OriginPipeline: delegate.build.PipelineName(),
+		Data:           atcConfig,
 	})
 }

--- a/atc/engine/set_pipeline_delegate_test.go
+++ b/atc/engine/set_pipeline_delegate_test.go
@@ -83,7 +83,7 @@ var _ = Describe("SetPipelineStepDelegate", func() {
 				},
 			}
 
-			checkErr = delegate.CheckRunSetPipelinePolicy(&pipelineConfig)
+			checkErr = delegate.CheckRunSetPipelinePolicy("target-pipeline", &pipelineConfig)
 		})
 
 		Context("when the action does not need to be checked", func() {
@@ -110,10 +110,11 @@ var _ = Describe("SetPipelineStepDelegate", func() {
 
 				input := fakePolicyChecker.CheckArgsForCall(0)
 				Expect(input).To(Equal(policy.PolicyCheckInput{
-					Action:   policy.ActionRunSetPipeline,
-					Team:     "some-team",
-					Pipeline: "some-pipeline",
-					Data:     &pipelineConfig,
+					Action:         policy.ActionRunSetPipeline,
+					Team:           "some-team",
+					Pipeline:       "target-pipeline",
+					OriginPipeline: "some-pipeline",
+					Data:           &pipelineConfig,
 				}))
 			})
 

--- a/atc/exec/build_step_delegate.go
+++ b/atc/exec/build_step_delegate.go
@@ -53,5 +53,5 @@ type SetPipelineStepDelegateFactory interface {
 type SetPipelineStepDelegate interface {
 	BuildStepDelegate
 	SetPipelineChanged(lager.Logger, bool)
-	CheckRunSetPipelinePolicy(*atc.Config) error
+	CheckRunSetPipelinePolicy(targetPipeline string, config *atc.Config) error
 }

--- a/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
+++ b/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
@@ -38,10 +38,11 @@ type FakeSetPipelineStepDelegate struct {
 	buildStartTimeReturnsOnCall map[int]struct {
 		result1 time.Time
 	}
-	CheckRunSetPipelinePolicyStub        func(*atc.Config) error
+	CheckRunSetPipelinePolicyStub        func(string, *atc.Config) error
 	checkRunSetPipelinePolicyMutex       sync.RWMutex
 	checkRunSetPipelinePolicyArgsForCall []struct {
-		arg1 *atc.Config
+		arg1 string
+		arg2 *atc.Config
 	}
 	checkRunSetPipelinePolicyReturns struct {
 		result1 error
@@ -300,18 +301,19 @@ func (fake *FakeSetPipelineStepDelegate) BuildStartTimeReturnsOnCall(i int, resu
 	}{result1}
 }
 
-func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicy(arg1 *atc.Config) error {
+func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicy(arg1 string, arg2 *atc.Config) error {
 	fake.checkRunSetPipelinePolicyMutex.Lock()
 	ret, specificReturn := fake.checkRunSetPipelinePolicyReturnsOnCall[len(fake.checkRunSetPipelinePolicyArgsForCall)]
 	fake.checkRunSetPipelinePolicyArgsForCall = append(fake.checkRunSetPipelinePolicyArgsForCall, struct {
-		arg1 *atc.Config
-	}{arg1})
+		arg1 string
+		arg2 *atc.Config
+	}{arg1, arg2})
 	stub := fake.CheckRunSetPipelinePolicyStub
 	fakeReturns := fake.checkRunSetPipelinePolicyReturns
-	fake.recordInvocation("CheckRunSetPipelinePolicy", []interface{}{arg1})
+	fake.recordInvocation("CheckRunSetPipelinePolicy", []interface{}{arg1, arg2})
 	fake.checkRunSetPipelinePolicyMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -325,17 +327,17 @@ func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicyCallCount() in
 	return len(fake.checkRunSetPipelinePolicyArgsForCall)
 }
 
-func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicyCalls(stub func(*atc.Config) error) {
+func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicyCalls(stub func(string, *atc.Config) error) {
 	fake.checkRunSetPipelinePolicyMutex.Lock()
 	defer fake.checkRunSetPipelinePolicyMutex.Unlock()
 	fake.CheckRunSetPipelinePolicyStub = stub
 }
 
-func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicyArgsForCall(i int) *atc.Config {
+func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicyArgsForCall(i int) (string, *atc.Config) {
 	fake.checkRunSetPipelinePolicyMutex.RLock()
 	defer fake.checkRunSetPipelinePolicyMutex.RUnlock()
 	argsForCall := fake.checkRunSetPipelinePolicyArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicyReturns(result1 error) {

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -224,7 +224,7 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 		return true, nil
 	}
 
-	err = delegate.CheckRunSetPipelinePolicy(&atcConfig)
+	err = delegate.CheckRunSetPipelinePolicy(pipelineRef.Name, &atcConfig)
 	if err != nil {
 		return false, err
 	}

--- a/atc/policy/checker.go
+++ b/atc/policy/checker.go
@@ -43,6 +43,7 @@ type PolicyCheckInput struct {
 	Team           string   `json:"team,omitempty"`
 	Roles          []string `json:"roles,omitempty"`
 	Pipeline       string   `json:"pipeline,omitempty"`
+	OriginPipeline string   `json:"origin_pipeline,omitempty"`
 	Data           any      `json:"data,omitempty"`
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

Pipelines can be set via fly or in a step. In the latter case, there are two pipelines: the origin pipeline that has been run and the target pipeline actually being set.

The payload sent to OPA server now distinguishes the two. `pipeline` will indicate the pipeline being set where `origin_pipeline` refers to the pipeline doing the set-pipeline.

Docs PR: https://github.com/concourse/docs/pull/608

closes #9507

## Release Note

* Breaking Change: Set-Pipeline OPA payload improvement
  * the payload sent to an OPA server when setting pipeline now includes `origin_pipeline`
  * In the case of pipeline being set by another pipeline, `pipeline` previously referred to the setting pipeline and not the target pipeline
  * the setting pipeline is now available in `origin_pipeline` and `pipeline` refers to the pipeline being set
