### PR TITLE
fix how resources with `check_every: never` are handled when scheduling builds

### DIFF
--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -41,15 +41,18 @@ type CheckFactory interface {
 
 	// Will try creating a Check build if one does not already exist.
 	//
+	// If manuallyTriggered is true, then a check build will always be
+	// made.
+	//
 	// If toDb is true, a build will be made in the database. When running
 	// multiple web nodes, this method ensures duplicate check builds are not
-	// created. If manuallyTriggered is true, then a check build will always be
-	// made.
+	// created.
 	//
 	// If toDb is false, an in-memory build will be made and sent directly to
 	// the build tracker on the current web node. If there are multiple web
 	// nodes then it is possible for duplicate check builds to be created.
-	// Within a single web node, the BuildTracker will ignore duplicate builds.
+	// Within a single web node, the BuildTracker will ignore duplicate builds
+	// for the same resource.
 	TryCreateCheck(ctx context.Context, checkable Checkable, resourceTypes ResourceTypes, from atc.Version, manuallyTriggered bool, skipIntervalRecursively bool, toDb bool) (Build, bool, error)
 
 	// Returns all resources that are triggers for jobs, excluding those with

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -109,10 +109,7 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 	logger := lagerctx.FromContext(ctx)
 
 	if !d.plan.SkipInterval {
-		if d.plan.Interval.Never {
-			// exit early if user specified to never run periodic checks
-			return nil, false, nil
-		} else if d.plan.IsResourceCheck() {
+		if d.plan.IsResourceCheck() {
 			// rate limit periodic resource checks so worker load (plus load on
 			// external services) isn't too spiky. note that we don't rate limit
 			// resource type or prototype checks, because they are created every time a

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -369,12 +369,12 @@ var _ = Describe("CheckDelegate", func() {
 					}
 				})
 
-				It("returns false", func() {
-					Expect(run).To(BeFalse())
+				It("returns true", func() {
+					Expect(run).To(BeTrue())
 				})
 
 				It("does not attempt to fetch the last check", func() {
-					Expect(fakeResourceConfigScope.LastCheckCallCount()).To(Equal(0))
+					Expect(fakeResourceConfigScope.LastCheckCallCount()).To(Equal(2))
 				})
 			})
 		})

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Scanner", func() {
 				})
 			})
 
-			Context("when CheckEvery is never", func() {
+			Context("when check_every is never", func() {
 				BeforeEach(func() {
 					fakeResource.CheckEveryReturns(&atc.CheckEvery{Never: true})
 					fakeResource.TypeReturns("parent")


### PR DESCRIPTION
## Changes proposed by this PR

closes #9590 #9592

1) Removed the If-check in check_delegate. It was a little redundant to
   have since we check this in Lidar already and it would be overridden
   if manually checked. It wound up overriding the intention from the
   component that sent the check in the first place. This allows our
   call that creates checks in the Scheduler to go through and actually
   run the check.

2) ~~In lidar, we'll override Never == true if the resource has never been
   previously checked. We do this by checking if the resource has a
   scope ID. This helps ensure pipelines that are initially set check
   the resource at least once and therefore allow any automatically
   triggered jobs to run.~~ Removed this change because I realized it would be a breaking change in behaviour. I confirmed that resource checking behaved this way in previous versions, therefore I don't want to change that unnecessarily when users may be relying on it when setting their pipelines. I have updated the docs to reflect this reality.

Another approach I looked at was trying to see if we could easily look up if a resource has `check_every: never` set. Sadly that information is not normalized in the database, it's sitting in a text column that stores json, making it a tad too expensive for me to want to query. Why not a jsonb column? It's probably a really old table and it's not worth the migration pain.