### PR TITLE
Chown bind-mount volumes when running as non-root user

### DIFF
--- a/atc/db/volume_repository.go
+++ b/atc/db/volume_repository.go
@@ -52,6 +52,8 @@ type VolumeRepository interface {
 
 const noTeam = 0
 
+var _ VolumeRepository = (*volumeRepository)(nil)
+
 type volumeRepository struct {
 	conn DbConn
 }

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -452,6 +452,7 @@ func (step *TaskStep) containerSpec(logger lager.Logger, state RunState, imageSp
 
 		Dir:      metadata.WorkingDirectory,
 		Hermetic: step.plan.Hermetic,
+		User:     config.Run.User,
 	}
 
 	var err error

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -295,6 +295,16 @@ var _ = Describe("TaskStep", func() {
 			})
 		})
 
+		Context("when a user is configured", func() {
+			BeforeEach(func() {
+				taskPlan.Config.Run.User = "some-user"
+			})
+
+			It("sets the user on the container spec", func() {
+				Expect(chosenContainer.Spec.User).To(Equal("some-user"))
+			})
+		})
+
 		Context("when a timeout is configured", func() {
 			BeforeEach(func() {
 				taskPlan.Timeout = "1ms"

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -126,6 +126,10 @@ type ContainerSpec struct {
 
 	// Hermetic indicates whether or not the container has external network access.
 	Hermetic bool
+
+	// User that bind mounts will be owned by and that processes will run under
+	// inside the container
+	User string
 }
 
 type BuildStepDelegate interface {
@@ -363,4 +367,11 @@ type VolumeMount struct {
 	// MountPath is the absolute path in the Container at which the Volume is
 	// mounted.
 	MountPath string
+}
+
+const ExistingOwner, ExistingGroup = -1, -1
+
+type VolumeOwnership struct {
+	Uid int
+	Gid int
 }

--- a/atc/worker/gardenruntime/container.go
+++ b/atc/worker/gardenruntime/container.go
@@ -18,6 +18,8 @@ const userPropertyName = "user"
 
 const exitStatusPropertyName = "concourse:exit-status"
 
+var _ runtime.Container = (*Container)(nil)
+
 type Container struct {
 	DBContainer_    db.CreatedContainer
 	GardenContainer gclient.Container

--- a/atc/worker/gardenruntime/gardenruntimetest/baggageclaim.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/baggageclaim.go
@@ -11,10 +11,9 @@ import (
 
 	"github.com/concourse/concourse/atc/runtime/runtimetest"
 	"github.com/concourse/concourse/worker/baggageclaim"
-	bclient "github.com/concourse/concourse/worker/baggageclaim/client"
 )
 
-var _ bclient.Client = (*Baggageclaim)(nil)
+var _ baggageclaim.Client = (*Baggageclaim)(nil)
 
 type Baggageclaim struct {
 	Volumes []*Volume

--- a/atc/worker/gardenruntime/gclient/client_stream_timeout_test.go
+++ b/atc/worker/gardenruntime/gclient/client_stream_timeout_test.go
@@ -58,7 +58,10 @@ var _ = Describe("stream http client", func() {
 			client := clientFactory.NewClient()
 			_, err := client.Create(garden.ContainerSpec{})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Client.Timeout"))
+			Expect(err.Error()).To(Or(
+				ContainSubstring("Client.Timeout"),
+				ContainSubstring("context deadline exceeded"),
+			))
 		})
 	})
 })

--- a/atc/worker/gardenruntime/image.go
+++ b/atc/worker/gardenruntime/image.go
@@ -41,7 +41,16 @@ func (worker *Worker) fetchImageForContainer(
 	logger := lagerctx.FromContext(ctx)
 
 	if imageSpec.ImageArtifact != nil {
-		volume, err := worker.findOrStreamVolume(ctx, imageSpec.Privileged, teamID, container, imageSpec.ImageArtifact, "/", delegate)
+		volume, err := worker.findOrStreamVolume(
+			ctx,
+			imageSpec.Privileged,
+			teamID,
+			container,
+			imageSpec.ImageArtifact,
+			"/",
+			runtime.VolumeOwnership{Uid: runtime.ExistingOwner, Gid: runtime.ExistingGroup},
+			delegate,
+		)
 		if err != nil {
 			logger.Error("failed-to-find-or-stream-volume-for-image", err)
 			return FetchedImage{}, fmt.Errorf("find or stream volume: %w", err)
@@ -54,6 +63,7 @@ func (worker *Worker) fetchImageForContainer(
 			volume,
 			teamID,
 			"/",
+			runtime.VolumeOwnership{Uid: runtime.ExistingOwner, Gid: runtime.ExistingGroup},
 		)
 		if err != nil {
 			logger.Error("failed-to-create-cow-volume-for-image", err)
@@ -122,6 +132,7 @@ func (worker *Worker) imageFromBaseResourceType(
 		importVolume,
 		teamID,
 		"/",
+		runtime.VolumeOwnership{Uid: runtime.ExistingOwner, Gid: runtime.ExistingGroup},
 	)
 	if err != nil {
 		return FetchedImage{}, err

--- a/atc/worker/gardenruntime/volume.go
+++ b/atc/worker/gardenruntime/volume.go
@@ -213,12 +213,15 @@ func (worker *Worker) findOrCreateVolumeForStreaming(
 	container db.CreatingContainer,
 	teamID int,
 	mountPath string,
+	ownerSpec runtime.VolumeOwnership,
 ) (Volume, error) {
 	return worker.findOrCreateVolumeForContainer(
 		ctx,
 		baggageclaim.VolumeSpec{
 			Strategy:   baggageclaim.EmptyStrategy{},
 			Privileged: privileged,
+			Uid:        new(ownerSpec.Uid),
+			Gid:        new(ownerSpec.Gid),
 		},
 		container,
 		teamID,
@@ -235,6 +238,7 @@ func (worker *Worker) findOrCreateCOWVolumeForContainer(
 	parent Volume,
 	teamID int,
 	mountPath string,
+	ownerSpec runtime.VolumeOwnership,
 ) (Volume, error) {
 	ctx = lagerctx.NewContext(ctx, lagerctx.FromContext(ctx).Session("find-or-create-cow-volume-for-container"))
 	return worker.findOrCreateVolume(
@@ -242,6 +246,8 @@ func (worker *Worker) findOrCreateCOWVolumeForContainer(
 		baggageclaim.VolumeSpec{
 			Strategy:   parent.COWStrategy(),
 			Privileged: privileged,
+			Uid:        new(ownerSpec.Uid),
+			Gid:        new(ownerSpec.Gid),
 		},
 		func() (db.CreatingVolume, db.CreatedVolume, error) {
 			return worker.db.VolumeRepo.FindContainerVolume(teamID, worker.Name(), container, mountPath)

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -795,15 +795,7 @@ func (worker *Worker) getUserInfo(
 		taskUser = imageMetadata.User
 	}
 
-	if taskUser == "root" {
-		// short-circut for most common case and skip streaming files
-		return runtime.VolumeOwnship{
-			Uid: runtime.ExistingOwner,
-			Gid: runtime.ExistingGroup,
-		}
-	}
-
-	if taskUser != "" {
+	if taskUser != "" && taskUser != "root" {
 		// Don't return errors so images that don't contain /etc/{passwd,group}
 		// don't fail. If we returned errors, these images would be unusable
 		// with Concourse (e.g. `FROM scratch` images)

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/concourse/concourse/atc/worker/gardenruntime/gclient"
 	"github.com/concourse/concourse/tracing"
 	"github.com/concourse/concourse/worker/baggageclaim"
+	"github.com/moby/sys/user"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -32,6 +33,8 @@ type Streamer interface {
 	Stream(ctx context.Context, src runtime.Artifact, dst runtime.Volume) error
 	StreamFile(ctx context.Context, src runtime.Artifact, path string) (io.ReadCloser, error)
 }
+
+var _ runtime.Worker = (*Worker)(nil)
 
 type Worker struct {
 	streamer Streamer
@@ -189,7 +192,9 @@ func (worker *Worker) createGardenContainer(
 		return nil, err
 	}
 
-	volumeMounts, err := worker.createVolumes(ctx, fetchedImage.Privileged, creatingContainer, containerSpec, delegate)
+	ownerSpec := worker.getUserInfo(ctx, containerSpec.ImageSpec, fetchedImage.Metadata, containerSpec.User)
+
+	volumeMounts, err := worker.createVolumes(ctx, fetchedImage.Privileged, creatingContainer, containerSpec, ownerSpec, delegate)
 	if err != nil {
 		logger.Error("failed-to-create-volume-mounts-for-container", err)
 		markContainerAsFailed(logger, creatingContainer)
@@ -323,6 +328,7 @@ func (worker *Worker) createVolumes(
 	privileged bool,
 	creatingContainer db.CreatingContainer,
 	spec runtime.ContainerSpec,
+	ownerSpec runtime.VolumeOwnership,
 	delegate runtime.BuildStepDelegate,
 ) ([]runtime.VolumeMount, error) {
 	var volumeMounts []runtime.VolumeMount
@@ -332,6 +338,8 @@ func (worker *Worker) createVolumes(
 		baggageclaim.VolumeSpec{
 			Strategy:   baggageclaim.EmptyStrategy{},
 			Privileged: privileged,
+			Uid:        new(ownerSpec.Uid),
+			Gid:        new(ownerSpec.Gid),
 		},
 		creatingContainer,
 		spec.TeamID,
@@ -348,17 +356,17 @@ func (worker *Worker) createVolumes(
 
 	volumeMounts = append(volumeMounts, scratchMount)
 
-	inputVolumeMounts, inputDestinationPaths, err := worker.cloneInputVolumes(ctx, spec, privileged, creatingContainer, delegate)
+	inputVolumeMounts, inputDestinationPaths, err := worker.cloneInputVolumes(ctx, spec, privileged, creatingContainer, ownerSpec, delegate)
 	if err != nil {
 		return nil, err
 	}
 
-	outputVolumeMounts, err := worker.createOutputVolumes(ctx, spec, privileged, creatingContainer, inputDestinationPaths)
+	outputVolumeMounts, err := worker.createOutputVolumes(ctx, spec, privileged, creatingContainer, inputDestinationPaths, ownerSpec)
 	if err != nil {
 		return nil, err
 	}
 
-	cacheVolumeMounts, err := worker.cloneCacheVolumes(ctx, spec, privileged, creatingContainer)
+	cacheVolumeMounts, err := worker.cloneCacheVolumes(ctx, spec, privileged, creatingContainer, ownerSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -374,6 +382,8 @@ func (worker *Worker) createVolumes(
 			baggageclaim.VolumeSpec{
 				Strategy:   baggageclaim.EmptyStrategy{},
 				Privileged: privileged,
+				Uid:        new(ownerSpec.Uid),
+				Gid:        new(ownerSpec.Gid),
 			},
 			creatingContainer,
 			spec.TeamID,
@@ -405,6 +415,7 @@ func (worker *Worker) cloneInputVolumes(
 	spec runtime.ContainerSpec,
 	privileged bool,
 	container db.CreatingContainer,
+	ownerSpec runtime.VolumeOwnership,
 	delegate runtime.BuildStepDelegate,
 ) ([]runtime.VolumeMount, map[string]bool, error) {
 
@@ -421,7 +432,7 @@ func (worker *Worker) cloneInputVolumes(
 
 		func(i int, input runtime.Input) {
 			g.Go(func() error {
-				v, err := worker.findOrStreamVolume(groupCtx, privileged, spec.TeamID, container, input.Artifact, input.DestinationPath, delegate)
+				v, err := worker.findOrStreamVolume(groupCtx, privileged, spec.TeamID, container, input.Artifact, input.DestinationPath, ownerSpec, delegate)
 				if err != nil {
 					return err
 				}
@@ -437,7 +448,7 @@ func (worker *Worker) cloneInputVolumes(
 		return nil, nil, err
 	}
 
-	mounts, err := worker.cloneLocalInputVolumes(ctx, spec, privileged, container, localInputs)
+	mounts, err := worker.cloneLocalInputVolumes(ctx, spec, privileged, container, localInputs, ownerSpec)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -451,6 +462,7 @@ func (worker *Worker) cloneLocalInputVolumes(
 	privileged bool,
 	container db.CreatingContainer,
 	inputs []mountableLocalInput,
+	ownerSpec runtime.VolumeOwnership,
 ) ([]runtime.VolumeMount, error) {
 	mounts := make([]runtime.VolumeMount, len(inputs))
 
@@ -462,6 +474,7 @@ func (worker *Worker) cloneLocalInputVolumes(
 			input.cowParent,
 			spec.TeamID,
 			input.mountPath,
+			ownerSpec,
 		)
 		if err != nil {
 			return nil, err
@@ -481,6 +494,7 @@ func (worker *Worker) createOutputVolumes(
 	privileged bool,
 	container db.CreatingContainer,
 	inputDestinationPaths map[string]bool,
+	ownerSpec runtime.VolumeOwnership,
 ) ([]runtime.VolumeMount, error) {
 	var mounts []runtime.VolumeMount
 
@@ -497,6 +511,8 @@ func (worker *Worker) createOutputVolumes(
 			baggageclaim.VolumeSpec{
 				Strategy:   baggageclaim.EmptyStrategy{},
 				Privileged: privileged,
+				Uid:        new(ownerSpec.Uid),
+				Gid:        new(ownerSpec.Gid),
 			},
 			container,
 			spec.TeamID,
@@ -520,6 +536,7 @@ func (worker *Worker) cloneCacheVolumes(
 	spec runtime.ContainerSpec,
 	privileged bool,
 	container db.CreatingContainer,
+	ownerSpec runtime.VolumeOwnership,
 ) ([]runtime.VolumeMount, error) {
 	mounts := make([]runtime.VolumeMount, len(spec.Caches))
 
@@ -548,6 +565,7 @@ func (worker *Worker) cloneCacheVolumes(
 				volume,
 				spec.TeamID,
 				mountPath,
+				ownerSpec,
 			)
 			if err != nil {
 				return nil, err
@@ -561,6 +579,8 @@ func (worker *Worker) cloneCacheVolumes(
 				baggageclaim.VolumeSpec{
 					Strategy:   baggageclaim.EmptyStrategy{},
 					Privileged: privileged,
+					Uid:        new(ownerSpec.Uid),
+					Gid:        new(ownerSpec.Gid),
 				},
 				container,
 				spec.TeamID,
@@ -677,6 +697,7 @@ func (worker *Worker) findOrStreamVolume(
 	container db.CreatingContainer,
 	artifact runtime.Artifact,
 	mountPath string,
+	ownerSpec runtime.VolumeOwnership,
 	delegate runtime.BuildStepDelegate,
 ) (Volume, error) {
 	logger := lagerctx.FromContext(ctx)
@@ -723,6 +744,7 @@ func (worker *Worker) findOrStreamVolume(
 				container,
 				teamID,
 				mountPath,
+				ownerSpec,
 			)
 			if err != nil {
 				logger.Error("failed-to-create-volume-for-streaming", err)
@@ -750,4 +772,67 @@ func (worker *Worker) findOrStreamVolume(
 			continue
 		}
 	}
+}
+
+func (worker *Worker) getUserInfo(
+	ctx context.Context,
+	imageSpec runtime.ImageSpec,
+	imageMetadata ImageMetadata,
+	taskUser string,
+) runtime.VolumeOwnership {
+	logger := lagerctx.FromContext(ctx)
+	keepExistingOwnership := runtime.VolumeOwnership{
+		Uid: runtime.ExistingOwner,
+		Gid: runtime.ExistingGroup,
+	}
+
+	if imageSpec.ImageArtifact == nil {
+		// No image to inspect, do nothing
+		return keepExistingOwnership
+	}
+
+	if taskUser == "" {
+		taskUser = imageMetadata.User
+	}
+
+	if taskUser == "root" {
+		// short-circut for most common case and skip streaming files
+		return runtime.VolumeOwnship{
+			Uid: runtime.ExistingOwner,
+			Gid: runtime.ExistingGroup,
+		}
+	}
+
+	if taskUser != "" {
+		// Don't return errors so images that don't contain /etc/{passwd,group}
+		// don't fail. If we returned errors, these images would be unusable
+		// with Concourse (e.g. `FROM scratch` images)
+		passwd, err := worker.streamer.StreamFile(ctx, imageSpec.ImageArtifact,
+			"rootfs/etc/passwd")
+		if err != nil {
+			logger.Error("streaming-etc-passwd-from-image", err)
+			return keepExistingOwnership
+		}
+		defer passwd.Close()
+
+		group, err := worker.streamer.StreamFile(ctx, imageSpec.ImageArtifact, "rootfs/etc/group")
+		if err != nil {
+			logger.Error("streaming-etc-group-from-image", err)
+			return keepExistingOwnership
+		}
+		defer group.Close()
+
+		execUser, err := user.GetExecUser(taskUser, &user.ExecUser{}, passwd, group)
+		if err != nil {
+			logger.Error("finding-user-id-in-image", err, lager.Data{"user": taskUser})
+			return keepExistingOwnership
+		}
+
+		return runtime.VolumeOwnership{
+			Uid: execUser.Uid,
+			Gid: execUser.Gid,
+		}
+	}
+
+	return keepExistingOwnership
 }

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -1287,6 +1287,283 @@ var _ = Describe("Garden Worker", func() {
 		})
 	})
 
+	Test("container with no image artifact leaves volume ownership as-is", func() {
+		inputVolume := grt.NewVolume("input")
+		scenario := Setup(
+			workertest.WithWorkers(
+				grt.NewWorker("worker").
+					WithVolumesCreatedInDBAndBaggageclaim(
+						inputVolume,
+					),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		container, _, err := worker.FindOrCreateContainer(
+			ctx,
+			db.NewFixedHandleContainerOwner("my-handle"),
+			db.ContainerMetadata{},
+			runtime.ContainerSpec{
+				TeamID:    scenario.TeamID,
+				JobID:     scenario.JobID,
+				StepName:  scenario.StepName,
+				Dir:       "/workdir",
+				ImageSpec: runtime.ImageSpec{},
+				User:      "somebody",
+				Inputs: []runtime.Input{
+					{
+						Artifact:        scenario.WorkerVolume("worker", inputVolume.Handle()),
+						DestinationPath: "/input",
+					},
+				},
+				Outputs: runtime.OutputPaths{
+					"output": "/output",
+				},
+				Caches: []string{"/cache"},
+			},
+			delegate,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		volumes := bindMountVolumes(worker, container)
+		Expect(volumes).To(HaveLen(5))
+
+		for path, vol := range volumes {
+			Expect(*vol.Spec.Uid).To(Equal(runtime.ExistingOwner), "mount %s", path)
+			Expect(*vol.Spec.Gid).To(Equal(runtime.ExistingGroup), "mount %s", path)
+		}
+	})
+
+	Test("container running as non-root resolves uid/gid from /etc/{passwd/group}", func() {
+		imageVolume := grt.NewVolume("image-volume").WithContent(runtimetest.VolumeContent{
+			"metadata.json": grt.ImageMetadataFile(gardenruntime.ImageMetadata{}),
+			"rootfs/etc/passwd": {
+				Data: []byte("myuser:x:1234:5678::/home/myuser:/bin/sh\n"),
+			},
+			"rootfs/etc/group": {
+				Data: []byte("mygroup:x:5678:\n"),
+			},
+		})
+		inputVolume := grt.NewVolume("input")
+		scenario := Setup(
+			workertest.WithBasicJob(),
+			workertest.WithWorkers(
+				grt.NewWorker("worker").
+					WithVolumesCreatedInDBAndBaggageclaim(
+						imageVolume,
+						inputVolume,
+					),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		container, _, err := worker.FindOrCreateContainer(
+			ctx,
+			db.NewFixedHandleContainerOwner("my-handle"),
+			db.ContainerMetadata{},
+			runtime.ContainerSpec{
+				TeamID:   scenario.TeamID,
+				JobID:    scenario.JobID,
+				StepName: scenario.StepName,
+
+				Dir:  "/workdir",
+				User: "myuser",
+				ImageSpec: runtime.ImageSpec{
+					ImageArtifact: scenario.WorkerVolume("worker", imageVolume.Handle()),
+				},
+				Inputs: []runtime.Input{
+					{
+						Artifact:        scenario.WorkerVolume("worker", inputVolume.Handle()),
+						DestinationPath: "/input",
+					},
+				},
+				Outputs: runtime.OutputPaths{
+					"output": "/output",
+				},
+				Caches: []string{"/cache"},
+			},
+			delegate,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		volumes := bindMountVolumes(worker, container)
+		Expect(volumes).To(HaveLen(5))
+
+		By("setting uid and gid on every bind-mount volume", func() {
+			for path, vol := range volumes {
+				Expect(*vol.Spec.Uid).To(Equal(1234), "mount %s", path)
+				Expect(*vol.Spec.Gid).To(Equal(5678), "mount %s", path)
+			}
+		})
+
+		By("leaving the rootfs volume's ownership as-is", func() {
+			rootfs, ok := findVolumeBy(worker, grt.StrategyEq(baggageclaim.COWStrategy{Parent: imageVolume}))
+			Expect(ok).To(BeTrue())
+			Expect(*rootfs.Spec.Uid).To(Equal(runtime.ExistingOwner))
+			Expect(*rootfs.Spec.Gid).To(Equal(runtime.ExistingGroup))
+		})
+	})
+
+	Test("container falls back to image's USER when task's run.user is not defined", func() {
+		imageVolume := grt.NewVolume("image-volume").WithContent(runtimetest.VolumeContent{
+			"metadata.json": grt.ImageMetadataFile(gardenruntime.ImageMetadata{
+				User: "myuser",
+			}),
+			"rootfs/etc/passwd": {
+				Data: []byte("myuser:x:1234:5678::/home/myuser:/bin/sh\n"),
+			},
+			"rootfs/etc/group": {
+				Data: []byte("mygroup:x:5678:\n"),
+			},
+		})
+		scenario := Setup(
+			workertest.WithBasicJob(),
+			workertest.WithWorkers(
+				grt.NewWorker("worker").
+					WithVolumesCreatedInDBAndBaggageclaim(imageVolume),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		container, _, err := worker.FindOrCreateContainer(
+			ctx,
+			db.NewFixedHandleContainerOwner("my-handle"),
+			db.ContainerMetadata{},
+			runtime.ContainerSpec{
+				TeamID:   scenario.TeamID,
+				JobID:    scenario.JobID,
+				StepName: scenario.StepName,
+
+				Dir:  "/workdir",
+				User: "",
+				ImageSpec: runtime.ImageSpec{
+					ImageArtifact: scenario.WorkerVolume("worker", imageVolume.Handle()),
+				},
+			},
+			delegate,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		volumes := bindMountVolumes(worker, container)
+		Expect(volumes).To(HaveLen(2))
+
+		for path, vol := range volumes {
+			Expect(*vol.Spec.Uid).To(Equal(1234), "mount %s", path)
+			Expect(*vol.Spec.Gid).To(Equal(5678), "mount %s", path)
+		}
+	})
+
+	Test("container with non-root user falls back to existing ownership when /etc/passwd is missing", func() {
+		imageVolume := grt.NewVolume("image-volume").WithContent(runtimetest.VolumeContent{
+			"metadata.json": grt.ImageMetadataFile(gardenruntime.ImageMetadata{}),
+		})
+		scenario := Setup(
+			workertest.WithBasicJob(),
+			workertest.WithWorkers(
+				grt.NewWorker("worker").
+					WithVolumesCreatedInDBAndBaggageclaim(imageVolume),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		container, _, err := worker.FindOrCreateContainer(
+			ctx,
+			db.NewFixedHandleContainerOwner("my-handle"),
+			db.ContainerMetadata{},
+			runtime.ContainerSpec{
+				TeamID:   scenario.TeamID,
+				JobID:    scenario.JobID,
+				StepName: scenario.StepName,
+
+				Dir:  "/workdir",
+				User: "myuser",
+				ImageSpec: runtime.ImageSpec{
+					ImageArtifact: scenario.WorkerVolume("worker", imageVolume.Handle()),
+				},
+			},
+			delegate,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		volumes := bindMountVolumes(worker, container)
+		Expect(volumes).To(HaveLen(2))
+
+		for path, vol := range volumes {
+			Expect(*vol.Spec.Uid).To(Equal(runtime.ExistingOwner), "mount %s", path)
+			Expect(*vol.Spec.Gid).To(Equal(runtime.ExistingGroup), "mount %s", path)
+		}
+	})
+
+	Test("container running as root leaves ownership as-is", func() {
+		imageVolume := grt.NewVolume("image-volume").WithContent(runtimetest.VolumeContent{
+			"metadata.json": grt.ImageMetadataFile(gardenruntime.ImageMetadata{}),
+			"rootfs/etc/passwd": {
+				Data: []byte("myuser:x:1234:5678::/home/myuser:/bin/sh\n"),
+			},
+			"rootfs/etc/group": {
+				Data: []byte("mygroup:x:5678:\n"),
+			},
+		})
+		inputVolume := grt.NewVolume("input")
+		scenario := Setup(
+			workertest.WithBasicJob(),
+			workertest.WithWorkers(
+				grt.NewWorker("worker").
+					WithVolumesCreatedInDBAndBaggageclaim(
+						imageVolume,
+						inputVolume,
+					),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		container, _, err := worker.FindOrCreateContainer(
+			ctx,
+			db.NewFixedHandleContainerOwner("my-handle"),
+			db.ContainerMetadata{},
+			runtime.ContainerSpec{
+				TeamID:   scenario.TeamID,
+				JobID:    scenario.JobID,
+				StepName: scenario.StepName,
+
+				Dir:  "/workdir",
+				User: "root",
+				ImageSpec: runtime.ImageSpec{
+					ImageArtifact: scenario.WorkerVolume("worker", imageVolume.Handle()),
+				},
+				Inputs: []runtime.Input{
+					{
+						Artifact:        scenario.WorkerVolume("worker", inputVolume.Handle()),
+						DestinationPath: "/input",
+					},
+				},
+				Outputs: runtime.OutputPaths{
+					"output": "/output",
+				},
+				Caches: []string{"/cache"},
+			},
+			delegate,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		volumes := bindMountVolumes(worker, container)
+		Expect(volumes).To(HaveLen(5))
+
+		By("leaving ownership and group as-is", func() {
+			for path, vol := range volumes {
+				Expect(*vol.Spec.Uid).To(Equal(runtime.ExistingOwner), "mount %s", path)
+				Expect(*vol.Spec.Gid).To(Equal(runtime.ExistingGroup), "mount %s", path)
+			}
+		})
+
+		By("leaving the rootfs volume's ownership as-is", func() {
+			rootfs, ok := findVolumeBy(worker, grt.StrategyEq(baggageclaim.COWStrategy{Parent: imageVolume}))
+			Expect(ok).To(BeTrue())
+			Expect(*rootfs.Spec.Uid).To(Equal(runtime.ExistingOwner))
+			Expect(*rootfs.Spec.Gid).To(Equal(runtime.ExistingGroup))
+		})
+	})
+
 	Test("hermetic container spec produces empty NetOut", func() {
 		scenario := Setup(
 			workertest.WithWorkers(

--- a/testflight/fixtures/nonroot-chowning.yml
+++ b/testflight/fixtures/nonroot-chowning.yml
@@ -1,0 +1,264 @@
+resources:
+  - name: image
+    type: mock
+    source:
+      mirror_self: true
+    version:
+      version: mock
+
+  - name: version
+    type: mock
+    source:
+      no_initial_version: true
+
+jobs:
+  - name: root
+    plan:
+      - get: image
+      - task: root
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: image
+          outputs:
+            - name: empty
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "root"
+                test "$(stat -c '%U' ./empty)" = "root"
+                test "$(stat -c '%U' ./image)" = "root"
+                echo "can write to file" > ./empty/file
+                echo "can write to file" > ./image/file
+
+  - name: root-privileged
+    plan:
+      - get: image
+      - task: root
+        privileged: true
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: image
+          outputs:
+            - name: empty
+          run:
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "root"
+                test "$(stat -c '%U' ./empty)" = "root"
+                test "$(stat -c '%U' ./image)" = "root"
+                echo "can write to file" > ./empty/file
+                echo "can write to file" > ./image/file
+
+  - name: nonroot
+    plan:
+      - get: image
+      - task: nonroot
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: image
+          outputs:
+            - name: empty
+          run:
+            user: nonroot
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "nonroot"
+                test "$(stat -c '%U' ./empty)" = "nonroot"
+                test "$(stat -c '%U' ./image)" = "nonroot"
+                echo "can write to file" > ./empty/file
+                echo "can write to file" > ./image/file
+
+  - name: nonroot-privileged
+    plan:
+      - get: image
+      - task: nonroot
+        privileged: true
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: image
+          outputs:
+            - name: empty
+          run:
+            user: nonroot
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "nonroot"
+                test "$(stat -c '%U' ./empty)" = "nonroot"
+                test "$(stat -c '%U' ./image)" = "nonroot"
+                echo "can write to file" > ./empty/file
+                echo "can write to file" > ./image/file
+
+  - name: different-users
+    plan:
+      - get: image
+      - task: nonroot
+        image: image
+        config:
+          platform: linux
+          outputs:
+            - name: empty
+          run:
+            user: nonroot
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "nonroot"
+                test "$(stat -c '%U' ./empty)" = "nonroot"
+                echo "can write to file" > ./empty/file
+
+      - task: adm
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: empty
+          outputs:
+            - name: empty
+          run:
+            user: adm
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "adm"
+                test "$(stat -c '%U' ./empty)" = "adm"
+                test "$(cat ./empty/file)" = "can write to file"
+                echo "hello from adm" > ./empty/file
+
+      - task: daemon
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: empty
+          outputs:
+            - name: empty
+          run:
+            user: daemon
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "daemon"
+                test "$(stat -c '%U' ./empty)" = "daemon"
+                test "$(cat ./empty/file)" = "hello from adm"
+                echo "hello from daemon" > ./empty/file
+
+      - task: news
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: empty
+          outputs:
+            - name: empty
+          run:
+            user: news
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "news"
+                test "$(stat -c '%U' ./empty)" = "news"
+                test "$(cat ./empty/file)" = "hello from daemon"
+                echo "hello from news" > ./empty/file
+
+  - name: put
+    plan:
+      - get: image
+      - task: nonroot
+        image: image
+        config:
+          platform: linux
+          outputs:
+            - name: empty
+          run:
+            user: nonroot
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "nonroot"
+                test "$(stat -c '%U' ./empty)" = "nonroot"
+                echo "written by nonroot" > ./empty/file
+
+      - put: version
+        params:
+          file: empty/file
+
+  - name: nonroot-to-root
+    plan:
+      - get: image
+      - task: nonroot
+        image: image
+        config:
+          platform: linux
+          outputs:
+            - name: empty
+          run:
+            user: nonroot
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "nonroot"
+                test "$(stat -c '%U' ./empty)" = "nonroot"
+                echo "written by nonroot" > ./empty/file
+
+      - task: root
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: empty
+          run:
+            user: root
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "root"
+                echo './empty is owned by root'
+                test "$(stat -c '%U' ./empty)" = "root"
+                echo './empty/file is still owned by root'
+                test "$(stat -c '%U' ./empty/file)" = "nonroot"
+                echo "written by root" >> ./empty/file

--- a/testflight/fixtures/nonroot-chowning.yml
+++ b/testflight/fixtures/nonroot-chowning.yml
@@ -11,6 +11,15 @@ resources:
     source:
       no_initial_version: true
 
+  - name: input
+    type: mock
+    source:
+      create_files:
+        file.yml: |
+          foo: bar
+    version:
+      version: mock
+
 jobs:
   - name: root
     plan:
@@ -262,3 +271,44 @@ jobs:
                 echo './empty/file is still owned by root'
                 test "$(stat -c '%U' ./empty/file)" = "nonroot"
                 echo "written by root" >> ./empty/file
+
+  - name: nonroot-and-root-same-parent-volume
+    plan:
+      - get: image
+      - get: input
+      - task: nonroot
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: input
+          run:
+            user: nonroot
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "nonroot"
+                test "$(stat -c '%U' ./input)" = "nonroot"
+                test "$(stat -c '%U' ./input/file.yml)" = "nonroot"
+                echo "written by nonroot" > ./input/file-new
+
+      - task: root
+        image: image
+        config:
+          platform: linux
+          inputs:
+            - name: input
+          run:
+            user: root
+            path: bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                set -x
+                test $(whoami) = "root"
+                test "$(stat -c '%U' ./input)" = "root"
+                test "$(stat -c '%U' ./input/file.yml)" = "root"

--- a/testflight/volume_mounting_test.go
+++ b/testflight/volume_mounting_test.go
@@ -87,4 +87,9 @@ var _ = Describe("Containers with nonroot users have their volume mounts chown'd
 		sess := fly("trigger-job", "-j", inPipeline("nonroot-to-root"), "-w")
 		Expect(sess).To(gexec.Exit(0))
 	}, DefaultSpecTimeout)
+
+	It("parent volume is correctly COW'd and only chown'd for the nonroot task", func(ctx SpecContext) {
+		sess := fly("trigger-job", "-j", inPipeline("nonroot-and-root-same-parent-volume"), "-w")
+		Expect(sess).To(gexec.Exit(0))
+	}, DefaultSpecTimeout)
 })

--- a/testflight/volume_mounting_test.go
+++ b/testflight/volume_mounting_test.go
@@ -47,3 +47,44 @@ var _ = Describe("A job with nested volume mounts", func() {
 		Expect(sess).To(gexec.Exit(0))
 	}, DefaultSpecTimeout)
 })
+
+var _ = Describe("Containers with nonroot users have their volume mounts chown'd", func() {
+	BeforeEach(func() {
+		setAndUnpausePipeline("fixtures/nonroot-chowning.yml")
+	})
+
+	It("volumes are by default owned by root", func(ctx SpecContext) {
+		sess := fly("trigger-job", "-j", inPipeline("root"), "-w")
+		Expect(sess).To(gexec.Exit(0))
+	}, DefaultSpecTimeout)
+
+	It("volumes are by default owned by root (privileged)", func(ctx SpecContext) {
+		sess := fly("trigger-job", "-j", inPipeline("root-privileged"), "-w")
+		Expect(sess).To(gexec.Exit(0))
+	}, DefaultSpecTimeout)
+
+	It("volumes owned by nonroot when user is nonroot", func(ctx SpecContext) {
+		sess := fly("trigger-job", "-j", inPipeline("nonroot"), "-w")
+		Expect(sess).To(gexec.Exit(0))
+	}, DefaultSpecTimeout)
+
+	It("volumes owned by nonroot when user is nonroot (privileged)", func(ctx SpecContext) {
+		sess := fly("trigger-job", "-j", inPipeline("nonroot-privileged"), "-w")
+		Expect(sess).To(gexec.Exit(0))
+	}, DefaultSpecTimeout)
+
+	It("volume passed between steps is chown'd by different nonroot users", func(ctx SpecContext) {
+		sess := fly("trigger-job", "-j", inPipeline("different-users"), "-w")
+		Expect(sess).To(gexec.Exit(0))
+	}, DefaultSpecTimeout)
+
+	It("passing nonroot volume to put step works", func(ctx SpecContext) {
+		sess := fly("trigger-job", "-j", inPipeline("put"), "-w")
+		Expect(sess).To(gexec.Exit(0))
+	}, DefaultSpecTimeout)
+
+	It("volumed owned by nonroot is passed as-is to step running as root", func(ctx SpecContext) {
+		sess := fly("trigger-job", "-j", inPipeline("nonroot-to-root"), "-w")
+		Expect(sess).To(gexec.Exit(0))
+	}, DefaultSpecTimeout)
+})

--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -22,6 +22,7 @@ import (
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	sq "github.com/Masterminds/squirrel"
+	"github.com/concourse/concourse/worker/baggageclaim"
 	bclient "github.com/concourse/concourse/worker/baggageclaim/client"
 	"golang.org/x/oauth2"
 
@@ -50,7 +51,7 @@ var (
 	AtcPassword    string
 
 	WorkerGardenClient       gclient.Client
-	WorkerBaggageclaimClient bclient.Client
+	WorkerBaggageclaimClient baggageclaim.Client
 
 	concourseReleaseVersion, bpmReleaseVersion, postgresReleaseVersion string
 	vaultReleaseVersion, credhubReleaseVersion, uaaReleaseVersion      string

--- a/worker/baggageclaim/README.md
+++ b/worker/baggageclaim/README.md
@@ -1,18 +1,23 @@
-# baggage claim
+# Baggageclaim
 
-*a volume manager for garden containers*
+*A volume manager for Concourse containers*
 
 ![Baggage Claim](https://farm4.staticflickr.com/3365/4623535134_c88f474f8d_d.jpg)
 
 [by](https://creativecommons.org/licenses/by-nc-nd/2.0/) [atmx](https://www.flickr.com/photos/atmtx/)
 
-## about
+## About
 
-*baggageclaim* allows you to create and layer volumes on a remote server. This
+*Baggageclaim* allows you to create and layer volumes on a remote server. This
 is particularly useful when used with [bind mounts][bind-mounts] or the RootFS
-when using [Garden][garden]. It allows directories to be made which can be
-populated before having copy-on-write layers layered on top. e.g. to provide
-caching.
+when creating containers. It allows directories to be made which can be
+populated before having copy-on-write (CoW) layers layered on top. This allows
+multiple containers to read and write to the same underlying volume without
+colliding with each others work, since they'll write to different CoW layers.
+
+Baggageclaim runs as an HTTP server. There is no authentication, but is
+configured to only listen on localhost (by default). A Concourse worker forwards
+a connection to the Baggageclaim server over SSH to a Concourse web node,
+allowing the web node to send requests to Baggageclaim securely.
 
 [bind-mounts]: http://man7.org/linux/man-pages/man8/mount.8.html#COMMAND-LINE_OPTIONS
-[garden]: https://github.com/cloudfoundry-incubator/garden-linux

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -716,8 +716,12 @@ func (vs *VolumeServer) doCreate(ctx context.Context, w http.ResponseWriter, req
 		ctx,
 		handle,
 		strategy,
-		volume.Properties(request.Properties),
-		request.Privileged,
+		volume.VolumeOpts{
+			Privileged: request.Privileged,
+			Properties: volume.Properties(request.Properties),
+			Uid:        request.Uid,
+			Gid:        request.Gid,
+		},
 	)
 
 	if err != nil {

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -524,10 +524,9 @@ func (vs *VolumeServer) StreamIn(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		var errExceedStreamLimit volume.ErrExceedStreamLimit
-		if errors.As(err, &errExceedStreamLimit) {
-			hLog.Error("exceeded-stream-limit", err)
-			RespondWithError(w, err, http.StatusForbidden)
+		if streamLimitErr, ok := errors.AsType[volume.ErrExceedStreamLimit](err); ok {
+			hLog.Error("exceeded-stream-limit", streamLimitErr)
+			RespondWithError(w, streamLimitErr, http.StatusForbidden)
 			return
 		}
 

--- a/worker/baggageclaim/api/volume_server_test.go
+++ b/worker/baggageclaim/api/volume_server_test.go
@@ -171,6 +171,32 @@ var _ = Describe("Volume Server", func() {
 		})
 	})
 
+	Describe("creating a volume with uid and gid", func() {
+		It("accepts uid and gid in the request body", func() {
+			body := &bytes.Buffer{}
+			err := json.NewEncoder(body).Encode(baggageclaim.VolumeRequest{
+				Handle: "some-handle",
+				Strategy: encStrategy(map[string]string{
+					"type": "empty",
+				}),
+				Uid: new(1234),
+				Gid: new(5678),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			recorder := httptest.NewRecorder()
+			request, _ := http.NewRequest("POST", "/volumes", body)
+			handler.ServeHTTP(recorder, request)
+			Expect(recorder.Code).To(Equal(201))
+
+			var created volume.Volume
+			Expect(json.NewDecoder(recorder.Body).Decode(&created)).To(Succeed())
+			Expect(created.Handle).To(Equal("some-handle"))
+			Expect(*created.Uid).To(Equal(1234))
+			Expect(*created.Gid).To(Equal(5678))
+		})
+	})
+
 	Describe("streaming tar files into volumes", func() {
 		var (
 			myVolume     volume.Volume

--- a/worker/baggageclaim/client.go
+++ b/worker/baggageclaim/client.go
@@ -157,6 +157,12 @@ type VolumeSpec struct {
 	// translation of the files in the volume so that they can be read by a
 	// non-privileged user.
 	Privileged bool
+
+	// The Uid and Gid that the volume should be owned by inside the container's
+	// user namespace. A value of '-1' means to leave ownership as-is. Both
+	// fields must be set to a value >= 0 if you want ownership to be changed.
+	Uid *int
+	Gid *int
 }
 
 type Strategy interface {

--- a/worker/baggageclaim/client/client.go
+++ b/worker/baggageclaim/client/client.go
@@ -26,9 +26,7 @@ import (
 
 var ErrVolumeDeletion = errors.New("failed-to-delete-volume")
 
-type Client interface {
-	baggageclaim.Client
-}
+var _ baggageclaim.Client = (*client)(nil)
 
 type client struct {
 	requestGenerator *rata.RequestGenerator
@@ -39,7 +37,7 @@ type client struct {
 	givenHttpClient *http.Client
 }
 
-func New(apiURL string, nestedRoundTripper http.RoundTripper) Client {
+func New(apiURL string, nestedRoundTripper http.RoundTripper) baggageclaim.Client {
 	return &client{
 		requestGenerator: rata.NewRequestGenerator(apiURL, baggageclaim.Routes),
 
@@ -49,7 +47,7 @@ func New(apiURL string, nestedRoundTripper http.RoundTripper) Client {
 	}
 }
 
-func NewWithHTTPClient(apiURL string, httpClient *http.Client) Client {
+func NewWithHTTPClient(apiURL string, httpClient *http.Client) baggageclaim.Client {
 	return &client{
 		givenHttpClient:  httpClient,
 		requestGenerator: rata.NewRequestGenerator(apiURL, baggageclaim.Routes),

--- a/worker/baggageclaim/client/client.go
+++ b/worker/baggageclaim/client/client.go
@@ -86,6 +86,8 @@ func (c *client) CreateVolume(ctx context.Context, handle string, volumeSpec bag
 		Strategy:   strategy.Encode(),
 		Properties: volumeSpec.Properties,
 		Privileged: volumeSpec.Privileged,
+		Uid:        volumeSpec.Uid,
+		Gid:        volumeSpec.Gid,
 	})
 
 	request, err := c.generateRequest(ctx, baggageclaim.CreateVolumeAsync, nil, buffer)

--- a/worker/baggageclaim/client/client_resiliency_test.go
+++ b/worker/baggageclaim/client/client_resiliency_test.go
@@ -46,10 +46,12 @@ var _ = Describe("baggageclaim http client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-volume"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle:     "some-volume",
-							Path:       "/some/path",
-							Properties: map[string]string{},
-							Privileged: false,
+							Handle: "some-volume",
+							Path:   "/some/path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: map[string]string{},
+								Privileged: false,
+							},
 						}),
 					),
 					ghttp.CombineHandlers(

--- a/worker/baggageclaim/client_test.go
+++ b/worker/baggageclaim/client_test.go
@@ -186,6 +186,51 @@ var _ = Describe("Baggage Claim Client", func() {
 					Expect(err.Error()).To(Equal("lost baggage"))
 				})
 			})
+
+			Context("when the volume spec sets uid and gid", func() {
+				It("encodes uid and gid into the create request body", func() {
+					reqChan := make(chan baggageclaim.VolumeRequest, 1)
+
+					bcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", "/volumes-async"),
+							func(w http.ResponseWriter, r *http.Request) {
+								var req baggageclaim.VolumeRequest
+								Expect(json.NewDecoder(r.Body).Decode(&req)).To(Succeed())
+								reqChan <- req
+							},
+							ghttp.RespondWithJSONEncoded(http.StatusCreated, baggageclaim.VolumeFutureResponse{
+								Handle: "some-handle",
+							}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
+								Handle: "some-handle",
+								Path:   "some-path",
+								VolumeOpts: volume.VolumeOpts{
+									Properties: volume.Properties{},
+								},
+							}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", "/volumes-async/some-handle"),
+							ghttp.RespondWith(http.StatusNoContent, ""),
+						),
+					)
+
+					_, err := bcClient.CreateVolume(context.Background(), "some-handle", baggageclaim.VolumeSpec{
+						Uid: new(1234),
+						Gid: new(5678),
+					})
+					Expect(err).ToNot(HaveOccurred())
+
+					var captured baggageclaim.VolumeRequest
+					Expect(reqChan).To(Receive(&captured))
+					Expect(*captured.Uid).To(Equal(1234))
+					Expect(*captured.Gid).To(Equal(5678))
+				})
+			})
 		})
 
 		Describe("Stream in a volume", func() {

--- a/worker/baggageclaim/client_test.go
+++ b/worker/baggageclaim/client_test.go
@@ -201,9 +201,11 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle:     "some-handle",
-							Path:       "some-path",
-							Properties: volume.Properties{},
+							Handle: "some-handle",
+							Path:   "some-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{},
+							},
 						}),
 					),
 					ghttp.CombineHandlers(
@@ -261,9 +263,11 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle:     "some-handle",
-							Path:       "some-path",
-							Properties: volume.Properties{},
+							Handle: "some-handle",
+							Path:   "some-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{},
+							},
 						}),
 					),
 					ghttp.CombineHandlers(
@@ -331,9 +335,11 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle:     "some-handle",
-							Path:       "some-path",
-							Properties: volume.Properties{},
+							Handle: "some-handle",
+							Path:   "some-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{},
+							},
 						}),
 					),
 					ghttp.CombineHandlers(
@@ -376,9 +382,11 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle:     "some-handle",
-							Path:       "some-path",
-							Properties: volume.Properties{},
+							Handle: "some-handle",
+							Path:   "some-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{},
+							},
 						}),
 					),
 					ghttp.CombineHandlers(
@@ -433,9 +441,11 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle:     "some-handle",
-							Path:       "some-path",
-							Properties: volume.Properties{},
+							Handle: "some-handle",
+							Path:   "some-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{},
+							},
 						}),
 					),
 					ghttp.CombineHandlers(

--- a/worker/baggageclaim/resources.go
+++ b/worker/baggageclaim/resources.go
@@ -9,6 +9,26 @@ type VolumeRequest struct {
 	Strategy   *json.RawMessage `json:"strategy"`
 	Properties VolumeProperties `json:"properties"`
 	Privileged bool             `json:"privileged,omitempty"`
+
+	// The Uid and Gid that the volume should be owned by inside the container's
+	// user namespace. A value of '-1' means to leave ownership as-is. Both
+	// fields must be set to a value >= 0 if you want ownership to be changed.
+	Uid *int `json:"uid,omitempty"`
+	Gid *int `json:"gid,omitempty"`
+}
+
+func (v *VolumeRequest) GetUid() int {
+	if v.Uid == nil {
+		return -1
+	}
+	return *v.Uid
+}
+
+func (v *VolumeRequest) GetGid() int {
+	if v.Gid == nil {
+		return -1
+	}
+	return *v.Gid
 }
 
 type VolumeResponse struct {

--- a/worker/baggageclaim/uidgid/mapper_linux.go
+++ b/worker/baggageclaim/uidgid/mapper_linux.go
@@ -5,6 +5,8 @@ import (
 	"syscall"
 )
 
+var _ Mapper = (*uidGidMapper)(nil)
+
 type uidGidMapper struct {
 	uids []syscall.SysProcIDMap
 	gids []syscall.SysProcIDMap

--- a/worker/baggageclaim/uidgid/mapper_nonlinux.go
+++ b/worker/baggageclaim/uidgid/mapper_nonlinux.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 )
 
+var _ Mapper = (*noopMapper)(nil)
+
 type noopMapper struct{}
 
 func NewPrivilegedMapper() Mapper {

--- a/worker/baggageclaim/uidgid/namespace.go
+++ b/worker/baggageclaim/uidgid/namespace.go
@@ -12,6 +12,7 @@ import (
 //counterfeiter:generate . Namespacer
 type Namespacer interface {
 	NamespacePath(logger lager.Logger, path string) error
+	NamespacePathToUser(logger lager.Logger, path string, uid, gid int) error
 	NamespaceCommand(cmd *exec.Cmd)
 }
 
@@ -37,6 +38,23 @@ func (n *UidNamespacer) NamespacePath(logger lager.Logger, rootfsPath string) er
 	return nil
 }
 
+func (n *UidNamespacer) NamespacePathToUser(logger lager.Logger, rootfsPath string, uid, gid int) error {
+	log := logger.Session("namespace", lager.Data{
+		"path": rootfsPath,
+		"uid":  uid,
+		"gid":  gid,
+	})
+
+	log.Debug("start")
+	defer log.Debug("done")
+
+	if err := filepath.WalkDir(rootfsPath, n.Translator.TranslatePathToUser(uid, gid)); err != nil {
+		log.Error("failed-to-walk-and-translate", err)
+	}
+
+	return nil
+}
+
 func (n *UidNamespacer) NamespaceCommand(cmd *exec.Cmd) {
 	n.Translator.TranslateCommand(cmd)
 }
@@ -45,5 +63,6 @@ var _ Namespacer = (*NoopNamespacer)(nil)
 
 type NoopNamespacer struct{}
 
-func (NoopNamespacer) NamespacePath(lager.Logger, string) error { return nil }
-func (NoopNamespacer) NamespaceCommand(cmd *exec.Cmd)           {}
+func (NoopNamespacer) NamespacePath(lager.Logger, string) error                 { return nil }
+func (NoopNamespacer) NamespacePathToUser(lager.Logger, string, int, int) error { return nil }
+func (NoopNamespacer) NamespaceCommand(cmd *exec.Cmd)                           {}

--- a/worker/baggageclaim/uidgid/namespace.go
+++ b/worker/baggageclaim/uidgid/namespace.go
@@ -15,6 +15,8 @@ type Namespacer interface {
 	NamespaceCommand(cmd *exec.Cmd)
 }
 
+var _ Namespacer = (*UidNamespacer)(nil)
+
 type UidNamespacer struct {
 	Translator Translator
 	Logger     lager.Logger
@@ -38,6 +40,8 @@ func (n *UidNamespacer) NamespacePath(logger lager.Logger, rootfsPath string) er
 func (n *UidNamespacer) NamespaceCommand(cmd *exec.Cmd) {
 	n.Translator.TranslateCommand(cmd)
 }
+
+var _ Namespacer = (*NoopNamespacer)(nil)
 
 type NoopNamespacer struct{}
 

--- a/worker/baggageclaim/uidgid/translator.go
+++ b/worker/baggageclaim/uidgid/translator.go
@@ -12,6 +12,8 @@ type Translator interface {
 	TranslateCommand(*exec.Cmd)
 }
 
+var _ Translator = (*translator)(nil)
+
 type translator struct {
 	mapper Mapper
 	chown  func(path string, uid int, gid int) error

--- a/worker/baggageclaim/uidgid/translator.go
+++ b/worker/baggageclaim/uidgid/translator.go
@@ -8,7 +8,12 @@ import (
 //counterfeiter:generate . Translator
 
 type Translator interface {
+	// Translate current path's UID/GID to work inside the container's user
+	// namespace
 	TranslatePath(path string, dir os.DirEntry, err error) error
+	// Translate current path's UID/GID to a specific UID/GID inside the
+	// container's user namespace
+	TranslatePathToUser(int, int) func(path string, dir os.DirEntry, err error) error
 	TranslateCommand(*exec.Cmd)
 }
 
@@ -21,6 +26,7 @@ type translator struct {
 }
 
 type Mapper interface {
+	// Maps a UID:GID from a container's user namespace back to the host user namespace
 	Map(int, int) (int, int)
 	Apply(*exec.Cmd)
 }
@@ -43,8 +49,10 @@ func (t *translator) TranslatePath(path string, dir os.DirEntry, err error) erro
 		return err
 	}
 
+	// We look at who the owner of the file/dir is in the host's user
+	// namespace and then figure out what UID/GID that maps to in the
+	// container's user namespace
 	uid, gid := t.getuidgid(info)
-
 	touid, togid := t.mapper.Map(uid, gid)
 
 	if touid != uid || togid != gid {
@@ -56,6 +64,32 @@ func (t *translator) TranslatePath(path string, dir os.DirEntry, err error) erro
 	}
 
 	return nil
+}
+
+func (t *translator) TranslatePathToUser(uid, gid int) func(path string, dir os.DirEntry, err error) error {
+	touid, togid := t.mapper.Map(uid, gid)
+	return func(path string, dir os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		info, err := dir.Info()
+		if err != nil {
+			return err
+		}
+
+		currentUid, currentGid := t.getuidgid(info)
+
+		if touid != currentUid || togid != currentGid {
+			mode := info.Mode()
+			t.chown(path, touid, togid)
+			if mode&os.ModeSymlink == 0 {
+				t.chmod(path, mode)
+			}
+		}
+
+		return nil
+	}
 }
 
 func (t *translator) TranslateCommand(cmd *exec.Cmd) {

--- a/worker/baggageclaim/uidgid/uidgidfakes/fake_namespacer.go
+++ b/worker/baggageclaim/uidgid/uidgidfakes/fake_namespacer.go
@@ -27,6 +27,20 @@ type FakeNamespacer struct {
 	namespacePathReturnsOnCall map[int]struct {
 		result1 error
 	}
+	NamespacePathToUserStub        func(lager.Logger, string, int, int) error
+	namespacePathToUserMutex       sync.RWMutex
+	namespacePathToUserArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 int
+		arg4 int
+	}
+	namespacePathToUserReturns struct {
+		result1 error
+	}
+	namespacePathToUserReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -121,6 +135,70 @@ func (fake *FakeNamespacer) NamespacePathReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.namespacePathReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeNamespacer) NamespacePathToUser(arg1 lager.Logger, arg2 string, arg3 int, arg4 int) error {
+	fake.namespacePathToUserMutex.Lock()
+	ret, specificReturn := fake.namespacePathToUserReturnsOnCall[len(fake.namespacePathToUserArgsForCall)]
+	fake.namespacePathToUserArgsForCall = append(fake.namespacePathToUserArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 int
+		arg4 int
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.NamespacePathToUserStub
+	fakeReturns := fake.namespacePathToUserReturns
+	fake.recordInvocation("NamespacePathToUser", []interface{}{arg1, arg2, arg3, arg4})
+	fake.namespacePathToUserMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeNamespacer) NamespacePathToUserCallCount() int {
+	fake.namespacePathToUserMutex.RLock()
+	defer fake.namespacePathToUserMutex.RUnlock()
+	return len(fake.namespacePathToUserArgsForCall)
+}
+
+func (fake *FakeNamespacer) NamespacePathToUserCalls(stub func(lager.Logger, string, int, int) error) {
+	fake.namespacePathToUserMutex.Lock()
+	defer fake.namespacePathToUserMutex.Unlock()
+	fake.NamespacePathToUserStub = stub
+}
+
+func (fake *FakeNamespacer) NamespacePathToUserArgsForCall(i int) (lager.Logger, string, int, int) {
+	fake.namespacePathToUserMutex.RLock()
+	defer fake.namespacePathToUserMutex.RUnlock()
+	argsForCall := fake.namespacePathToUserArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeNamespacer) NamespacePathToUserReturns(result1 error) {
+	fake.namespacePathToUserMutex.Lock()
+	defer fake.namespacePathToUserMutex.Unlock()
+	fake.NamespacePathToUserStub = nil
+	fake.namespacePathToUserReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeNamespacer) NamespacePathToUserReturnsOnCall(i int, result1 error) {
+	fake.namespacePathToUserMutex.Lock()
+	defer fake.namespacePathToUserMutex.Unlock()
+	fake.NamespacePathToUserStub = nil
+	if fake.namespacePathToUserReturnsOnCall == nil {
+		fake.namespacePathToUserReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.namespacePathToUserReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/worker/baggageclaim/uidgid/uidgidfakes/fake_translator.go
+++ b/worker/baggageclaim/uidgid/uidgidfakes/fake_translator.go
@@ -28,6 +28,18 @@ type FakeTranslator struct {
 	translatePathReturnsOnCall map[int]struct {
 		result1 error
 	}
+	TranslatePathToUserStub        func(int, int) func(path string, dir os.DirEntry, err error) error
+	translatePathToUserMutex       sync.RWMutex
+	translatePathToUserArgsForCall []struct {
+		arg1 int
+		arg2 int
+	}
+	translatePathToUserReturns struct {
+		result1 func(path string, dir os.DirEntry, err error) error
+	}
+	translatePathToUserReturnsOnCall map[int]struct {
+		result1 func(path string, dir os.DirEntry, err error) error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -124,6 +136,68 @@ func (fake *FakeTranslator) TranslatePathReturnsOnCall(i int, result1 error) {
 	}
 	fake.translatePathReturnsOnCall[i] = struct {
 		result1 error
+	}{result1}
+}
+
+func (fake *FakeTranslator) TranslatePathToUser(arg1 int, arg2 int) func(path string, dir os.DirEntry, err error) error {
+	fake.translatePathToUserMutex.Lock()
+	ret, specificReturn := fake.translatePathToUserReturnsOnCall[len(fake.translatePathToUserArgsForCall)]
+	fake.translatePathToUserArgsForCall = append(fake.translatePathToUserArgsForCall, struct {
+		arg1 int
+		arg2 int
+	}{arg1, arg2})
+	stub := fake.TranslatePathToUserStub
+	fakeReturns := fake.translatePathToUserReturns
+	fake.recordInvocation("TranslatePathToUser", []interface{}{arg1, arg2})
+	fake.translatePathToUserMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeTranslator) TranslatePathToUserCallCount() int {
+	fake.translatePathToUserMutex.RLock()
+	defer fake.translatePathToUserMutex.RUnlock()
+	return len(fake.translatePathToUserArgsForCall)
+}
+
+func (fake *FakeTranslator) TranslatePathToUserCalls(stub func(int, int) func(path string, dir os.DirEntry, err error) error) {
+	fake.translatePathToUserMutex.Lock()
+	defer fake.translatePathToUserMutex.Unlock()
+	fake.TranslatePathToUserStub = stub
+}
+
+func (fake *FakeTranslator) TranslatePathToUserArgsForCall(i int) (int, int) {
+	fake.translatePathToUserMutex.RLock()
+	defer fake.translatePathToUserMutex.RUnlock()
+	argsForCall := fake.translatePathToUserArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeTranslator) TranslatePathToUserReturns(result1 func(path string, dir os.DirEntry, err error) error) {
+	fake.translatePathToUserMutex.Lock()
+	defer fake.translatePathToUserMutex.Unlock()
+	fake.TranslatePathToUserStub = nil
+	fake.translatePathToUserReturns = struct {
+		result1 func(path string, dir os.DirEntry, err error) error
+	}{result1}
+}
+
+func (fake *FakeTranslator) TranslatePathToUserReturnsOnCall(i int, result1 func(path string, dir os.DirEntry, err error) error) {
+	fake.translatePathToUserMutex.Lock()
+	defer fake.translatePathToUserMutex.Unlock()
+	fake.TranslatePathToUserStub = nil
+	if fake.translatePathToUserReturnsOnCall == nil {
+		fake.translatePathToUserReturnsOnCall = make(map[int]struct {
+			result1 func(path string, dir os.DirEntry, err error) error
+		})
+	}
+	fake.translatePathToUserReturnsOnCall[i] = struct {
+		result1 func(path string, dir os.DirEntry, err error) error
 	}{result1}
 }
 

--- a/worker/baggageclaim/volume/promise_test.go
+++ b/worker/baggageclaim/volume/promise_test.go
@@ -12,9 +12,11 @@ var _ = Describe("Volume Promise", func() {
 		promise    Promise
 		testErr    = errors.New("some-error")
 		testVolume = Volume{
-			Handle:     "some-handle",
-			Path:       "some-path",
-			Properties: make(Properties),
+			Handle: "some-handle",
+			Path:   "some-path",
+			VolumeOpts: VolumeOpts{
+				Properties: make(Properties),
+			},
 		}
 	)
 

--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -49,6 +49,8 @@ type Repository interface {
 	CleanupOrphanedVolumes(ctx context.Context) error
 }
 
+var _ Repository = (*repository)(nil)
+
 type repository struct {
 	filesystem Filesystem
 

--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -221,7 +221,7 @@ func (repo *repository) CreateVolume(ctx context.Context, handle string, strateg
 			return Volume{}, err
 		}
 	} else {
-		err = repo.namespacer(opts.Privileged).NamespacePath(logger, initVolume.DataPath())
+		err = namespacer.NamespacePath(logger, initVolume.DataPath())
 		if err != nil {
 			logger.Error("failed-to-namespace-data", err)
 			return Volume{}, err

--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -28,7 +28,7 @@ var ErrUnsupportedStreamEncoding = errors.New("unsupported stream encoding")
 type Repository interface {
 	ListVolumes(ctx context.Context, queryProperties Properties) (Volumes, error)
 	GetVolume(ctx context.Context, handle string) (Volume, bool, error)
-	CreateVolume(ctx context.Context, handle string, strategy Strategy, properties Properties, isPrivileged bool) (Volume, error)
+	CreateVolume(ctx context.Context, handle string, strategy Strategy, opts VolumeOpts) (Volume, error)
 	DestroyVolume(ctx context.Context, handle string) error
 	DestroyVolumeAndDescendants(ctx context.Context, handle string) error
 
@@ -174,7 +174,7 @@ func (repo *repository) CleanupOrphanedVolumes(ctx context.Context) error {
 	return repo.filesystem.CleanupOrphanedEntries()
 }
 
-func (repo *repository) CreateVolume(ctx context.Context, handle string, strategy Strategy, properties Properties, isPrivileged bool) (Volume, error) {
+func (repo *repository) CreateVolume(ctx context.Context, handle string, strategy Strategy, opts VolumeOpts) (Volume, error) {
 	ctx, span := tracing.StartSpan(ctx, "volumeRepository.CreateVolume", tracing.Attrs{
 		"volume":   handle,
 		"strategy": strategy.String(),
@@ -199,22 +199,33 @@ func (repo *repository) CreateVolume(ctx context.Context, handle string, strateg
 		}
 	}()
 
-	err = initVolume.StoreProperties(properties)
+	err = initVolume.StoreProperties(opts.Properties)
 	if err != nil {
 		logger.Error("failed-to-set-properties", err)
 		return Volume{}, err
 	}
 
-	err = initVolume.StorePrivileged(isPrivileged)
+	err = initVolume.StorePrivileged(opts.Privileged)
 	if err != nil {
 		logger.Error("failed-to-set-privileged", err)
 		return Volume{}, err
 	}
 
-	err = repo.namespacer(isPrivileged).NamespacePath(logger, initVolume.DataPath())
-	if err != nil {
-		logger.Error("failed-to-namespace-data", err)
-		return Volume{}, err
+	namespacer := repo.namespacer(opts.Privileged)
+	uid := opts.GetUid()
+	gid := opts.GetGid()
+	if uid >= 0 && gid >= 0 {
+		err = namespacer.NamespacePathToUser(logger, initVolume.DataPath(), uid, gid)
+		if err != nil {
+			logger.Error("failed-to-namespace-data-to-user", err)
+			return Volume{}, err
+		}
+	} else {
+		err = repo.namespacer(opts.Privileged).NamespacePath(logger, initVolume.DataPath())
+		if err != nil {
+			logger.Error("failed-to-namespace-data", err)
+			return Volume{}, err
+		}
 	}
 
 	liveVolume, err := initVolume.Initialize()
@@ -226,9 +237,11 @@ func (repo *repository) CreateVolume(ctx context.Context, handle string, strateg
 	initialized = true
 
 	return Volume{
-		Handle:     liveVolume.Handle(),
-		Path:       liveVolume.DataPath(),
-		Properties: properties,
+		Handle: liveVolume.Handle(),
+		Path:   liveVolume.DataPath(),
+		VolumeOpts: VolumeOpts{
+			Properties: opts.Properties,
+		},
 	}, nil
 }
 
@@ -670,10 +683,12 @@ func (repo *repository) volumeFrom(liveVolume FilesystemLiveVolume) (Volume, err
 	}
 
 	return Volume{
-		Handle:     liveVolume.Handle(),
-		Path:       liveVolume.DataPath(),
-		Properties: properties,
-		Privileged: isPrivileged,
+		Handle: liveVolume.Handle(),
+		Path:   liveVolume.DataPath(),
+		VolumeOpts: VolumeOpts{
+			Properties: properties,
+			Privileged: isPrivileged,
+		},
 	}, nil
 }
 

--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -237,11 +237,9 @@ func (repo *repository) CreateVolume(ctx context.Context, handle string, strateg
 	initialized = true
 
 	return Volume{
-		Handle: liveVolume.Handle(),
-		Path:   liveVolume.DataPath(),
-		VolumeOpts: VolumeOpts{
-			Properties: opts.Properties,
-		},
+		Handle:     liveVolume.Handle(),
+		Path:       liveVolume.DataPath(),
+		VolumeOpts: opts,
 	}, nil
 }
 

--- a/worker/baggageclaim/volume/repository_test.go
+++ b/worker/baggageclaim/volume/repository_test.go
@@ -58,8 +58,8 @@ var _ = Describe("Repository", func() {
 			opts = volume.VolumeOpts{
 				Properties: volume.Properties{"some": "properties"},
 				Privileged: false,
-				Uid:        -1,
-				Gid:        -1,
+				Uid:        new(-1),
+				Gid:        new(-1),
 			}
 		})
 
@@ -184,6 +184,63 @@ var _ = Describe("Repository", func() {
 
 							It("destroys the initializing volume", func() {
 								Expect(fakeInitVolume.DestroyCallCount()).To(Equal(1))
+							})
+						})
+					})
+
+					Context("when uid and gid are set to specific values", func() {
+						BeforeEach(func() {
+							opts.Uid = new(1234)
+							opts.Gid = new(5678)
+						})
+
+						Context("when the volume is unprivileged", func() {
+							BeforeEach(func() {
+								opts.Privileged = false
+							})
+
+							It("namespaces the data path to the requested user via the unprivileged namespacer", func() {
+								Expect(fakeUnprivilegedNamespacer.NamespacePathCallCount()).To(Equal(0))
+								Expect(fakePrivilegedNamespacer.NamespacePathToUserCallCount()).To(Equal(0))
+								Expect(fakeUnprivilegedNamespacer.NamespacePathToUserCallCount()).To(Equal(1))
+
+								_, path, uid, gid := fakeUnprivilegedNamespacer.NamespacePathToUserArgsForCall(0)
+								Expect(path).To(Equal("init-data-path"))
+								Expect(uid).To(Equal(1234))
+								Expect(gid).To(Equal(5678))
+							})
+
+							Context("when namespacing fails", func() {
+								disaster := errors.New("nope")
+
+								BeforeEach(func() {
+									fakeUnprivilegedNamespacer.NamespacePathToUserReturns(disaster)
+								})
+
+								It("returns the error", func() {
+									Expect(createErr).To(Equal(disaster))
+								})
+
+								It("destroys the initializing volume", func() {
+									Expect(fakeInitVolume.DestroyCallCount()).To(Equal(1))
+								})
+							})
+						})
+
+						Context("when the volume is privileged", func() {
+							BeforeEach(func() {
+								opts.Privileged = true
+							})
+
+							It("namespaces the data path to the requested user via the privileged namespacer", func() {
+								Expect(fakePrivilegedNamespacer.NamespacePathCallCount()).To(Equal(0))
+								Expect(fakeUnprivilegedNamespacer.NamespacePathToUserCallCount()).To(Equal(0))
+								Expect(fakePrivilegedNamespacer.NamespacePathToUserCallCount()).To(Equal(1))
+
+								_, path, uid, gid := fakePrivilegedNamespacer.NamespacePathToUserArgsForCall(0)
+								Expect(path).To(Equal("init-data-path"))
+								Expect(uid).To(Equal(1234))
+								Expect(gid).To(Equal(5678))
 							})
 						})
 					})

--- a/worker/baggageclaim/volume/repository_test.go
+++ b/worker/baggageclaim/volume/repository_test.go
@@ -47,8 +47,7 @@ var _ = Describe("Repository", func() {
 	Describe("CreateVolume", func() {
 		var (
 			fakeStrategy *volumefakes.FakeStrategy
-			properties   volume.Properties
-			privileged   bool
+			opts         volume.VolumeOpts
 
 			createdVolume volume.Volume
 			createErr     error
@@ -56,8 +55,12 @@ var _ = Describe("Repository", func() {
 
 		BeforeEach(func() {
 			fakeStrategy = new(volumefakes.FakeStrategy)
-			properties = volume.Properties{"some": "properties"}
-			privileged = false
+			opts = volume.VolumeOpts{
+				Properties: volume.Properties{"some": "properties"},
+				Privileged: false,
+				Uid:        -1,
+				Gid:        -1,
+			}
 		})
 
 		JustBeforeEach(func() {
@@ -65,8 +68,7 @@ var _ = Describe("Repository", func() {
 				context.Background(),
 				"some-handle",
 				fakeStrategy,
-				properties,
-				privileged,
+				opts,
 			)
 		})
 
@@ -104,7 +106,7 @@ var _ = Describe("Repository", func() {
 						Expect(createdVolume).To(Equal(volume.Volume{
 							Handle:     "live-handle",
 							Path:       "live-data-path",
-							Properties: properties,
+							VolumeOpts: opts,
 						}))
 					})
 
@@ -120,7 +122,7 @@ var _ = Describe("Repository", func() {
 
 					Context("when the volume is privileged", func() {
 						BeforeEach(func() {
-							privileged = true
+							opts.Privileged = true
 						})
 
 						It("stores volume privileged with the right value", func() {
@@ -154,7 +156,7 @@ var _ = Describe("Repository", func() {
 
 					Context("when the volume is not privileged", func() {
 						BeforeEach(func() {
-							privileged = false
+							opts.Privileged = false
 						})
 
 						It("stores volume privileged with the right value", func() {
@@ -484,28 +486,36 @@ var _ = Describe("Repository", func() {
 				It("returns all volumes", func() {
 					Expect(volumes).To(Equal(volume.Volumes{
 						{
-							Handle:     "handle-1",
-							Path:       "handle-1-data-path",
-							Properties: volume.Properties{"a": "a", "b": "b"},
-							Privileged: true,
+							Handle: "handle-1",
+							Path:   "handle-1-data-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{"a": "a", "b": "b"},
+								Privileged: true,
+							},
 						},
 						{
-							Handle:     "handle-2",
-							Path:       "handle-2-data-path",
-							Properties: volume.Properties{"a": "a"},
-							Privileged: false,
+							Handle: "handle-2",
+							Path:   "handle-2-data-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{"a": "a"},
+								Privileged: false,
+							},
 						},
 						{
-							Handle:     "handle-3",
-							Path:       "handle-3-data-path",
-							Properties: volume.Properties{"b": "b"},
-							Privileged: true,
+							Handle: "handle-3",
+							Path:   "handle-3-data-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{"b": "b"},
+								Privileged: true,
+							},
 						},
 						{
-							Handle:     "handle-4",
-							Path:       "handle-4-data-path",
-							Properties: volume.Properties{},
-							Privileged: false,
+							Handle: "handle-4",
+							Path:   "handle-4-data-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{},
+								Privileged: false,
+							},
 						},
 					}))
 				})
@@ -519,22 +529,28 @@ var _ = Describe("Repository", func() {
 						It("is not included in the response", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
-									Handle:     "handle-1",
-									Path:       "handle-1-data-path",
-									Properties: volume.Properties{"a": "a", "b": "b"},
-									Privileged: true,
+									Handle: "handle-1",
+									Path:   "handle-1-data-path",
+									VolumeOpts: volume.VolumeOpts{
+										Properties: volume.Properties{"a": "a", "b": "b"},
+										Privileged: true,
+									},
 								},
 								{
-									Handle:     "handle-3",
-									Path:       "handle-3-data-path",
-									Properties: volume.Properties{"b": "b"},
-									Privileged: true,
+									Handle: "handle-3",
+									Path:   "handle-3-data-path",
+									VolumeOpts: volume.VolumeOpts{
+										Properties: volume.Properties{"b": "b"},
+										Privileged: true,
+									},
 								},
 								{
-									Handle:     "handle-4",
-									Path:       "handle-4-data-path",
-									Properties: volume.Properties{},
-									Privileged: false,
+									Handle: "handle-4",
+									Path:   "handle-4-data-path",
+									VolumeOpts: volume.VolumeOpts{
+										Properties: volume.Properties{},
+										Privileged: false,
+									},
 								},
 							}))
 						})
@@ -548,22 +564,28 @@ var _ = Describe("Repository", func() {
 						It("returns only working volumes", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
-									Handle:     "handle-1",
-									Path:       "handle-1-data-path",
-									Properties: volume.Properties{"a": "a", "b": "b"},
-									Privileged: true,
+									Handle: "handle-1",
+									Path:   "handle-1-data-path",
+									VolumeOpts: volume.VolumeOpts{
+										Properties: volume.Properties{"a": "a", "b": "b"},
+										Privileged: true,
+									},
 								},
 								{
-									Handle:     "handle-3",
-									Path:       "handle-3-data-path",
-									Properties: volume.Properties{"b": "b"},
-									Privileged: true,
+									Handle: "handle-3",
+									Path:   "handle-3-data-path",
+									VolumeOpts: volume.VolumeOpts{
+										Properties: volume.Properties{"b": "b"},
+										Privileged: true,
+									},
 								},
 								{
-									Handle:     "handle-4",
-									Path:       "handle-4-data-path",
-									Properties: volume.Properties{},
-									Privileged: false,
+									Handle: "handle-4",
+									Path:   "handle-4-data-path",
+									VolumeOpts: volume.VolumeOpts{
+										Properties: volume.Properties{},
+										Privileged: false,
+									},
 								},
 							}))
 						})
@@ -579,16 +601,20 @@ var _ = Describe("Repository", func() {
 				It("returns only volumes whose properties match", func() {
 					Expect(volumes).To(Equal(volume.Volumes{
 						{
-							Handle:     "handle-1",
-							Path:       "handle-1-data-path",
-							Properties: volume.Properties{"a": "a", "b": "b"},
-							Privileged: true,
+							Handle: "handle-1",
+							Path:   "handle-1-data-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{"a": "a", "b": "b"},
+								Privileged: true,
+							},
 						},
 						{
-							Handle:     "handle-2",
-							Path:       "handle-2-data-path",
-							Properties: volume.Properties{"a": "a"},
-							Privileged: false,
+							Handle: "handle-2",
+							Path:   "handle-2-data-path",
+							VolumeOpts: volume.VolumeOpts{
+								Properties: volume.Properties{"a": "a"},
+								Privileged: false,
+							},
 						},
 					}))
 				})
@@ -602,10 +628,12 @@ var _ = Describe("Repository", func() {
 						It("is not included in the response", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
-									Handle:     "handle-1",
-									Path:       "handle-1-data-path",
-									Properties: volume.Properties{"a": "a", "b": "b"},
-									Privileged: true,
+									Handle: "handle-1",
+									Path:   "handle-1-data-path",
+									VolumeOpts: volume.VolumeOpts{
+										Properties: volume.Properties{"a": "a", "b": "b"},
+										Privileged: true,
+									},
 								},
 							}))
 						})
@@ -619,10 +647,12 @@ var _ = Describe("Repository", func() {
 						It("returns only working volumes", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
-									Handle:     "handle-1",
-									Path:       "handle-1-data-path",
-									Properties: volume.Properties{"a": "a", "b": "b"},
-									Privileged: true,
+									Handle: "handle-1",
+									Path:   "handle-1-data-path",
+									VolumeOpts: volume.VolumeOpts{
+										Properties: volume.Properties{"a": "a", "b": "b"},
+										Privileged: true,
+									},
 								},
 							}))
 						})
@@ -680,10 +710,12 @@ var _ = Describe("Repository", func() {
 			It("returns the volume and true", func() {
 				Expect(found).To(BeTrue())
 				Expect(foundVolume).To(Equal(volume.Volume{
-					Handle:     "some-volume",
-					Path:       "some-data-path",
-					Properties: volume.Properties{"a": "a", "b": "b"},
-					Privileged: true,
+					Handle: "some-volume",
+					Path:   "some-data-path",
+					VolumeOpts: volume.VolumeOpts{
+						Properties: volume.Properties{"a": "a", "b": "b"},
+						Privileged: true,
+					},
 				}))
 			})
 
@@ -1019,10 +1051,12 @@ var _ = Describe("Repository", func() {
 				It("returns the parent volume and true", func() {
 					Expect(found).To(BeTrue())
 					Expect(parent).To(Equal(volume.Volume{
-						Handle:     "parent-volume",
-						Path:       "parent-data-path",
-						Properties: volume.Properties{"parent": "property"},
-						Privileged: true,
+						Handle: "parent-volume",
+						Path:   "parent-data-path",
+						VolumeOpts: volume.VolumeOpts{
+							Properties: volume.Properties{"parent": "property"},
+							Privileged: true,
+						},
 					}))
 				})
 

--- a/worker/baggageclaim/volume/strategizer.go
+++ b/worker/baggageclaim/volume/strategizer.go
@@ -15,6 +15,8 @@ type Strategizer interface {
 var ErrNoStrategy = errors.New("no strategy given")
 var ErrUnknownStrategy = errors.New("unknown strategy")
 
+var _ Strategizer = (*strategizer)(nil)
+
 type strategizer struct{}
 
 func NewStrategizer() Strategizer {

--- a/worker/baggageclaim/volume/volume.go
+++ b/worker/baggageclaim/volume/volume.go
@@ -1,10 +1,30 @@
 package volume
 
 type Volume struct {
-	Handle     string     `json:"handle"`
-	Path       string     `json:"path"`
-	Properties Properties `json:"properties"`
-	Privileged bool       `json:"privileged"`
+	Handle string `json:"handle"`
+	Path   string `json:"path"`
+	VolumeOpts
 }
 
 type Volumes []Volume
+
+type VolumeOpts struct {
+	Properties Properties `json:"properties"`
+	Privileged bool       `json:"privileged"`
+	Uid        *int       `json:"uid,omitempty"`
+	Gid        *int       `json:"gid,omitempty"`
+}
+
+func (v *VolumeOpts) GetUid() int {
+	if v.Uid == nil {
+		return -1
+	}
+	return *v.Uid
+}
+
+func (v *VolumeOpts) GetGid() int {
+	if v.Gid == nil {
+		return -1
+	}
+	return *v.Gid
+}

--- a/worker/baggageclaim/volume/volumefakes/fake_repository.go
+++ b/worker/baggageclaim/volume/volumefakes/fake_repository.go
@@ -22,14 +22,13 @@ type FakeRepository struct {
 	cleanupOrphanedVolumesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CreateVolumeStub        func(context.Context, string, volume.Strategy, volume.Properties, bool) (volume.Volume, error)
+	CreateVolumeStub        func(context.Context, string, volume.Strategy, volume.VolumeOpts) (volume.Volume, error)
 	createVolumeMutex       sync.RWMutex
 	createVolumeArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 volume.Strategy
-		arg4 volume.Properties
-		arg5 bool
+		arg4 volume.VolumeOpts
 	}
 	createVolumeReturns struct {
 		result1 volume.Volume
@@ -263,22 +262,21 @@ func (fake *FakeRepository) CleanupOrphanedVolumesReturnsOnCall(i int, result1 e
 	}{result1}
 }
 
-func (fake *FakeRepository) CreateVolume(arg1 context.Context, arg2 string, arg3 volume.Strategy, arg4 volume.Properties, arg5 bool) (volume.Volume, error) {
+func (fake *FakeRepository) CreateVolume(arg1 context.Context, arg2 string, arg3 volume.Strategy, arg4 volume.VolumeOpts) (volume.Volume, error) {
 	fake.createVolumeMutex.Lock()
 	ret, specificReturn := fake.createVolumeReturnsOnCall[len(fake.createVolumeArgsForCall)]
 	fake.createVolumeArgsForCall = append(fake.createVolumeArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
 		arg3 volume.Strategy
-		arg4 volume.Properties
-		arg5 bool
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg4 volume.VolumeOpts
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.CreateVolumeStub
 	fakeReturns := fake.createVolumeReturns
-	fake.recordInvocation("CreateVolume", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("CreateVolume", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createVolumeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -292,17 +290,17 @@ func (fake *FakeRepository) CreateVolumeCallCount() int {
 	return len(fake.createVolumeArgsForCall)
 }
 
-func (fake *FakeRepository) CreateVolumeCalls(stub func(context.Context, string, volume.Strategy, volume.Properties, bool) (volume.Volume, error)) {
+func (fake *FakeRepository) CreateVolumeCalls(stub func(context.Context, string, volume.Strategy, volume.VolumeOpts) (volume.Volume, error)) {
 	fake.createVolumeMutex.Lock()
 	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = stub
 }
 
-func (fake *FakeRepository) CreateVolumeArgsForCall(i int) (context.Context, string, volume.Strategy, volume.Properties, bool) {
+func (fake *FakeRepository) CreateVolumeArgsForCall(i int) (context.Context, string, volume.Strategy, volume.VolumeOpts) {
 	fake.createVolumeMutex.RLock()
 	defer fake.createVolumeMutex.RUnlock()
 	argsForCall := fake.createVolumeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeRepository) CreateVolumeReturns(result1 volume.Volume, result2 error) {

--- a/worker/runtime/user_namespace.go
+++ b/worker/runtime/user_namespace.go
@@ -14,6 +14,8 @@ const (
 	gidMap = "/proc/self/gid_map"
 )
 
+var _ UserNamespace = (*userNamespace)(nil)
+
 type userNamespace struct{}
 
 func NewUserNamespace() UserNamespace {


### PR DESCRIPTION
## Changes proposed by this PR

closes #403

When a container runs as a non-root user, any input/output/cache volumes will be `chown`'d to the non-root user. This means every file and directory inside the volume will be owned by the non-root user, as well as the mount point the volume is mounted at inside the container. This will allow tasks running with non-root users to easily interact with volumes made from other steps that would previously remain owned by `root`. See the issue for workarounds users made. These workarounds should no longer be necessary after this change.

I'm labelling this as a **breaking change** since this is something Concourse will do automatically that may break existing workflows IF you're running tasks as a nonroot user. We can add an opt-out toggle in the future if deemed necessary. Based on #403 though, it _seems_ like most users would appreciate the change proposed in this PR.

For anyone that runs stuff as `root` all the time, things should continue to work as-is.

This does introduce a potential footgun for any tasks that output a volume.
```yaml
# this is a task config, I'm omitting most fields
platform: linux

outputs:
- name: some-output

run:
  user: nonroot
```

If the step(s) that follow this task run as `root`, they'll receive `some-output` unchanged. It won't be owned by root, it'll still be owned as `nonroot`. If the user doesn't exist in their container then they'll see the raw UID/GID of the `nonroot` user.

I made this pipeline to test some basic scenarios. All jobs pass when using this PR:

<details>
<summary>Click to expand and  view pipeline</summary>

```yaml
resources:
  - name: image
    type: mock
    source:
      mirror_self: true
    version:
      version: mock

  - name: version
    type: mock
    source:
      no_initial_version: true

jobs:
  - name: root
    plan:
      - get: image
      - task: root
        image: image
        config:
          platform: linux
          inputs:
            - name: image
          outputs:
            - name: empty
          run:
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah /
                echo "hello world" > ./empty/file
                echo "hello image" > ./image/image

  - name: root-privileged
    plan:
      - get: image
      - task: root
        privileged: true
        image: image
        config:
          platform: linux
          inputs:
            - name: image
          outputs:
            - name: empty
          run:
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah /
                echo "hello world" > ./empty/file
                echo "hello image" > ./image/image

  - name: nonroot
    plan:
      - get: image
      - task: nonroot
        image: image
        config:
          platform: linux
          inputs:
            - name: image
          outputs:
            - name: empty
          run:
            user: nonroot
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah /
                echo "hello world" > ./empty/file
                echo "hello image" > ./image/image

  - name: nonroot-privileged
    plan:
      - get: image
      - task: nonroot
        privileged: true
        image: image
        config:
          platform: linux
          inputs:
            - name: image
          outputs:
            - name: empty
          run:
            user: nonroot
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah /
                echo "hello world" > ./empty/file
                echo "hello image" > ./image/image

  - name: different-users
    plan:
      - get: image
      - task: nonroot
        image: image
        config:
          platform: linux
          outputs:
            - name: empty
          run:
            user: nonroot
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                echo "hello from nonroot" > ./empty/file

      - task: adm
        image: image
        config:
          platform: linux
          inputs:
            - name: empty
          outputs:
            - name: empty
          run:
            user: adm
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah ./empty
                cat ./empty/file
                echo "hello from adm" > ./empty/file

      - task: daemon
        image: image
        config:
          platform: linux
          inputs:
            - name: empty
          run:
            user: daemon
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah ./empty
                cat ./empty/file
                echo "hello from daemon" > ./empty/file

      - task: news
        image: image
        config:
          platform: linux
          inputs:
            - name: empty
          outputs:
            - name: empty
          run:
            user: news
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah ./empty
                cat ./empty/file
                echo "hello from news" > ./empty/file

  - name: put
    plan:
      - get: image
      - task: nonroot
        image: image
        config:
          platform: linux
          outputs:
            - name: empty
          run:
            user: nonroot
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah /
                echo "hello from nonroot" > ./empty/file
      - put: version
        params:
          file: empty/file

  - name: nonroot-to-root
    plan:
      - get: image
      - task: nonroot
        image: image
        config:
          platform: linux
          outputs:
            - name: empty
          run:
            user: nonroot
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                echo "hello from nonroot" > ./empty/file

      - task: root
        image: image
        config:
          platform: linux
          inputs:
            - name: empty
          run:
            user: root
            path: bash
            args:
              - -c
              - |
                set -x
                whoami
                ls -lah .
                ls -lah ./empty
                cat ./empty/file
                echo "hello from root" > ./empty/file
```

<details>