### PR TITLE
unescape the redirect uri before further parsing it

### DIFF
--- a/skymarshal/skyserver/skyserver.go
+++ b/skymarshal/skyserver/skyserver.go
@@ -162,14 +162,46 @@ func (s *SkyServer) Callback(w http.ResponseWriter, r *http.Request) {
 func (s *SkyServer) Redirect(w http.ResponseWriter, r *http.Request, oauth2Token *oauth2.Token, redirectURI string) {
 	logger := s.config.Logger.Session("redirect")
 
-	redirectURL, err := url.ParseRequestURI("/" + strings.TrimLeft(redirectURI, "/"))
+	// Iteratively unescape so stacked encodings (e.g. %25252F -> %252F -> %2F)
+	// cannot sneak a "/" past the TrimLeft check below.
+	uri := redirectURI
+	unescaped := false
+	for range 5 { // Cap at 5 times so we don't get stuck in here forever
+		decoded, err := url.QueryUnescape(uri)
+		if err != nil {
+			logger.Error("failed-to-unescape-redirect-url", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if decoded == uri {
+			unescaped = true
+			break
+		}
+		uri = decoded
+	}
+
+	if !unescaped {
+		logger.Error("failed-to-unescape-redirect-url", fmt.Errorf("escaped the URI a max of 5 times: %s", redirectURI))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Some browsers and proxies normalise "\" to "/", which would turn
+	// /\example.com into //example.com (protocol-relative) after the redirect.
+	if strings.Contains(uri, `\`) {
+		logger.Error("invalid-redirect", fmt.Errorf("Unsupported redirect uri: %s", redirectURI))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	redirectURL, err := url.ParseRequestURI("/" + strings.TrimLeft(uri, "/"))
 	if err != nil {
 		logger.Error("failed-to-parse-redirect-url", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	if redirectURL.Host != "" || redirectURL.Scheme != "" {
+	if redirectURL.Host != "" || redirectURL.Scheme != "" || strings.HasPrefix(redirectURL.Path, "//") {
 		logger.Error("invalid-redirect", fmt.Errorf("Unsupported redirect uri: %s", redirectURI))
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/skymarshal/skyserver/skyserver_test.go
+++ b/skymarshal/skyserver/skyserver_test.go
@@ -501,6 +501,145 @@ var _ = Describe("Sky Server API", func() {
 							})
 						})
 
+						Context("when redirect URI is single-encoded", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("/%2Fexample.com", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("normalises to a same-origin path", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+								locationURL, err := response.Request.Response.Location()
+								Expect(err).NotTo(HaveOccurred())
+								Expect(locationURL.Path).To(Equal("/example.com"))
+							})
+						})
+
+						Context("when redirect URI is double-encoded", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("/%252Fexample.com", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("normalises to a same-origin path", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+								locationURL, err := response.Request.Response.Location()
+								Expect(err).NotTo(HaveOccurred())
+								Expect(locationURL.Path).To(Equal("/example.com"))
+							})
+						})
+
+						Context("when redirect URI is triple-encoded", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("%25252Fexample.com", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("normalises to a same-origin path (regression for multi-encoding bypass)", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+								locationURL, err := response.Request.Response.Location()
+								Expect(err).NotTo(HaveOccurred())
+								Expect(locationURL.Path).To(Equal("/example.com"))
+							})
+						})
+
+						Context("when redirect URI is encoded more than 5 times", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("%25252525252525252525252525252525252525252Fexample.com", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("returns 400", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+							})
+						})
+
+						Context("when redirect URI is encoded protocol-relative", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("%2F%2Fexample.com", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("normalises to a same-origin path", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+								locationURL, err := response.Request.Response.Location()
+								Expect(err).NotTo(HaveOccurred())
+								Expect(locationURL.Path).To(Equal("/example.com"))
+							})
+						})
+
+						Context("when redirect URI uses mixed-case percent-hex", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("/%2fexample.com", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("normalises to a same-origin path", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+								locationURL, err := response.Request.Response.Location()
+								Expect(err).NotTo(HaveOccurred())
+								Expect(locationURL.Path).To(Equal("/example.com"))
+							})
+						})
+
+						Context("when redirect URI contains a literal backslash", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken(`/\example.com`, time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("returns 400", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+							})
+						})
+
+						Context("when redirect URI is encoded-backslash", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("/%5Cexample.com", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("returns 400", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+							})
+						})
+
+						Context("when redirect URI is double-encoded backslash", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("/%255Cexample.com", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("returns 400", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+							})
+						})
+
+						Context("when redirect URI is two backslashes", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken(`\\example.com`, time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("returns 400", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+							})
+						})
+
+						Context("when redirect URI contains a legitimate %20 space", func() {
+							BeforeEach(func() {
+								stateToken := signStateToken("/teams/main/pipelines/my%20pipeline", time.Now().Unix())
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("preserves the path and redirects", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+								locationURL, err := response.Request.Response.Location()
+								Expect(err).NotTo(HaveOccurred())
+								Expect(locationURL.Path).To(Equal("/teams/main/pipelines/my pipeline"))
+							})
+						})
+
 						Context("when redirecting to the ATC", func() {
 							BeforeEach(func() {
 								stateToken := signStateToken("/valid-redirect", time.Now().Unix())


### PR DESCRIPTION
## Changes proposed by this PR

Further hardens the redirect function in the skyserver used during the login flow.
