### PR TITLE
feat: Add health endpoint basic structures and routes

### DIFF
--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -59,6 +59,7 @@ var (
 	dbWorkerFactory         *dbfakes.FakeWorkerFactory
 	dbWorkerTeamFactory     *dbfakes.FakeTeamFactory
 	dbWorkerLifecycle       *dbfakes.FakeWorkerLifecycle
+	fakeDbConn              *dbfakes.FakeDbConn
 	build                   *dbfakes.FakeBuild
 	dbBuildFactory          *dbfakes.FakeBuildFactory
 	dbUserFactory           *dbfakes.FakeUserFactory
@@ -138,6 +139,7 @@ var _ = BeforeEach(func() {
 
 	dbWorkerFactory = new(dbfakes.FakeWorkerFactory)
 	dbWorkerLifecycle = new(dbfakes.FakeWorkerLifecycle)
+	fakeDbConn = new(dbfakes.FakeDbConn)
 
 	fakeWorkerPool = new(apifakes.FakePool)
 
@@ -209,6 +211,8 @@ var _ = BeforeEach(func() {
 		dbResourceConfigFactory,
 		dbUserFactory,
 		dbComponentFactory,
+		fakeDbConn,
+		1, // minWorkerCount
 
 		constructedEventHandler.Construct,
 

--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -212,7 +212,8 @@ var _ = BeforeEach(func() {
 		dbUserFactory,
 		dbComponentFactory,
 		fakeDbConn,
-		1, // minWorkerCount
+		1,   // minWorkerCount
+		2.0, // componentStaleMultiplier
 
 		constructedEventHandler.Construct,
 

--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -167,16 +167,13 @@ var _ = BeforeEach(func() {
 
 	build = new(dbfakes.FakeBuild)
 
-	checkPipelineAccessHandlerFactory := auth.NewCheckPipelineAccessHandlerFactory(dbTeamFactory)
-
-	checkBuildReadAccessHandlerFactory := auth.NewCheckBuildReadAccessHandlerFactory(dbBuildFactory)
-
-	checkBuildWriteAccessHandlerFactory := auth.NewCheckBuildWriteAccessHandlerFactory(dbBuildFactory)
-
-	checkWorkerTeamAccessHandlerFactory := auth.NewCheckWorkerTeamAccessHandlerFactory(dbWorkerFactory)
-
 	fakePolicyChecker = new(policycheckerfakes.FakePolicyChecker)
 	fakePolicyChecker.CheckReturns(policy.PassedPolicyCheck(), nil)
+
+	checkPipelineAccessHandlerFactory := auth.NewCheckPipelineAccessHandlerFactory(dbTeamFactory)
+	checkBuildReadAccessHandlerFactory := auth.NewCheckBuildReadAccessHandlerFactory(dbBuildFactory)
+	checkBuildWriteAccessHandlerFactory := auth.NewCheckBuildWriteAccessHandlerFactory(dbBuildFactory)
+	checkWorkerTeamAccessHandlerFactory := auth.NewCheckWorkerTeamAccessHandlerFactory(dbWorkerFactory)
 
 	apiWrapper := wrappa.MultiWrappa{
 		wrappa.NewPolicyCheckWrappa(logger, fakePolicyChecker),
@@ -263,6 +260,50 @@ var _ = AfterEach(func() {
 	os.Remove(cliDownloadsDir)
 	server.Close()
 })
+
+// buildTestServer constructs and starts a test HTTP server with the given minWorkerCount.
+// Use this in tests that need a non-default minWorkerCount (e.g. to exercise the degraded worker path).
+// Callers are responsible for closing the returned server.
+func buildTestServer(workerCount int) *httptest.Server {
+	checkPipelineAccessHandlerFactory := auth.NewCheckPipelineAccessHandlerFactory(dbTeamFactory)
+	checkBuildReadAccessHandlerFactory := auth.NewCheckBuildReadAccessHandlerFactory(dbBuildFactory)
+	checkBuildWriteAccessHandlerFactory := auth.NewCheckBuildWriteAccessHandlerFactory(dbBuildFactory)
+	checkWorkerTeamAccessHandlerFactory := auth.NewCheckWorkerTeamAccessHandlerFactory(dbWorkerFactory)
+
+	apiWrapper := wrappa.MultiWrappa{
+		wrappa.NewPolicyCheckWrappa(logger, fakePolicyChecker),
+		wrappa.NewAPIAuthWrappa(
+			checkPipelineAccessHandlerFactory,
+			checkBuildReadAccessHandlerFactory,
+			checkBuildWriteAccessHandlerFactory,
+			checkWorkerTeamAccessHandlerFactory,
+		),
+	}
+
+	handler, err := api.NewHandler(
+		logger,
+		externalURL, "", clusterName,
+		apiWrapper,
+		dbTeamFactory, dbPipelineFactory, dbJobFactory, dbResourceFactory,
+		dbWorkerFactory, dbWorkerTeamFactory, fakeVolumeRepository, fakeContainerRepository,
+		fakeDestroyer, dbBuildFactory, dbCheckFactory, dbResourceConfigFactory,
+		dbUserFactory, dbComponentFactory, fakeDbConn,
+		workerCount,
+		2.0,
+		constructedEventHandler.Construct,
+		fakeWorkerPool, sink, isTLSEnabled, cliDownloadsDir,
+		"1.2.3", "4.5.6",
+		fakeSecretManager, fakeVarSourcePool, credsManagers,
+		interceptTimeoutFactory, time.Second, dbWall, fakeClock, dbSigningKeyFactory,
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	accessorHandler := accessor.NewHandler(
+		logger, "some-action", handler, fakeAccessor,
+		new(auditorfakes.FakeAuditor), map[string]string{},
+	)
+	return httptest.NewServer(wrappa.LoggerHandler{Logger: logger, Handler: accessorHandler})
+}
 
 func TestAPI(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -85,6 +85,11 @@ var (
 	client *http.Client
 )
 
+func TestAPI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "API Suite")
+}
+
 type fakeEventHandlerFactory struct {
 	build db.BuildForAPI
 
@@ -170,6 +175,31 @@ var _ = BeforeEach(func() {
 	fakePolicyChecker = new(policycheckerfakes.FakePolicyChecker)
 	fakePolicyChecker.CheckReturns(policy.PassedPolicyCheck(), nil)
 
+	server = newApiTestServer()
+
+	client = &http.Client{
+		Transport: &http.Transport{},
+	}
+})
+
+var _ = AfterEach(func() {
+	os.Remove(cliDownloadsDir)
+	server.Close()
+})
+
+func newApiTestServer(opts ...apiConfigOpt) *httptest.Server {
+	testServerConfig := &apiServerConfig{
+		workerCount:              1,
+		componentStaleMultiplier: 2.0,
+		concourseVersion:         "1.2.3",
+		workerVersion:            "4.5.6",
+		interceptUpdateInterval:  time.Second,
+	}
+
+	for _, opt := range opts {
+		opt(testServerConfig)
+	}
+
 	checkPipelineAccessHandlerFactory := auth.NewCheckPipelineAccessHandlerFactory(dbTeamFactory)
 	checkBuildReadAccessHandlerFactory := auth.NewCheckBuildReadAccessHandlerFactory(dbBuildFactory)
 	checkBuildWriteAccessHandlerFactory := auth.NewCheckBuildWriteAccessHandlerFactory(dbBuildFactory)
@@ -189,7 +219,7 @@ var _ = BeforeEach(func() {
 		logger,
 
 		externalURL,
-		"",
+		"", // OIDC issuer
 		clusterName,
 
 		apiWrapper,
@@ -209,8 +239,8 @@ var _ = BeforeEach(func() {
 		dbUserFactory,
 		dbComponentFactory,
 		fakeDbConn,
-		1,   // minWorkerCount
-		2.0, // componentStaleMultiplier
+		testServerConfig.workerCount,
+		testServerConfig.componentStaleMultiplier,
 
 		constructedEventHandler.Construct,
 
@@ -221,13 +251,13 @@ var _ = BeforeEach(func() {
 		isTLSEnabled,
 
 		cliDownloadsDir,
-		"1.2.3",
-		"4.5.6",
+		testServerConfig.concourseVersion,
+		testServerConfig.workerVersion,
 		fakeSecretManager,
 		fakeVarSourcePool,
 		credsManagers,
 		interceptTimeoutFactory,
-		time.Second,
+		testServerConfig.interceptUpdateInterval,
 		dbWall,
 		fakeClock,
 		dbSigningKeyFactory,
@@ -249,63 +279,21 @@ var _ = BeforeEach(func() {
 		Handler: accessorHandler,
 	}
 
-	server = httptest.NewServer(handler)
-
-	client = &http.Client{
-		Transport: &http.Transport{},
-	}
-})
-
-var _ = AfterEach(func() {
-	os.Remove(cliDownloadsDir)
-	server.Close()
-})
-
-// buildTestServer constructs and starts a test HTTP server with the given minWorkerCount.
-// Use this in tests that need a non-default minWorkerCount (e.g. to exercise the degraded worker path).
-// Callers are responsible for closing the returned server.
-func buildTestServer(workerCount int) *httptest.Server {
-	checkPipelineAccessHandlerFactory := auth.NewCheckPipelineAccessHandlerFactory(dbTeamFactory)
-	checkBuildReadAccessHandlerFactory := auth.NewCheckBuildReadAccessHandlerFactory(dbBuildFactory)
-	checkBuildWriteAccessHandlerFactory := auth.NewCheckBuildWriteAccessHandlerFactory(dbBuildFactory)
-	checkWorkerTeamAccessHandlerFactory := auth.NewCheckWorkerTeamAccessHandlerFactory(dbWorkerFactory)
-
-	apiWrapper := wrappa.MultiWrappa{
-		wrappa.NewPolicyCheckWrappa(logger, fakePolicyChecker),
-		wrappa.NewAPIAuthWrappa(
-			checkPipelineAccessHandlerFactory,
-			checkBuildReadAccessHandlerFactory,
-			checkBuildWriteAccessHandlerFactory,
-			checkWorkerTeamAccessHandlerFactory,
-		),
-	}
-
-	handler, err := api.NewHandler(
-		logger,
-		externalURL, "", clusterName,
-		apiWrapper,
-		dbTeamFactory, dbPipelineFactory, dbJobFactory, dbResourceFactory,
-		dbWorkerFactory, dbWorkerTeamFactory, fakeVolumeRepository, fakeContainerRepository,
-		fakeDestroyer, dbBuildFactory, dbCheckFactory, dbResourceConfigFactory,
-		dbUserFactory, dbComponentFactory, fakeDbConn,
-		workerCount,
-		2.0,
-		constructedEventHandler.Construct,
-		fakeWorkerPool, sink, isTLSEnabled, cliDownloadsDir,
-		"1.2.3", "4.5.6",
-		fakeSecretManager, fakeVarSourcePool, credsManagers,
-		interceptTimeoutFactory, time.Second, dbWall, fakeClock, dbSigningKeyFactory,
-	)
-	Expect(err).NotTo(HaveOccurred())
-
-	accessorHandler := accessor.NewHandler(
-		logger, "some-action", handler, fakeAccessor,
-		new(auditorfakes.FakeAuditor), map[string]string{},
-	)
-	return httptest.NewServer(wrappa.LoggerHandler{Logger: logger, Handler: accessorHandler})
+	return httptest.NewServer(handler)
 }
 
-func TestAPI(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "API Suite")
+type apiServerConfig struct {
+	workerCount              int
+	componentStaleMultiplier float64
+	concourseVersion         string
+	workerVersion            string
+	interceptUpdateInterval  time.Duration
+}
+
+type apiConfigOpt func(*apiServerConfig)
+
+func withWorkerCount(count int) apiConfigOpt {
+	return func(a *apiServerConfig) {
+		a.workerCount = count
+	}
 }

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -214,6 +214,7 @@ func NewHandler(
 		atc.DownloadCLI:  http.HandlerFunc(cliServer.Download),
 		atc.GetInfo:      http.HandlerFunc(infoServer.Info),
 		atc.GetInfoCreds: http.HandlerFunc(infoServer.Creds),
+		atc.GetHealth:    http.HandlerFunc(http.NotFound),
 
 		atc.GetUser:              http.HandlerFunc(usersServer.GetUser),
 		atc.ListActiveUsersSince: http.HandlerFunc(usersServer.GetUsersSince),

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -69,6 +69,7 @@ func NewHandler(
 	dbComponentFactory db.ComponentFactory,
 	dbConn db.DbConn,
 	minWorkerCount int,
+	componentStaleMultiplier float64,
 
 	eventHandlerFactory buildserver.EventHandlerFactory,
 
@@ -115,7 +116,7 @@ func NewHandler(
 	volumesServer := volumeserver.NewServer(logger, volumeRepository, destroyer)
 	teamServer := teamserver.NewServer(logger, dbTeamFactory, externalURL)
 	infoServer := infoserver.NewServer(logger, version, workerVersion, externalURL, clusterName, credsManagers)
-	healthServer := healthserver.NewServer(logger, dbConn, dbWorkerFactory, minWorkerCount)
+	healthServer := healthserver.NewServer(logger, dbConn, dbWorkerFactory, dbComponentFactory, minWorkerCount, componentStaleMultiplier)
 	artifactServer := artifactserver.NewServer(logger, workerPool)
 	usersServer := usersserver.NewServer(logger, dbUserFactory)
 	wallServer := wallserver.NewServer(dbWall, logger)

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -11,10 +11,11 @@ import (
 	"github.com/concourse/concourse/atc/api/artifactserver"
 	"github.com/concourse/concourse/atc/api/buildserver"
 	"github.com/concourse/concourse/atc/api/ccserver"
-	"github.com/concourse/concourse/atc/api/componentsserver"
 	"github.com/concourse/concourse/atc/api/cliserver"
+	"github.com/concourse/concourse/atc/api/componentsserver"
 	"github.com/concourse/concourse/atc/api/configserver"
 	"github.com/concourse/concourse/atc/api/containerserver"
+	"github.com/concourse/concourse/atc/api/healthserver"
 	"github.com/concourse/concourse/atc/api/idtokenserver"
 	"github.com/concourse/concourse/atc/api/infoserver"
 	"github.com/concourse/concourse/atc/api/jobserver"
@@ -66,6 +67,8 @@ func NewHandler(
 	dbResourceConfigFactory db.ResourceConfigFactory,
 	dbUserFactory db.UserFactory,
 	dbComponentFactory db.ComponentFactory,
+	dbConn db.DbConn,
+	minWorkerCount int,
 
 	eventHandlerFactory buildserver.EventHandlerFactory,
 
@@ -112,6 +115,7 @@ func NewHandler(
 	volumesServer := volumeserver.NewServer(logger, volumeRepository, destroyer)
 	teamServer := teamserver.NewServer(logger, dbTeamFactory, externalURL)
 	infoServer := infoserver.NewServer(logger, version, workerVersion, externalURL, clusterName, credsManagers)
+	healthServer := healthserver.NewServer(logger, dbConn, dbWorkerFactory, minWorkerCount)
 	artifactServer := artifactserver.NewServer(logger, workerPool)
 	usersServer := usersserver.NewServer(logger, dbUserFactory)
 	wallServer := wallserver.NewServer(dbWall, logger)
@@ -214,7 +218,7 @@ func NewHandler(
 		atc.DownloadCLI:  http.HandlerFunc(cliServer.Download),
 		atc.GetInfo:      http.HandlerFunc(infoServer.Info),
 		atc.GetInfoCreds: http.HandlerFunc(infoServer.Creds),
-		atc.GetHealth:    http.HandlerFunc(http.NotFound),
+		atc.GetHealth: http.HandlerFunc(healthServer.GetHealth),
 
 		atc.GetUser:              http.HandlerFunc(usersServer.GetUser),
 		atc.ListActiveUsersSince: http.HandlerFunc(usersServer.GetUsersSince),

--- a/atc/api/health_test.go
+++ b/atc/api/health_test.go
@@ -1,0 +1,240 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbfakes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// fakeRowScanner is a minimal squirrel.RowScanner that returns a fixed bool.
+type fakeRowScanner struct {
+	val interface{}
+	err error
+}
+
+func (f *fakeRowScanner) Scan(dest ...interface{}) error {
+	if f.err != nil {
+		return f.err
+	}
+	if len(dest) > 0 {
+		if d, ok := dest[0].(*bool); ok {
+			*d = f.val.(bool)
+		}
+	}
+	return nil
+}
+
+var _ sq.RowScanner = &fakeRowScanner{}
+
+func makeWorker(state db.WorkerState) *dbfakes.FakeWorker {
+	w := new(dbfakes.FakeWorker)
+	w.StateReturns(state)
+	return w
+}
+
+func dbHealthyStub(_ context.Context, _ string, _ ...any) sq.RowScanner {
+	return &fakeRowScanner{val: false} // pg_is_in_recovery = false → writable
+}
+
+func dbReadOnlyStub(_ context.Context, _ string, _ ...any) sq.RowScanner {
+	return &fakeRowScanner{val: true} // pg_is_in_recovery = true → standby
+}
+
+func dbDownStub(_ context.Context, _ string, _ ...any) sq.RowScanner {
+	return &fakeRowScanner{err: errors.New("connection refused")}
+}
+
+var _ = Describe("Health API", func() {
+	var response *http.Response
+
+	JustBeforeEach(func() {
+		var err error
+		response, err = client.Get(server.URL + "/api/v1/health")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		response.Body.Close()
+	})
+
+	Describe("GET /api/v1/health", func() {
+		Context("when the database is healthy and workers meet the threshold", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+					makeWorker(db.WorkerStateRunning),
+				}, nil)
+			})
+
+			It("returns 200", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+			})
+
+			It("returns status ok with healthy subsystems", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusOK))
+				Expect(health.Database.Status).To(Equal(atc.HealthStatusHealthy))
+				Expect(health.Workers.Status).To(Equal(atc.HealthStatusHealthy))
+				Expect(health.Workers.Total).To(Equal(2))
+				Expect(health.Workers.Running).To(Equal(2))
+			})
+
+			It("includes a recent timestamp", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Timestamp).To(BeTemporally("~", time.Now().UTC(), 5*time.Second))
+			})
+		})
+
+		Context("when running workers exactly meet the minimum threshold", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				// minWorkerCount=1 in suite; 1 running, 1 stalled → exactly meets threshold
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+					makeWorker(db.WorkerStateStalled),
+				}, nil)
+			})
+
+			It("returns 200", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+			})
+
+			It("returns status ok", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusOK))
+				Expect(health.Workers.Status).To(Equal(atc.HealthStatusHealthy))
+				Expect(health.Workers.Running).To(Equal(1))
+			})
+		})
+
+		Context("when running workers are below the minimum threshold but at least one exists", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				// minWorkerCount=1, but 0 running → degraded (there are workers, just none running)
+				// Actually with total=1 stalled, running=0 < minWorkerCount=1 → degraded path
+				// But our logic says running==0 → unhealthy, so let's test with minWorkerCount override
+				// The suite hardcodes minWorkerCount=1; to test degraded we'd need minWorkerCount=2.
+				// Instead test the failing path: stalled workers, running=0.
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateStalled),
+				}, nil)
+			})
+
+			It("returns 503", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusServiceUnavailable))
+			})
+
+			It("reports workers as unhealthy (no running workers)", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
+				Expect(health.Workers.Status).To(Equal(atc.HealthStatusUnhealthy))
+				Expect(health.Workers.Total).To(Equal(1))
+				Expect(health.Workers.Running).To(Equal(0))
+			})
+		})
+
+		Context("when there are no workers at all", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				dbWorkerFactory.WorkersReturns([]db.Worker{}, nil)
+			})
+
+			It("returns 503", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusServiceUnavailable))
+			})
+
+			It("reports workers as unhealthy with zero counts", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
+				Expect(health.Workers.Status).To(Equal(atc.HealthStatusUnhealthy))
+				Expect(health.Workers.Total).To(Equal(0))
+				Expect(health.Workers.Running).To(Equal(0))
+			})
+		})
+
+		Context("when the database is unreachable", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbDownStub
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+				}, nil)
+			})
+
+			It("returns 503", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusServiceUnavailable))
+			})
+
+			It("reports database as unhealthy and overall status as failing", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
+				Expect(health.Database.Status).To(Equal(atc.HealthStatusUnhealthy))
+				Expect(health.Database.Error).NotTo(BeEmpty())
+			})
+		})
+
+		Context("when the database is read-only (standby replica)", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbReadOnlyStub
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+				}, nil)
+			})
+
+			It("returns 503", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusServiceUnavailable))
+			})
+
+			It("reports database as unhealthy with a read-only error message", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
+				Expect(health.Database.Status).To(Equal(atc.HealthStatusUnhealthy))
+				Expect(health.Database.Error).To(ContainSubstring("read-only"))
+			})
+		})
+
+		Context("when workers cannot be fetched from the database", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				dbWorkerFactory.WorkersReturns(nil, errors.New("db error"))
+			})
+
+			It("returns 503", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusServiceUnavailable))
+			})
+
+			It("reports workers as unhealthy", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
+				Expect(health.Workers.Status).To(Equal(atc.HealthStatusUnhealthy))
+			})
+		})
+	})
+})

--- a/atc/api/health_test.go
+++ b/atc/api/health_test.go
@@ -43,6 +43,15 @@ func makeWorker(state db.WorkerState) *dbfakes.FakeWorker {
 	return w
 }
 
+func makeComponent(name string, interval time.Duration, lastRan time.Time, paused bool) *dbfakes.FakeComponent {
+	c := new(dbfakes.FakeComponent)
+	c.NameReturns(name)
+	c.IntervalReturns(interval)
+	c.LastRanReturns(lastRan)
+	c.PausedReturns(paused)
+	return c
+}
+
 func dbHealthyStub(_ context.Context, _ string, _ ...any) sq.RowScanner {
 	return &fakeRowScanner{val: false} // pg_is_in_recovery = false → writable
 }
@@ -234,6 +243,155 @@ var _ = Describe("Health API", func() {
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
 				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
 				Expect(health.Workers.Status).To(Equal(atc.HealthStatusUnhealthy))
+			})
+		})
+
+		Context("when a runtime component is stale", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+				}, nil)
+				// scheduler last ran 10 minutes ago, interval is 1 minute → 10x > 2x multiplier → stale
+				dbComponentFactory.AllReturns([]db.Component{
+					makeComponent(atc.ComponentScheduler, time.Minute, time.Now().Add(-10*time.Minute), false),
+					makeComponent(atc.ComponentBuildTracker, time.Minute, time.Now().Add(-30*time.Second), false),
+				}, nil)
+			})
+
+			It("returns 200 (degraded is not failing)", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+			})
+
+			It("reports overall status as degraded", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusDegraded))
+			})
+
+			It("marks the stale scheduler component as unhealthy", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+
+				var scheduler *atc.ComponentHealth
+				for i := range health.Components {
+					if health.Components[i].Name == atc.ComponentScheduler {
+						scheduler = &health.Components[i]
+					}
+				}
+				Expect(scheduler).NotTo(BeNil())
+				Expect(scheduler.Stale).To(BeTrue())
+				Expect(scheduler.Status).To(Equal(atc.HealthStatusUnhealthy))
+			})
+
+			It("marks the healthy tracker component as healthy", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+
+				var tracker *atc.ComponentHealth
+				for i := range health.Components {
+					if health.Components[i].Name == atc.ComponentBuildTracker {
+						tracker = &health.Components[i]
+					}
+				}
+				Expect(tracker).NotTo(BeNil())
+				Expect(tracker.Stale).To(BeFalse())
+				Expect(tracker.Status).To(Equal(atc.HealthStatusHealthy))
+			})
+		})
+
+		Context("when only a GC component is stale", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+				}, nil)
+				// collector_volumes last ran 1 hour ago, interval is 1 minute → stale, but GC only
+				dbComponentFactory.AllReturns([]db.Component{
+					makeComponent(atc.ComponentScheduler, time.Minute, time.Now().Add(-30*time.Second), false),
+					makeComponent(atc.ComponentCollectorVolumes, time.Minute, time.Now().Add(-time.Hour), false),
+				}, nil)
+			})
+
+			It("returns 200", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+			})
+
+			It("reports overall status as ok", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusOK))
+			})
+
+			It("marks the stale GC component as unhealthy in the JSON", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+
+				var collector *atc.ComponentHealth
+				for i := range health.Components {
+					if health.Components[i].Name == atc.ComponentCollectorVolumes {
+						collector = &health.Components[i]
+					}
+				}
+				Expect(collector).NotTo(BeNil())
+				Expect(collector.Stale).To(BeTrue())
+				Expect(collector.Status).To(Equal(atc.HealthStatusUnhealthy))
+			})
+		})
+
+		Context("when a component is paused", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+				}, nil)
+				// scheduler is paused and hasn't run — should not be considered stale
+				dbComponentFactory.AllReturns([]db.Component{
+					makeComponent(atc.ComponentScheduler, time.Minute, time.Now().Add(-time.Hour), true),
+				}, nil)
+			})
+
+			It("returns 200 with status ok", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusOK))
+			})
+
+			It("reports the component as paused and not stale", func() {
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+
+				Expect(health.Components).To(HaveLen(1))
+				Expect(health.Components[0].Paused).To(BeTrue())
+				Expect(health.Components[0].Stale).To(BeFalse())
+				Expect(health.Components[0].Status).To(Equal(atc.HealthStatusHealthy))
+			})
+		})
+
+		Context("when component factory returns an error", func() {
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+				}, nil)
+				dbComponentFactory.AllReturns(nil, errors.New("db error"))
+			})
+
+			It("returns 200 with status ok and empty components list", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusOK))
+				Expect(health.Components).To(BeEmpty())
 			})
 		})
 	})

--- a/atc/api/health_test.go
+++ b/atc/api/health_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -134,14 +135,49 @@ var _ = Describe("Health API", func() {
 			})
 		})
 
+		Context("when running workers are above zero but below the minimum threshold", func() {
+			var customServer *httptest.Server
+
+			BeforeEach(func() {
+				fakeDbConn.QueryRowContextStub = dbHealthyStub
+				// 2 running workers, minWorkerCount=3 → below threshold → degraded
+				dbWorkerFactory.WorkersReturns([]db.Worker{
+					makeWorker(db.WorkerStateRunning),
+					makeWorker(db.WorkerStateRunning),
+					makeWorker(db.WorkerStateStalled),
+				}, nil)
+				customServer = buildTestServer(3)
+			})
+
+			AfterEach(func() {
+				customServer.Close()
+			})
+
+			It("returns 200 (degraded is not failing)", func() {
+				response, err := client.Get(customServer.URL + "/api/v1/health")
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+			})
+
+			It("returns status degraded", func() {
+				response, err := client.Get(customServer.URL + "/api/v1/health")
+				Expect(err).NotTo(HaveOccurred())
+				defer response.Body.Close()
+
+				body, _ := io.ReadAll(response.Body)
+				var health atc.Health
+				Expect(json.Unmarshal(body, &health)).To(Succeed())
+				Expect(health.Status).To(Equal(atc.HealthStatusDegraded))
+				Expect(health.Workers.Status).To(Equal(atc.HealthStatusDegraded))
+				Expect(health.Workers.Running).To(Equal(2))
+				Expect(health.Workers.Total).To(Equal(3))
+			})
+		})
+
 		Context("when running workers are below the minimum threshold but at least one exists", func() {
 			BeforeEach(func() {
 				fakeDbConn.QueryRowContextStub = dbHealthyStub
-				// minWorkerCount=1, but 0 running → degraded (there are workers, just none running)
-				// Actually with total=1 stalled, running=0 < minWorkerCount=1 → degraded path
-				// But our logic says running==0 → unhealthy, so let's test with minWorkerCount override
-				// The suite hardcodes minWorkerCount=1; to test degraded we'd need minWorkerCount=2.
-				// Instead test the failing path: stalled workers, running=0.
 				dbWorkerFactory.WorkersReturns([]db.Worker{
 					makeWorker(db.WorkerStateStalled),
 				}, nil)

--- a/atc/api/health_test.go
+++ b/atc/api/health_test.go
@@ -270,7 +270,7 @@ var _ = Describe("Health API", func() {
 				Expect(health.Status).To(Equal(atc.HealthStatusDegraded))
 			})
 
-			It("marks the stale scheduler component as unhealthy", func() {
+			It("marks the scheduler component as unhealthy", func() {
 				body, _ := io.ReadAll(response.Body)
 				var health atc.Health
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
@@ -282,7 +282,6 @@ var _ = Describe("Health API", func() {
 					}
 				}
 				Expect(scheduler).NotTo(BeNil())
-				Expect(scheduler.Stale).To(BeTrue())
 				Expect(scheduler.Status).To(Equal(atc.HealthStatusUnhealthy))
 			})
 
@@ -298,7 +297,6 @@ var _ = Describe("Health API", func() {
 					}
 				}
 				Expect(tracker).NotTo(BeNil())
-				Expect(tracker.Stale).To(BeFalse())
 				Expect(tracker.Status).To(Equal(atc.HealthStatusHealthy))
 			})
 		})
@@ -327,7 +325,7 @@ var _ = Describe("Health API", func() {
 				Expect(health.Status).To(Equal(atc.HealthStatusOK))
 			})
 
-			It("marks the stale GC component as unhealthy in the JSON", func() {
+			It("marks the GC component as unhealthy in the JSON", func() {
 				body, _ := io.ReadAll(response.Body)
 				var health atc.Health
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
@@ -339,7 +337,6 @@ var _ = Describe("Health API", func() {
 					}
 				}
 				Expect(collector).NotTo(BeNil())
-				Expect(collector.Stale).To(BeTrue())
 				Expect(collector.Status).To(Equal(atc.HealthStatusUnhealthy))
 			})
 		})
@@ -364,14 +361,13 @@ var _ = Describe("Health API", func() {
 				Expect(health.Status).To(Equal(atc.HealthStatusOK))
 			})
 
-			It("reports the component as paused and not stale", func() {
+			It("reports the component as paused and healthy", func() {
 				body, _ := io.ReadAll(response.Body)
 				var health atc.Health
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
 
 				Expect(health.Components).To(HaveLen(1))
 				Expect(health.Components[0].Paused).To(BeTrue())
-				Expect(health.Components[0].Stale).To(BeFalse())
 				Expect(health.Components[0].Status).To(Equal(atc.HealthStatusHealthy))
 			})
 		})

--- a/atc/api/health_test.go
+++ b/atc/api/health_test.go
@@ -44,6 +44,13 @@ func makeWorker(state db.WorkerState) *dbfakes.FakeWorker {
 	return w
 }
 
+func makeNamedWorker(name string, state db.WorkerState) *dbfakes.FakeWorker {
+	w := new(dbfakes.FakeWorker)
+	w.NameReturns(name)
+	w.StateReturns(state)
+	return w
+}
+
 func makeComponent(name string, interval time.Duration, lastRan time.Time, paused bool) *dbfakes.FakeComponent {
 	c := new(dbfakes.FakeComponent)
 	c.NameReturns(name)
@@ -64,6 +71,13 @@ func dbReadOnlyStub(_ context.Context, _ string, _ ...any) sq.RowScanner {
 func dbDownStub(_ context.Context, _ string, _ ...any) sq.RowScanner {
 	return &fakeRowScanner{err: errors.New("connection refused")}
 }
+
+// workerStatus is a string alias matching WorkerHealth.Status — keeps test assertions readable.
+const (
+	workerStatusHealthy   = string(atc.HealthStatusHealthy)
+	workerStatusDegraded  = string(atc.HealthStatusDegraded)
+	workerStatusUnhealthy = string(atc.HealthStatusUnhealthy)
+)
 
 var _ = Describe("Health API", func() {
 	var response *http.Response
@@ -98,7 +112,7 @@ var _ = Describe("Health API", func() {
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
 				Expect(health.Status).To(Equal(atc.HealthStatusOK))
 				Expect(health.Database.Status).To(Equal(atc.HealthStatusHealthy))
-				Expect(health.Workers.Status).To(Equal(atc.HealthStatusHealthy))
+				Expect(health.Workers.Status).To(Equal(workerStatusHealthy))
 				Expect(health.Workers.Total).To(Equal(2))
 				Expect(health.Workers.Running).To(Equal(2))
 			})
@@ -130,7 +144,7 @@ var _ = Describe("Health API", func() {
 				var health atc.Health
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
 				Expect(health.Status).To(Equal(atc.HealthStatusOK))
-				Expect(health.Workers.Status).To(Equal(atc.HealthStatusHealthy))
+				Expect(health.Workers.Status).To(Equal(workerStatusHealthy))
 				Expect(health.Workers.Running).To(Equal(1))
 			})
 		})
@@ -142,9 +156,9 @@ var _ = Describe("Health API", func() {
 				fakeDbConn.QueryRowContextStub = dbHealthyStub
 				// 2 running workers, minWorkerCount=3 → below threshold → degraded
 				dbWorkerFactory.WorkersReturns([]db.Worker{
-					makeWorker(db.WorkerStateRunning),
-					makeWorker(db.WorkerStateRunning),
-					makeWorker(db.WorkerStateStalled),
+					makeNamedWorker("worker-01", db.WorkerStateRunning),
+					makeNamedWorker("worker-02", db.WorkerStateRunning),
+					makeNamedWorker("worker-03", db.WorkerStateStalled),
 				}, nil)
 				customServer = buildTestServer(3)
 			})
@@ -154,32 +168,33 @@ var _ = Describe("Health API", func() {
 			})
 
 			It("returns 200 (degraded is not failing)", func() {
-				response, err := client.Get(customServer.URL + "/api/v1/health")
+				resp, err := client.Get(customServer.URL + "/api/v1/health")
 				Expect(err).NotTo(HaveOccurred())
-				defer response.Body.Close()
-				Expect(response.StatusCode).To(Equal(http.StatusOK))
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			})
 
-			It("returns status degraded", func() {
-				response, err := client.Get(customServer.URL + "/api/v1/health")
+			It("returns status degraded with unhealthy workers listed", func() {
+				resp, err := client.Get(customServer.URL + "/api/v1/health")
 				Expect(err).NotTo(HaveOccurred())
-				defer response.Body.Close()
+				defer resp.Body.Close()
 
-				body, _ := io.ReadAll(response.Body)
+				body, _ := io.ReadAll(resp.Body)
 				var health atc.Health
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
 				Expect(health.Status).To(Equal(atc.HealthStatusDegraded))
-				Expect(health.Workers.Status).To(Equal(atc.HealthStatusDegraded))
+				Expect(health.Workers.Status).To(Equal(workerStatusDegraded))
 				Expect(health.Workers.Running).To(Equal(2))
 				Expect(health.Workers.Total).To(Equal(3))
+				Expect(health.Workers.UnhealthyWorkers).To(ConsistOf("worker-03"))
 			})
 		})
 
-		Context("when running workers are below the minimum threshold but at least one exists", func() {
+		Context("when there are no running workers but some are registered", func() {
 			BeforeEach(func() {
 				fakeDbConn.QueryRowContextStub = dbHealthyStub
 				dbWorkerFactory.WorkersReturns([]db.Worker{
-					makeWorker(db.WorkerStateStalled),
+					makeNamedWorker("worker-01", db.WorkerStateStalled),
 				}, nil)
 			})
 
@@ -187,14 +202,15 @@ var _ = Describe("Health API", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusServiceUnavailable))
 			})
 
-			It("reports workers as unhealthy (no running workers)", func() {
+			It("reports workers as unhealthy with the stalled worker listed", func() {
 				body, _ := io.ReadAll(response.Body)
 				var health atc.Health
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
 				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
-				Expect(health.Workers.Status).To(Equal(atc.HealthStatusUnhealthy))
+				Expect(health.Workers.Status).To(Equal(workerStatusUnhealthy))
 				Expect(health.Workers.Total).To(Equal(1))
 				Expect(health.Workers.Running).To(Equal(0))
+				Expect(health.Workers.UnhealthyWorkers).To(ConsistOf("worker-01"))
 			})
 		})
 
@@ -213,9 +229,10 @@ var _ = Describe("Health API", func() {
 				var health atc.Health
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
 				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
-				Expect(health.Workers.Status).To(Equal(atc.HealthStatusUnhealthy))
+				Expect(health.Workers.Status).To(Equal(workerStatusUnhealthy))
 				Expect(health.Workers.Total).To(Equal(0))
 				Expect(health.Workers.Running).To(Equal(0))
+				Expect(health.Workers.UnhealthyWorkers).To(BeEmpty())
 			})
 		})
 
@@ -278,7 +295,7 @@ var _ = Describe("Health API", func() {
 				var health atc.Health
 				Expect(json.Unmarshal(body, &health)).To(Succeed())
 				Expect(health.Status).To(Equal(atc.HealthStatusFailing))
-				Expect(health.Workers.Status).To(Equal(atc.HealthStatusUnhealthy))
+				Expect(health.Workers.Status).To(Equal(workerStatusUnhealthy))
 			})
 		})
 

--- a/atc/api/health_test.go
+++ b/atc/api/health_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Health API", func() {
 					makeNamedWorker("worker-02", db.WorkerStateRunning),
 					makeNamedWorker("worker-03", db.WorkerStateStalled),
 				}, nil)
-				customServer = buildTestServer(3)
+				customServer = newApiTestServer(withWorkerCount(3))
 			})
 
 			AfterEach(func() {

--- a/atc/api/healthserver/health.go
+++ b/atc/api/healthserver/health.go
@@ -120,7 +120,6 @@ func (s *Server) checkComponents() ([]atc.ComponentHealth, bool) {
 			Status:  status,
 			Paused:  c.Paused(),
 			LastRan: c.LastRan(),
-			Stale:   stale,
 		})
 	}
 

--- a/atc/api/healthserver/health.go
+++ b/atc/api/healthserver/health.go
@@ -17,21 +17,21 @@ func (s *Server) GetHealth(w http.ResponseWriter, r *http.Request) {
 		Timestamp: time.Now().UTC(),
 	}
 
-	// --- Database health ---
 	dbHealth := s.checkDatabase(r.Context())
 	health.Database = dbHealth
 
-	// --- Worker health ---
 	workerHealth := s.checkWorkers()
 	health.Workers = workerHealth
 
-	// --- Overall status ---
+	componentHealths, runtimeDegraded := s.checkComponents()
+	health.Components = componentHealths
+
 	switch {
 	case dbHealth.Status == atc.HealthStatusUnhealthy:
 		health.Status = atc.HealthStatusFailing
 	case workerHealth.Status == atc.HealthStatusUnhealthy:
 		health.Status = atc.HealthStatusFailing
-	case workerHealth.Status == atc.HealthStatusDegraded:
+	case workerHealth.Status == atc.HealthStatusDegraded || runtimeDegraded:
 		health.Status = atc.HealthStatusDegraded
 	default:
 		health.Status = atc.HealthStatusOK
@@ -73,9 +73,7 @@ func (s *Server) checkDatabase(ctx context.Context) atc.DatabaseHealth {
 func (s *Server) checkWorkers() atc.WorkerHealth {
 	workers, err := s.workerFactory.Workers()
 	if err != nil {
-		return atc.WorkerHealth{
-			Status: atc.HealthStatusUnhealthy,
-		}
+		return atc.WorkerHealth{Status: atc.HealthStatusUnhealthy}
 	}
 
 	total := len(workers)
@@ -83,24 +81,60 @@ func (s *Server) checkWorkers() atc.WorkerHealth {
 
 	switch {
 	case total == 0 || running == 0:
-		return atc.WorkerHealth{
-			Status:  atc.HealthStatusUnhealthy,
-			Total:   total,
-			Running: running,
-		}
+		return atc.WorkerHealth{Status: atc.HealthStatusUnhealthy, Total: total, Running: running}
 	case running < s.minWorkerCount:
-		return atc.WorkerHealth{
-			Status:  atc.HealthStatusDegraded,
-			Total:   total,
-			Running: running,
-		}
+		return atc.WorkerHealth{Status: atc.HealthStatusDegraded, Total: total, Running: running}
 	default:
-		return atc.WorkerHealth{
-			Status:  atc.HealthStatusHealthy,
-			Total:   total,
-			Running: running,
-		}
+		return atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: total, Running: running}
 	}
+}
+
+// checkComponents fetches all components and checks their staleness.
+// Returns the per-component health list and whether any runtime component is stale.
+func (s *Server) checkComponents() ([]atc.ComponentHealth, bool) {
+	components, err := s.componentFactory.All()
+	if err != nil {
+		return nil, false
+	}
+
+	runtimeSet := make(map[string]struct{}, len(atc.ComponentsRuntime))
+	for _, name := range atc.ComponentsRuntime {
+		runtimeSet[name] = struct{}{}
+	}
+
+	var healths []atc.ComponentHealth
+	runtimeDegraded := false
+
+	for _, c := range components {
+		stale := isStale(c, s.componentStaleMultiplier)
+		status := atc.HealthStatusHealthy
+		if stale {
+			status = atc.HealthStatusUnhealthy
+			if _, isRuntime := runtimeSet[c.Name()]; isRuntime {
+				runtimeDegraded = true
+			}
+		}
+
+		healths = append(healths, atc.ComponentHealth{
+			Name:    c.Name(),
+			Status:  status,
+			Paused:  c.Paused(),
+			LastRan: c.LastRan(),
+			Stale:   stale,
+		})
+	}
+
+	return healths, runtimeDegraded
+}
+
+// isStale returns true if the component has not run within the stale window.
+// Paused components and components that have never run are never considered stale.
+func isStale(c db.Component, multiplier float64) bool {
+	if c.Paused() || c.LastRan().IsZero() {
+		return false
+	}
+	staleWindow := time.Duration(float64(c.Interval()) * multiplier)
+	return time.Since(c.LastRan()) > staleWindow
 }
 
 func countWorkers(workers []db.Worker, state db.WorkerState) int {

--- a/atc/api/healthserver/health.go
+++ b/atc/api/healthserver/health.go
@@ -1,0 +1,114 @@
+package healthserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+)
+
+func (s *Server) GetHealth(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.Session("get-health")
+
+	health := atc.Health{
+		Timestamp: time.Now().UTC(),
+	}
+
+	// --- Database health ---
+	dbHealth := s.checkDatabase(r.Context())
+	health.Database = dbHealth
+
+	// --- Worker health ---
+	workerHealth := s.checkWorkers()
+	health.Workers = workerHealth
+
+	// --- Overall status ---
+	switch {
+	case dbHealth.Status == atc.HealthStatusUnhealthy:
+		health.Status = atc.HealthStatusFailing
+	case workerHealth.Status == atc.HealthStatusUnhealthy:
+		health.Status = atc.HealthStatusFailing
+	case workerHealth.Status == atc.HealthStatusDegraded:
+		health.Status = atc.HealthStatusDegraded
+	default:
+		health.Status = atc.HealthStatusOK
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if health.Status == atc.HealthStatusFailing {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	if err := json.NewEncoder(w).Encode(health); err != nil {
+		logger.Error("failed-to-encode-health", err)
+	}
+}
+
+// checkDatabase pings the database and verifies it is writable (not a standby replica).
+func (s *Server) checkDatabase(ctx context.Context) atc.DatabaseHealth {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	var inRecovery bool
+	err := s.dbConn.QueryRowContext(ctx, "SELECT pg_is_in_recovery()").Scan(&inRecovery)
+	if err != nil {
+		return atc.DatabaseHealth{
+			Status: atc.HealthStatusUnhealthy,
+			Error:  "database unreachable",
+		}
+	}
+	if inRecovery {
+		return atc.DatabaseHealth{
+			Status: atc.HealthStatusUnhealthy,
+			Error:  "database is read-only",
+		}
+	}
+	return atc.DatabaseHealth{Status: atc.HealthStatusHealthy}
+}
+
+// checkWorkers aggregates worker states against the configured minimum.
+func (s *Server) checkWorkers() atc.WorkerHealth {
+	workers, err := s.workerFactory.Workers()
+	if err != nil {
+		return atc.WorkerHealth{
+			Status: atc.HealthStatusUnhealthy,
+		}
+	}
+
+	total := len(workers)
+	running := countWorkers(workers, db.WorkerStateRunning)
+
+	switch {
+	case total == 0 || running == 0:
+		return atc.WorkerHealth{
+			Status:  atc.HealthStatusUnhealthy,
+			Total:   total,
+			Running: running,
+		}
+	case running < s.minWorkerCount:
+		return atc.WorkerHealth{
+			Status:  atc.HealthStatusDegraded,
+			Total:   total,
+			Running: running,
+		}
+	default:
+		return atc.WorkerHealth{
+			Status:  atc.HealthStatusHealthy,
+			Total:   total,
+			Running: running,
+		}
+	}
+}
+
+func countWorkers(workers []db.Worker, state db.WorkerState) int {
+	n := 0
+	for _, w := range workers {
+		if w.State() == state {
+			n++
+		}
+	}
+	return n
+}

--- a/atc/api/healthserver/health.go
+++ b/atc/api/healthserver/health.go
@@ -10,6 +10,9 @@ import (
 	"github.com/concourse/concourse/atc/db"
 )
 
+// GetHealth returns the health of the Concourse cluster — database, workers, and components.
+// A 503 response indicates a cluster-level problem (e.g. database unreachable, no workers),
+// not a failure of the web node handling this request.
 func (s *Server) GetHealth(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Session("get-health")
 
@@ -29,9 +32,9 @@ func (s *Server) GetHealth(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case dbHealth.Status == atc.HealthStatusUnhealthy:
 		health.Status = atc.HealthStatusFailing
-	case workerHealth.Status == atc.HealthStatusUnhealthy:
+	case workerHealth.Status == string(atc.HealthStatusUnhealthy):
 		health.Status = atc.HealthStatusFailing
-	case workerHealth.Status == atc.HealthStatusDegraded || runtimeDegraded:
+	case workerHealth.Status == string(atc.HealthStatusDegraded) || runtimeDegraded:
 		health.Status = atc.HealthStatusDegraded
 	default:
 		health.Status = atc.HealthStatusOK
@@ -44,6 +47,7 @@ func (s *Server) GetHealth(w http.ResponseWriter, r *http.Request) {
 
 	if err := json.NewEncoder(w).Encode(health); err != nil {
 		logger.Error("failed-to-encode-health", err)
+		http.Error(w, "failed to encode health response", http.StatusInternalServerError)
 	}
 }
 
@@ -73,19 +77,27 @@ func (s *Server) checkDatabase(ctx context.Context) atc.DatabaseHealth {
 func (s *Server) checkWorkers() atc.WorkerHealth {
 	workers, err := s.workerFactory.Workers()
 	if err != nil {
-		return atc.WorkerHealth{Status: atc.HealthStatusUnhealthy}
+		return atc.WorkerHealth{Status: string(atc.HealthStatusUnhealthy)}
 	}
 
 	total := len(workers)
-	running := countWorkers(workers, db.WorkerStateRunning)
+	running := 0
+	var unhealthy []string
+	for _, w := range workers {
+		if w.State() == db.WorkerStateRunning {
+			running++
+		} else {
+			unhealthy = append(unhealthy, w.Name())
+		}
+	}
 
 	switch {
 	case total == 0 || running == 0:
-		return atc.WorkerHealth{Status: atc.HealthStatusUnhealthy, Total: total, Running: running}
+		return atc.WorkerHealth{Status: string(atc.HealthStatusUnhealthy), Total: total, Running: running, UnhealthyWorkers: unhealthy}
 	case running < s.minWorkerCount:
-		return atc.WorkerHealth{Status: atc.HealthStatusDegraded, Total: total, Running: running}
+		return atc.WorkerHealth{Status: string(atc.HealthStatusDegraded), Total: total, Running: running, UnhealthyWorkers: unhealthy}
 	default:
-		return atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: total, Running: running}
+		return atc.WorkerHealth{Status: string(atc.HealthStatusHealthy), Total: total, Running: running, UnhealthyWorkers: unhealthy}
 	}
 }
 
@@ -134,14 +146,4 @@ func isStale(c db.Component, multiplier float64) bool {
 	}
 	staleWindow := time.Duration(float64(c.Interval()) * multiplier)
 	return time.Since(c.LastRan()) > staleWindow
-}
-
-func countWorkers(workers []db.Worker, state db.WorkerState) int {
-	n := 0
-	for _, w := range workers {
-		if w.State() == state {
-			n++
-		}
-	}
-	return n
 }

--- a/atc/api/healthserver/server.go
+++ b/atc/api/healthserver/server.go
@@ -1,0 +1,28 @@
+package healthserver
+
+import (
+	"code.cloudfoundry.org/lager/v3"
+	"github.com/concourse/concourse/atc/db"
+)
+
+// Server holds the dependencies needed to serve the health endpoint.
+type Server struct {
+	logger           lager.Logger
+	dbConn           db.DbConn
+	workerFactory    db.WorkerFactory
+	minWorkerCount   int
+}
+
+func NewServer(
+	logger lager.Logger,
+	dbConn db.DbConn,
+	workerFactory db.WorkerFactory,
+	minWorkerCount int,
+) *Server {
+	return &Server{
+		logger:         logger,
+		dbConn:         dbConn,
+		workerFactory:  workerFactory,
+		minWorkerCount: minWorkerCount,
+	}
+}

--- a/atc/api/healthserver/server.go
+++ b/atc/api/healthserver/server.go
@@ -7,22 +7,28 @@ import (
 
 // Server holds the dependencies needed to serve the health endpoint.
 type Server struct {
-	logger           lager.Logger
-	dbConn           db.DbConn
-	workerFactory    db.WorkerFactory
-	minWorkerCount   int
+	logger                   lager.Logger
+	dbConn                   db.DbConn
+	workerFactory            db.WorkerFactory
+	componentFactory         db.ComponentFactory
+	minWorkerCount           int
+	componentStaleMultiplier float64
 }
 
 func NewServer(
 	logger lager.Logger,
 	dbConn db.DbConn,
 	workerFactory db.WorkerFactory,
+	componentFactory db.ComponentFactory,
 	minWorkerCount int,
+	componentStaleMultiplier float64,
 ) *Server {
 	return &Server{
-		logger:         logger,
-		dbConn:         dbConn,
-		workerFactory:  workerFactory,
-		minWorkerCount: minWorkerCount,
+		logger:                   logger,
+		dbConn:                   dbConn,
+		workerFactory:            workerFactory,
+		componentFactory:         componentFactory,
+		minWorkerCount:           minWorkerCount,
+		componentStaleMultiplier: componentStaleMultiplier,
 	}
 }

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -204,6 +204,10 @@ type RunCommand struct {
 		ClientSecret            string `long:"client-secret" required:"true" description:"Client secret to use for login flow"`
 	} `group:"Web Server"`
 
+	Health struct {
+		MinWorkerCount int `long:"health-min-worker-count" default:"1" description:"Minimum number of running workers for the health endpoint to report healthy. Below this threshold the status is degraded (still 200). Zero workers is always failing."`
+	} `group:"Health Endpoint"`
+
 	LogDBQueries   bool `long:"log-db-queries" description:"Log database queries."`
 	LogClusterName bool `long:"log-cluster-name" description:"Log cluster name."`
 
@@ -952,6 +956,7 @@ func (cmd *RunCommand) constructAPIMembers(
 		dbResourceConfigFactory,
 		userFactory,
 		dbComponentFactory,
+		dbConn,
 		pool,
 		secretManager,
 		credsManagers,
@@ -2073,6 +2078,7 @@ func (cmd *RunCommand) constructAPIHandler(
 	resourceConfigFactory db.ResourceConfigFactory,
 	dbUserFactory db.UserFactory,
 	dbComponentFactory db.ComponentFactory,
+	dbConn db.DbConn,
 	workerPool worker.Pool,
 	secretManager creds.Secrets,
 	credsManagers creds.Managers,
@@ -2152,6 +2158,8 @@ func (cmd *RunCommand) constructAPIHandler(
 		resourceConfigFactory,
 		dbUserFactory,
 		dbComponentFactory,
+		dbConn,
+		cmd.Health.MinWorkerCount,
 
 		buildserver.NewEventHandler,
 

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -205,7 +205,8 @@ type RunCommand struct {
 	} `group:"Web Server"`
 
 	Health struct {
-		MinWorkerCount int `long:"health-min-worker-count" default:"1" description:"Minimum number of running workers for the health endpoint to report healthy. Below this threshold the status is degraded (still 200). Zero workers is always failing."`
+		MinWorkerCount         int     `long:"health-min-worker-count" default:"1" description:"Minimum number of running workers for the health endpoint to report healthy. Below this threshold the status is degraded (still 200). Zero workers is always failing."`
+		ComponentStaleMultiplier float64 `long:"health-component-stale-multiplier" default:"2.0" description:"A component is considered stale when it has not run for more than this multiplier times its interval. Stale runtime components (scheduler, tracker, scanner) cause degraded status."`
 	} `group:"Health Endpoint"`
 
 	LogDBQueries   bool `long:"log-db-queries" description:"Log database queries."`
@@ -2160,6 +2161,7 @@ func (cmd *RunCommand) constructAPIHandler(
 		dbComponentFactory,
 		dbConn,
 		cmd.Health.MinWorkerCount,
+		cmd.Health.ComponentStaleMultiplier,
 
 		buildserver.NewEventHandler,
 

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -205,7 +205,7 @@ type RunCommand struct {
 	} `group:"Web Server"`
 
 	Health struct {
-		MinWorkerCount         int     `long:"health-min-worker-count" default:"1" description:"Minimum number of running workers for the health endpoint to report healthy. Below this threshold the status is degraded (still 200). Zero workers is always failing."`
+		MinWorkerCount           int     `long:"health-min-worker-count" default:"1" description:"Minimum number of running workers before the health endpoint reports degraded. Setting this to 0 means the endpoint will only report healthy or failing — never degraded."`
 		ComponentStaleMultiplier float64 `long:"health-component-stale-multiplier" default:"2.0" description:"A component is considered stale when it has not run for more than this multiplier times its interval. Stale runtime components (scheduler, tracker, scanner) cause degraded status."`
 	} `group:"Health Endpoint"`
 

--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -141,6 +141,7 @@ func (a *auditor) ValidateAction(action string) bool {
 		atc.DownloadCLI,
 		atc.GetInfo,
 		atc.GetInfoCreds,
+		atc.GetHealth,
 		atc.ListActiveUsersSince,
 		atc.GetUser,
 		atc.GetWall,

--- a/atc/health.go
+++ b/atc/health.go
@@ -4,10 +4,11 @@ import "time"
 
 // Health represents the overall health status of the Concourse ATC instance.
 type Health struct {
-	Status    string         `json:"status"`
-	Timestamp time.Time      `json:"timestamp"`
-	Database  DatabaseHealth `json:"database"`
-	Workers   WorkerHealth   `json:"workers"`
+	Status     string            `json:"status"`
+	Timestamp  time.Time         `json:"timestamp"`
+	Database   DatabaseHealth    `json:"database"`
+	Workers    WorkerHealth      `json:"workers"`
+	Components []ComponentHealth `json:"components"`
 }
 
 // DatabaseHealth represents the health of the database connection.
@@ -23,6 +24,15 @@ type WorkerHealth struct {
 	Running int    `json:"running"`
 }
 
+// ComponentHealth represents the health of a single ATC component.
+type ComponentHealth struct {
+	Name    string    `json:"name"`
+	Status  string    `json:"status"`
+	Paused  bool      `json:"paused"`
+	LastRan time.Time `json:"last_ran"`
+	Stale   bool      `json:"stale"`
+}
+
 // Overall health status values — used in Health.Status.
 const (
 	HealthStatusOK       = "ok"
@@ -30,7 +40,7 @@ const (
 	HealthStatusFailing  = "failing"
 )
 
-// Per-subsystem status values — used in DatabaseHealth.Status and WorkerHealth.Status.
+// Per-subsystem status values — used in DatabaseHealth.Status, WorkerHealth.Status, ComponentHealth.Status.
 const (
 	HealthStatusHealthy   = "healthy"
 	HealthStatusUnhealthy = "unhealthy"

--- a/atc/health.go
+++ b/atc/health.go
@@ -28,4 +28,3 @@ const (
 	HealthStatusUnhealthy = "unhealthy"
 	HealthStatusDegraded  = "degraded"
 )
-

--- a/atc/health.go
+++ b/atc/health.go
@@ -1,0 +1,31 @@
+package atc
+
+import "time"
+
+// Health represents the overall health status of the Concourse ATC instance
+type Health struct {
+	Status    string        `json:"status"`
+	Version   string        `json:"version,omitempty"`
+	Timestamp time.Time     `json:"timestamp"`
+	Details   HealthDetails `json:"details"`
+}
+
+// HealthDetails contains detailed health information for different components
+type HealthDetails struct {
+	Database     HealthStatus `json:"database"`
+	WorkerHealth HealthStatus `json:"worker_health"`
+}
+
+// HealthStatus represents the health status of a specific component
+type HealthStatus struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+// Health status constants
+const (
+	HealthStatusHealthy   = "healthy"
+	HealthStatusUnhealthy = "unhealthy"
+	HealthStatusDegraded  = "degraded"
+)
+

--- a/atc/health.go
+++ b/atc/health.go
@@ -2,29 +2,36 @@ package atc
 
 import "time"
 
-// Health represents the overall health status of the Concourse ATC instance
+// Health represents the overall health status of the Concourse ATC instance.
 type Health struct {
-	Status    string        `json:"status"`
-	Version   string        `json:"version,omitempty"`
-	Timestamp time.Time     `json:"timestamp"`
-	Details   HealthDetails `json:"details"`
+	Status    string         `json:"status"`
+	Timestamp time.Time      `json:"timestamp"`
+	Database  DatabaseHealth `json:"database"`
+	Workers   WorkerHealth   `json:"workers"`
 }
 
-// HealthDetails contains detailed health information for different components
-type HealthDetails struct {
-	Database     HealthStatus `json:"database"`
-	WorkerHealth HealthStatus `json:"worker_health"`
+// DatabaseHealth represents the health of the database connection.
+type DatabaseHealth struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
 }
 
-// HealthStatus represents the health status of a specific component
-type HealthStatus struct {
+// WorkerHealth represents the aggregate health of registered workers.
+type WorkerHealth struct {
 	Status  string `json:"status"`
-	Message string `json:"message,omitempty"`
+	Total   int    `json:"total"`
+	Running int    `json:"running"`
 }
 
-// Health status constants
+// Overall health status values — used in Health.Status.
+const (
+	HealthStatusOK       = "ok"
+	HealthStatusDegraded = "degraded"
+	HealthStatusFailing  = "failing"
+)
+
+// Per-subsystem status values — used in DatabaseHealth.Status and WorkerHealth.Status.
 const (
 	HealthStatusHealthy   = "healthy"
 	HealthStatusUnhealthy = "unhealthy"
-	HealthStatusDegraded  = "degraded"
 )

--- a/atc/health.go
+++ b/atc/health.go
@@ -30,7 +30,6 @@ type ComponentHealth struct {
 	Status  string    `json:"status"`
 	Paused  bool      `json:"paused"`
 	LastRan time.Time `json:"last_ran"`
-	Stale   bool      `json:"stale"`
 }
 
 // Overall health status values — used in Health.Status.

--- a/atc/health.go
+++ b/atc/health.go
@@ -2,9 +2,28 @@ package atc
 
 import "time"
 
+// systemStatus represents the overall health of the ATC instance.
+// Valid values: ok, degraded, failing.
+type systemStatus string
+
+const (
+	HealthStatusOK       systemStatus = "ok"
+	HealthStatusDegraded systemStatus = "degraded"
+	HealthStatusFailing  systemStatus = "failing"
+)
+
+// subsystemStatus represents the binary health of an individual subsystem (database, component).
+// Valid values: healthy, unhealthy.
+type subsystemStatus string
+
+const (
+	HealthStatusHealthy   subsystemStatus = "healthy"
+	HealthStatusUnhealthy subsystemStatus = "unhealthy"
+)
+
 // Health represents the overall health status of the Concourse ATC instance.
 type Health struct {
-	Status     string            `json:"status"`
+	Status     systemStatus      `json:"status"`
 	Timestamp  time.Time         `json:"timestamp"`
 	Database   DatabaseHealth    `json:"database"`
 	Workers    WorkerHealth      `json:"workers"`
@@ -13,34 +32,24 @@ type Health struct {
 
 // DatabaseHealth represents the health of the database connection.
 type DatabaseHealth struct {
-	Status string `json:"status"`
-	Error  string `json:"error,omitempty"`
+	Status subsystemStatus `json:"status"`
+	Error  string          `json:"error,omitempty"`
 }
 
 // WorkerHealth represents the aggregate health of registered workers.
+// Status is one of: "healthy", "degraded", "unhealthy" — workers uniquely span
+// both binary and graduated health levels, so the field is typed as string.
 type WorkerHealth struct {
-	Status  string `json:"status"`
-	Total   int    `json:"total"`
-	Running int    `json:"running"`
+	Status           string   `json:"status"`
+	Total            int      `json:"total"`
+	Running          int      `json:"running"`
+	UnhealthyWorkers []string `json:"unhealthy_workers,omitempty"`
 }
 
 // ComponentHealth represents the health of a single ATC component.
 type ComponentHealth struct {
-	Name    string    `json:"name"`
-	Status  string    `json:"status"`
-	Paused  bool      `json:"paused"`
-	LastRan time.Time `json:"last_ran"`
+	Name    string          `json:"name"`
+	Status  subsystemStatus `json:"status"`
+	Paused  bool            `json:"paused"`
+	LastRan time.Time       `json:"last_ran"`
 }
-
-// Overall health status values — used in Health.Status.
-const (
-	HealthStatusOK       = "ok"
-	HealthStatusDegraded = "degraded"
-	HealthStatusFailing  = "failing"
-)
-
-// Per-subsystem status values — used in DatabaseHealth.Status, WorkerHealth.Status, ComponentHealth.Status.
-const (
-	HealthStatusHealthy   = "healthy"
-	HealthStatusUnhealthy = "unhealthy"
-)

--- a/atc/health_test.go
+++ b/atc/health_test.go
@@ -1,0 +1,76 @@
+package atc_test
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Health", func() {
+	Describe("JSON marshaling", func() {
+		It("marshals Health struct correctly", func() {
+			timestamp := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			health := atc.Health{
+				Status:    atc.HealthStatusHealthy,
+				Version:   "1.2.3",
+				Timestamp: timestamp,
+				Details: atc.HealthDetails{
+					Database: atc.HealthStatus{
+						Status: atc.HealthStatusHealthy,
+					},
+					WorkerHealth: atc.HealthStatus{
+						Status:  atc.HealthStatusDegraded,
+						Message: "Low worker count",
+					},
+				},
+			}
+
+			jsonBytes, err := json.Marshal(health)
+			Expect(err).NotTo(HaveOccurred())
+
+			var unmarshaled atc.Health
+			err = json.Unmarshal(jsonBytes, &unmarshaled)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(unmarshaled.Status).To(Equal(atc.HealthStatusHealthy))
+			Expect(unmarshaled.Version).To(Equal("1.2.3"))
+			Expect(unmarshaled.Timestamp).To(Equal(timestamp))
+			Expect(unmarshaled.Details.Database.Status).To(Equal(atc.HealthStatusHealthy))
+			Expect(unmarshaled.Details.WorkerHealth.Status).To(Equal(atc.HealthStatusDegraded))
+			Expect(unmarshaled.Details.WorkerHealth.Message).To(Equal("Low worker count"))
+		})
+
+		It("handles empty messages correctly", func() {
+			health := atc.Health{
+				Status:    atc.HealthStatusUnhealthy,
+				Timestamp: time.Now(),
+				Details: atc.HealthDetails{
+					Database: atc.HealthStatus{
+						Status:  atc.HealthStatusUnhealthy,
+						Message: "Connection failed",
+					},
+					WorkerHealth: atc.HealthStatus{
+						Status: atc.HealthStatusHealthy,
+					},
+				},
+			}
+
+			jsonBytes, err := json.Marshal(health)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(string(jsonBytes)).To(ContainSubstring(`"message":"Connection failed"`))
+		})
+	})
+
+	Describe("Health status constants", func() {
+		It("has correct constant values", func() {
+			Expect(atc.HealthStatusHealthy).To(Equal("healthy"))
+			Expect(atc.HealthStatusUnhealthy).To(Equal("unhealthy"))
+			Expect(atc.HealthStatusDegraded).To(Equal("degraded"))
+		})
+	})
+})
+

--- a/atc/health_test.go
+++ b/atc/health_test.go
@@ -68,8 +68,8 @@ var _ = Describe("Health", func() {
 				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
 				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 1, Running: 1},
 				Components: []atc.ComponentHealth{
-					{Name: atc.ComponentScheduler, Status: atc.HealthStatusUnhealthy, Paused: false, LastRan: lastRan, Stale: true},
-					{Name: atc.ComponentCollectorVolumes, Status: atc.HealthStatusUnhealthy, Paused: false, LastRan: lastRan, Stale: true},
+					{Name: atc.ComponentScheduler, Status: atc.HealthStatusUnhealthy, Paused: false, LastRan: lastRan},
+					{Name: atc.ComponentCollectorVolumes, Status: atc.HealthStatusUnhealthy, Paused: false, LastRan: lastRan},
 				},
 			}
 
@@ -80,7 +80,7 @@ var _ = Describe("Health", func() {
 			Expect(json.Unmarshal(jsonBytes, &unmarshaled)).To(Succeed())
 			Expect(unmarshaled.Components).To(HaveLen(2))
 			Expect(unmarshaled.Components[0].Name).To(Equal(atc.ComponentScheduler))
-			Expect(unmarshaled.Components[0].Stale).To(BeTrue())
+			Expect(unmarshaled.Components[0].Status).To(Equal(atc.HealthStatusUnhealthy))
 			Expect(unmarshaled.Components[1].Name).To(Equal(atc.ComponentCollectorVolumes))
 		})
 

--- a/atc/health_test.go
+++ b/atc/health_test.go
@@ -73,4 +73,3 @@ var _ = Describe("Health", func() {
 		})
 	})
 })
-

--- a/atc/health_test.go
+++ b/atc/health_test.go
@@ -16,23 +16,15 @@ var _ = Describe("Health", func() {
 			health := atc.Health{
 				Status:    atc.HealthStatusOK,
 				Timestamp: timestamp,
-				Database: atc.DatabaseHealth{
-					Status: atc.HealthStatusHealthy,
-				},
-				Workers: atc.WorkerHealth{
-					Status:  atc.HealthStatusHealthy,
-					Total:   3,
-					Running: 3,
-				},
+				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
+				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 3, Running: 3},
 			}
 
 			jsonBytes, err := json.Marshal(health)
 			Expect(err).NotTo(HaveOccurred())
 
 			var unmarshaled atc.Health
-			err = json.Unmarshal(jsonBytes, &unmarshaled)
-			Expect(err).NotTo(HaveOccurred())
-
+			Expect(json.Unmarshal(jsonBytes, &unmarshaled)).To(Succeed())
 			Expect(unmarshaled.Status).To(Equal(atc.HealthStatusOK))
 			Expect(unmarshaled.Timestamp).To(Equal(timestamp))
 			Expect(unmarshaled.Database.Status).To(Equal(atc.HealthStatusHealthy))
@@ -45,18 +37,12 @@ var _ = Describe("Health", func() {
 			health := atc.Health{
 				Status:    atc.HealthStatusFailing,
 				Timestamp: time.Now(),
-				Database: atc.DatabaseHealth{
-					Status: atc.HealthStatusUnhealthy,
-					Error:  "connection refused",
-				},
-				Workers: atc.WorkerHealth{
-					Status: atc.HealthStatusHealthy,
-				},
+				Database:  atc.DatabaseHealth{Status: atc.HealthStatusUnhealthy, Error: "connection refused"},
+				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy},
 			}
 
 			jsonBytes, err := json.Marshal(health)
 			Expect(err).NotTo(HaveOccurred())
-
 			Expect(string(jsonBytes)).To(ContainSubstring(`"error":"connection refused"`))
 		})
 
@@ -70,8 +56,46 @@ var _ = Describe("Health", func() {
 
 			jsonBytes, err := json.Marshal(health)
 			Expect(err).NotTo(HaveOccurred())
-
 			Expect(string(jsonBytes)).NotTo(ContainSubstring(`"error"`))
+		})
+
+		It("marshals Health struct with components correctly", func() {
+			timestamp := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+			lastRan := time.Date(2023, 1, 1, 11, 55, 0, 0, time.UTC)
+			health := atc.Health{
+				Status:    atc.HealthStatusDegraded,
+				Timestamp: timestamp,
+				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
+				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 1, Running: 1},
+				Components: []atc.ComponentHealth{
+					{Name: atc.ComponentScheduler, Status: atc.HealthStatusUnhealthy, Paused: false, LastRan: lastRan, Stale: true},
+					{Name: atc.ComponentCollectorVolumes, Status: atc.HealthStatusUnhealthy, Paused: false, LastRan: lastRan, Stale: true},
+				},
+			}
+
+			jsonBytes, err := json.Marshal(health)
+			Expect(err).NotTo(HaveOccurred())
+
+			var unmarshaled atc.Health
+			Expect(json.Unmarshal(jsonBytes, &unmarshaled)).To(Succeed())
+			Expect(unmarshaled.Components).To(HaveLen(2))
+			Expect(unmarshaled.Components[0].Name).To(Equal(atc.ComponentScheduler))
+			Expect(unmarshaled.Components[0].Stale).To(BeTrue())
+			Expect(unmarshaled.Components[1].Name).To(Equal(atc.ComponentCollectorVolumes))
+		})
+
+		It("marshals an empty components list as an empty array", func() {
+			health := atc.Health{
+				Status:     atc.HealthStatusOK,
+				Timestamp:  time.Now(),
+				Database:   atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
+				Workers:    atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 1, Running: 1},
+				Components: []atc.ComponentHealth{},
+			}
+
+			jsonBytes, err := json.Marshal(health)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(jsonBytes)).To(ContainSubstring(`"components":[]`))
 		})
 	})
 

--- a/atc/health_test.go
+++ b/atc/health_test.go
@@ -14,17 +14,15 @@ var _ = Describe("Health", func() {
 		It("marshals Health struct correctly", func() {
 			timestamp := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
 			health := atc.Health{
-				Status:    atc.HealthStatusHealthy,
-				Version:   "1.2.3",
+				Status:    atc.HealthStatusOK,
 				Timestamp: timestamp,
-				Details: atc.HealthDetails{
-					Database: atc.HealthStatus{
-						Status: atc.HealthStatusHealthy,
-					},
-					WorkerHealth: atc.HealthStatus{
-						Status:  atc.HealthStatusDegraded,
-						Message: "Low worker count",
-					},
+				Database: atc.DatabaseHealth{
+					Status: atc.HealthStatusHealthy,
+				},
+				Workers: atc.WorkerHealth{
+					Status:  atc.HealthStatusHealthy,
+					Total:   3,
+					Running: 3,
 				},
 			}
 
@@ -35,41 +33,58 @@ var _ = Describe("Health", func() {
 			err = json.Unmarshal(jsonBytes, &unmarshaled)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(unmarshaled.Status).To(Equal(atc.HealthStatusHealthy))
-			Expect(unmarshaled.Version).To(Equal("1.2.3"))
+			Expect(unmarshaled.Status).To(Equal(atc.HealthStatusOK))
 			Expect(unmarshaled.Timestamp).To(Equal(timestamp))
-			Expect(unmarshaled.Details.Database.Status).To(Equal(atc.HealthStatusHealthy))
-			Expect(unmarshaled.Details.WorkerHealth.Status).To(Equal(atc.HealthStatusDegraded))
-			Expect(unmarshaled.Details.WorkerHealth.Message).To(Equal("Low worker count"))
+			Expect(unmarshaled.Database.Status).To(Equal(atc.HealthStatusHealthy))
+			Expect(unmarshaled.Workers.Status).To(Equal(atc.HealthStatusHealthy))
+			Expect(unmarshaled.Workers.Total).To(Equal(3))
+			Expect(unmarshaled.Workers.Running).To(Equal(3))
 		})
 
-		It("handles empty messages correctly", func() {
+		It("includes the error field when database is unhealthy", func() {
 			health := atc.Health{
-				Status:    atc.HealthStatusUnhealthy,
+				Status:    atc.HealthStatusFailing,
 				Timestamp: time.Now(),
-				Details: atc.HealthDetails{
-					Database: atc.HealthStatus{
-						Status:  atc.HealthStatusUnhealthy,
-						Message: "Connection failed",
-					},
-					WorkerHealth: atc.HealthStatus{
-						Status: atc.HealthStatusHealthy,
-					},
+				Database: atc.DatabaseHealth{
+					Status: atc.HealthStatusUnhealthy,
+					Error:  "connection refused",
+				},
+				Workers: atc.WorkerHealth{
+					Status: atc.HealthStatusHealthy,
 				},
 			}
 
 			jsonBytes, err := json.Marshal(health)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(string(jsonBytes)).To(ContainSubstring(`"message":"Connection failed"`))
+			Expect(string(jsonBytes)).To(ContainSubstring(`"error":"connection refused"`))
+		})
+
+		It("omits the error field when database is healthy", func() {
+			health := atc.Health{
+				Status:    atc.HealthStatusOK,
+				Timestamp: time.Now(),
+				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
+				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 1, Running: 1},
+			}
+
+			jsonBytes, err := json.Marshal(health)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(string(jsonBytes)).NotTo(ContainSubstring(`"error"`))
 		})
 	})
 
 	Describe("Health status constants", func() {
-		It("has correct constant values", func() {
+		It("has correct overall status values", func() {
+			Expect(atc.HealthStatusOK).To(Equal("ok"))
+			Expect(atc.HealthStatusDegraded).To(Equal("degraded"))
+			Expect(atc.HealthStatusFailing).To(Equal("failing"))
+		})
+
+		It("has correct subsystem status values", func() {
 			Expect(atc.HealthStatusHealthy).To(Equal("healthy"))
 			Expect(atc.HealthStatusUnhealthy).To(Equal("unhealthy"))
-			Expect(atc.HealthStatusDegraded).To(Equal("degraded"))
 		})
 	})
 })

--- a/atc/health_test.go
+++ b/atc/health_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Health", func() {
 				Status:    atc.HealthStatusOK,
 				Timestamp: timestamp,
 				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
-				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 3, Running: 3},
+				Workers:   atc.WorkerHealth{Status: string(atc.HealthStatusHealthy), Total: 3, Running: 3},
 			}
 
 			jsonBytes, err := json.Marshal(health)
@@ -28,9 +28,41 @@ var _ = Describe("Health", func() {
 			Expect(unmarshaled.Status).To(Equal(atc.HealthStatusOK))
 			Expect(unmarshaled.Timestamp).To(Equal(timestamp))
 			Expect(unmarshaled.Database.Status).To(Equal(atc.HealthStatusHealthy))
-			Expect(unmarshaled.Workers.Status).To(Equal(atc.HealthStatusHealthy))
+			Expect(unmarshaled.Workers.Status).To(Equal(string(atc.HealthStatusHealthy)))
 			Expect(unmarshaled.Workers.Total).To(Equal(3))
 			Expect(unmarshaled.Workers.Running).To(Equal(3))
+		})
+
+		It("includes unhealthy_workers when workers are not running", func() {
+			health := atc.Health{
+				Status:    atc.HealthStatusFailing,
+				Timestamp: time.Now(),
+				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
+				Workers: atc.WorkerHealth{
+					Status:           string(atc.HealthStatusUnhealthy),
+					Total:            2,
+					Running:          0,
+					UnhealthyWorkers: []string{"worker-01", "worker-02"},
+				},
+			}
+
+			jsonBytes, err := json.Marshal(health)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(jsonBytes)).To(ContainSubstring(`"unhealthy_workers"`))
+			Expect(string(jsonBytes)).To(ContainSubstring("worker-01"))
+		})
+
+		It("omits unhealthy_workers when all workers are running", func() {
+			health := atc.Health{
+				Status:    atc.HealthStatusOK,
+				Timestamp: time.Now(),
+				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
+				Workers:   atc.WorkerHealth{Status: string(atc.HealthStatusHealthy), Total: 1, Running: 1},
+			}
+
+			jsonBytes, err := json.Marshal(health)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(jsonBytes)).NotTo(ContainSubstring(`"unhealthy_workers"`))
 		})
 
 		It("includes the error field when database is unhealthy", func() {
@@ -38,7 +70,7 @@ var _ = Describe("Health", func() {
 				Status:    atc.HealthStatusFailing,
 				Timestamp: time.Now(),
 				Database:  atc.DatabaseHealth{Status: atc.HealthStatusUnhealthy, Error: "connection refused"},
-				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy},
+				Workers:   atc.WorkerHealth{Status: string(atc.HealthStatusHealthy)},
 			}
 
 			jsonBytes, err := json.Marshal(health)
@@ -51,7 +83,7 @@ var _ = Describe("Health", func() {
 				Status:    atc.HealthStatusOK,
 				Timestamp: time.Now(),
 				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
-				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 1, Running: 1},
+				Workers:   atc.WorkerHealth{Status: string(atc.HealthStatusHealthy), Total: 1, Running: 1},
 			}
 
 			jsonBytes, err := json.Marshal(health)
@@ -66,7 +98,7 @@ var _ = Describe("Health", func() {
 				Status:    atc.HealthStatusDegraded,
 				Timestamp: timestamp,
 				Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
-				Workers:   atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 1, Running: 1},
+				Workers:   atc.WorkerHealth{Status: string(atc.HealthStatusHealthy), Total: 1, Running: 1},
 				Components: []atc.ComponentHealth{
 					{Name: atc.ComponentScheduler, Status: atc.HealthStatusUnhealthy, Paused: false, LastRan: lastRan},
 					{Name: atc.ComponentCollectorVolumes, Status: atc.HealthStatusUnhealthy, Paused: false, LastRan: lastRan},
@@ -89,7 +121,7 @@ var _ = Describe("Health", func() {
 				Status:     atc.HealthStatusOK,
 				Timestamp:  time.Now(),
 				Database:   atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
-				Workers:    atc.WorkerHealth{Status: atc.HealthStatusHealthy, Total: 1, Running: 1},
+				Workers:    atc.WorkerHealth{Status: string(atc.HealthStatusHealthy), Total: 1, Running: 1},
 				Components: []atc.ComponentHealth{},
 			}
 
@@ -100,15 +132,15 @@ var _ = Describe("Health", func() {
 	})
 
 	Describe("Health status constants", func() {
-		It("has correct overall status values", func() {
-			Expect(atc.HealthStatusOK).To(Equal("ok"))
-			Expect(atc.HealthStatusDegraded).To(Equal("degraded"))
-			Expect(atc.HealthStatusFailing).To(Equal("failing"))
+		It("serialises overall status values correctly", func() {
+			Expect(string(atc.HealthStatusOK)).To(Equal("ok"))
+			Expect(string(atc.HealthStatusDegraded)).To(Equal("degraded"))
+			Expect(string(atc.HealthStatusFailing)).To(Equal("failing"))
 		})
 
-		It("has correct subsystem status values", func() {
-			Expect(atc.HealthStatusHealthy).To(Equal("healthy"))
-			Expect(atc.HealthStatusUnhealthy).To(Equal("unhealthy"))
+		It("serialises subsystem status values correctly", func() {
+			Expect(string(atc.HealthStatusHealthy)).To(Equal("healthy"))
+			Expect(string(atc.HealthStatusUnhealthy)).To(Equal("unhealthy"))
 		})
 	})
 })

--- a/atc/routes.go
+++ b/atc/routes.go
@@ -91,6 +91,7 @@ const (
 	DownloadCLI  = "DownloadCLI"
 	GetInfo      = "GetInfo"
 	GetInfoCreds = "GetInfoCreds"
+	GetHealth    = "GetHealth"
 
 	ListContainers           = "ListContainers"
 	GetContainer             = "GetContainer"
@@ -227,6 +228,7 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/cli", Method: "GET", Name: DownloadCLI},
 	{Path: "/api/v1/info", Method: "GET", Name: GetInfo},
 	{Path: "/api/v1/info/creds", Method: "GET", Name: GetInfoCreds},
+	{Path: "/api/v1/health", Method: "GET", Name: GetHealth},
 
 	{Path: "/api/v1/user", Method: "GET", Name: GetUser},
 	{Path: "/api/v1/users", Method: "GET", Name: ListActiveUsersSince},

--- a/atc/wrappa/api_auth_wrappa.go
+++ b/atc/wrappa/api_auth_wrappa.go
@@ -98,6 +98,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 		case atc.DownloadCLI,
 			atc.CheckResourceWebHook,
 			atc.GetInfo,
+			atc.GetHealth,
 			atc.GetCC,
 			atc.ListTeams,
 			atc.ListAllPipelines,

--- a/atc/wrappa/reject_archived_wrappa.go
+++ b/atc/wrappa/reject_archived_wrappa.go
@@ -135,7 +135,8 @@ func (rw *RejectArchivedWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.PauseAllComponents,
 			atc.UnpauseAllComponents,
 			atc.PauseComponent,
-			atc.UnpauseComponent:
+			atc.UnpauseComponent,
+			atc.GetHealth:
 
 		default:
 			panic("how do archived pipelines affect your endpoint?")


### PR DESCRIPTION
## Changes proposed by this PR

Initial work based on https://github.com/concourse/rfcs/pull/141

- __`atc/health.go`__ - Health DTOs and constants 
- __`atc/health_test.go`__ - Comprehensive unit tests
- __`atc/routes.go`__ - Modified with health route constants and mapping


## Notes to reviewer
This is the very beginning of the `/api/v1/health` endpoint feature. The focus of this PR is to establish basic structure and data types. Actual logic will follow in separate PR's following the "Implementation plan" I created in the rfc PR. The focus on the review here that I desire is the design and validity of the data structures and JSON schema. Since I will follow-up with the actual health server in the next PR, I used stubs for now in places, where the handler was expected.

