### PR TITLE
feat: add validation for team names to prevent '/' characters in rename-team command

### DIFF
--- a/fly/commands/rename_team.go
+++ b/fly/commands/rename_team.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"strings"
+	"errors"
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
@@ -13,7 +15,22 @@ type RenameTeamCommand struct {
 	NewTeamName string               `short:"n" long:"new-name" required:"true" description:"New team name"`
 }
 
+func (command *RenameTeamCommand) Validate() error {
+	if strings.Contains(command.Team.Name(), "/") {
+		return errors.New("old team name cannot contain '/'")
+	}
+	if strings.Contains(command.NewTeamName, "/") {
+		return errors.New("new team name cannot contain '/'")
+	}
+	return nil
+}
+
 func (command *RenameTeamCommand) Execute([]string) error {
+	err := command.Validate()
+	if err != nil {
+		return err
+	}
+	
 	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
 	if err != nil {
 		return err

--- a/fly/integration/rename_team_test.go
+++ b/fly/integration/rename_team_test.go
@@ -41,6 +41,32 @@ var _ = Describe("rename-team", func() {
 		})
 	})
 
+	Context("when specifying a new team name with '/'", func() {
+		It("fails and says '/' characters are not allowed", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-team", "-o", "a-team", "-n", "forbidden/teamname")
+			
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			
+			<-sess.Exited
+			Expect(sess.ExitCode()).To(Equal(1))
+			Expect(sess.Err).To(gbytes.Say("error: new team name cannot contain '/'"))
+		})
+	})
+
+	Context("when specifying an old team name with '/'", func() {
+		It("fails and says '/' characters are not allowed", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-team", "-o", "forbidden/teamname", "-n", "b-team")
+			
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			
+			<-sess.Exited
+			Expect(sess.ExitCode()).To(Equal(1))
+			Expect(sess.Err).To(gbytes.Say("error: old team name cannot contain '/'"))
+		})
+	})
+	
 	Context("when not specifying a new name", func() {
 		It("fails and says you should provide a new name for the team", func() {
 			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-team", "-o", "a-team")


### PR DESCRIPTION

## Changes proposed by this PR

Follow up of #9537
Teams should not be able to contain "/" in their names. This change handle rename-pipeline command.

* add validation for "/" in rename-team command
* extend tests for the command

## Notes to reviewer

Sample test could be executed by running:
```sh
fly -t dev set-team -n new/team --local-user=test
```

---

I've also test to rename teams and pipelines through API. Both operation succeeds and I was able to rename pipeline from `vault2` to `vault/2`, as well as team `ivan` to `ivan/2`. Sample calls:
- pipeline rename with `/`
  ```sh
  curl --request PUT \
    --url http://localhost:8080/api/v1/teams/ivan/pipelines/vault2/rename \
    --header 'authorization: Bearer <token>' \
    --header 'content-type: application/json' \
    --data '{
    "name": "vault/2"
  }'
  ```
  The response of that call contains only warning:
  ```sh
  {"warnings":[{"type":"invalid_identifier","message":"pipeline: 'vault/2' is not a valid identifier: illegal character '/'"}]}
  ```

- team rename with `/`:
  ```sh
  curl --request PUT \
    --url http://localhost:8080/api/v1/teams/ivan/rename \
    --header 'authorization: Bearer <token>' \
    --header 'content-type: application/json' \
    --data '{
    "name": "ivan/2"
  }'
  The response of that call contains only warning:
  
  ```sh
  {"warnings":[{"type":"invalid_identifier","message":"team: 'ivan/2' is not a valid identifier: illegal character '/'"}]}
  ```

However, I believe those exceptions would be handled in #9271

---