### PR TITLE
Use os.Root when extracting files

### DIFF
--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -2,8 +2,10 @@ package tarfs
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -23,6 +25,12 @@ func Extract(src io.Reader, dest string) error {
 
 	chown := os.Getuid() == 0
 
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
 	for {
 		hdr, err := tarReader.Next()
 		if err == io.EOF {
@@ -37,7 +45,7 @@ func Extract(src io.Reader, dest string) error {
 			continue
 		}
 
-		err = ExtractEntry(hdr, dest, tarReader, chown)
+		err = extractEntry(root, hdr, tarReader, chown)
 		if err != nil {
 			return err
 		}
@@ -56,48 +64,83 @@ func (err BreakoutError) Error() string {
 }
 
 func ExtractEntry(header *tar.Header, dest string, input io.Reader, chown bool) error {
-	filePath := filepath.Join(dest, header.Name)
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return extractEntry(root, header, input, chown)
+}
+
+const pathEscapesErr = "path escapes"
+
+func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool) error {
+	filePath := header.Name
 	fileInfo := header.FileInfo()
 	fileMode := fileInfo.Mode()
 
-	err := os.MkdirAll(filepath.Dir(filePath), 0755)
+	err := root.MkdirAll(filepath.Dir(filePath), 0755)
 	if err != nil {
 		return err
 	}
 
 	switch header.Typeflag {
 	case tar.TypeLink:
-		targetPath := filepath.Join(dest, header.Linkname)
+		header.Linkname = stripRoot(header.Linkname)
 
-		if !strings.HasPrefix(targetPath, dest) {
-			return BreakoutError{header.Name, header.Linkname}
-		}
-
-		err := os.Link(filepath.Join(dest, header.Linkname), filePath)
+		err = root.Link(header.Linkname, filePath)
 		if err != nil {
+			// We only care about path-escape errors. All others are ignored and we fall through
+			if linkErr, ok := errors.AsType[*os.LinkError](err); ok {
+				if strings.Contains(linkErr.Error(), pathEscapesErr) {
+					return BreakoutError{
+						HeaderName: header.Name,
+						LinkName:   header.Linkname,
+					}
+				}
+			}
 			return err
 		}
 
 	case tar.TypeSymlink:
-		targetPath := filepath.Join(dest, header.Linkname)
-
-		if !strings.HasPrefix(targetPath, dest) {
-			return BreakoutError{header.Name, header.Linkname}
+		if !filepath.IsAbs(header.Linkname) {
+			// Absolute symlinks are left as-is because in containerized
+			// environments absolute paths won't escape the container. For
+			// non-containerized environments, sorry, can't help ya! We do use
+			// os.Root, so if someone tries to do an extraction attack by:
+			// 1) Creating a symlink that points at an absolute path
+			// 2) Create a file that would follow that symlink, writing outside
+			//    the extraction path
+			// os.Root won't allow that.
+			// For symlinks pointing to relative paths, we detect if they try to
+			// point to a path outside of the destination path and return a BreakoutErr
+			_, err := root.Stat(filepath.Join(filepath.Dir(filePath), header.Linkname))
+			if err != nil {
+				// We only care about path-escape errors. All others are ignored and we fall through
+				if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
+					if strings.Contains(pathErr.Error(), pathEscapesErr) {
+						return BreakoutError{
+							HeaderName: header.Name,
+							LinkName:   header.Linkname,
+						}
+					}
+				}
+			}
 		}
 
-		err := os.Symlink(header.Linkname, filePath)
+		err = root.Symlink(header.Linkname, filePath)
 		if err != nil {
 			return err
 		}
 
 	case tar.TypeDir:
-		err := os.MkdirAll(filePath, fileMode)
+		err := root.MkdirAll(filePath, fileMode.Perm())
 		if err != nil {
 			return err
 		}
 
 	case tar.TypeReg, tar.TypeRegA:
-		file, err := os.Create(filePath)
+		file, err := root.Create(filePath)
 		if err != nil {
 			return err
 		}
@@ -114,7 +157,7 @@ func ExtractEntry(header *tar.Header, dest string, input io.Reader, chown bool) 
 		}
 
 	case tar.TypeBlock, tar.TypeChar, tar.TypeFifo:
-		err := mknodEntry(header, filePath)
+		err := mknodEntry(header, filepath.Join(root.Name(), filePath))
 		if err != nil {
 			return err
 		}
@@ -128,20 +171,20 @@ func ExtractEntry(header *tar.Header, dest string, input io.Reader, chown bool) 
 	}
 
 	if runtime.GOOS != "windows" && chown {
-		err = os.Lchown(filePath, header.Uid, header.Gid)
+		err = root.Lchown(filePath, header.Uid, header.Gid)
 		if err != nil {
 			return err
 		}
 	}
 
 	// must be done after chown
-	err = lchmod(header, filePath, fileMode)
+	err = lchmod(root, header, filePath, fileMode)
 	if err != nil {
 		return err
 	}
 
 	// must be done after everything
-	err = lchtimes(header, filePath)
+	err = lchtimes(root, header, filePath)
 	if err != nil {
 		return err
 	}
@@ -149,19 +192,19 @@ func ExtractEntry(header *tar.Header, dest string, input io.Reader, chown bool) 
 	return nil
 }
 
-func lchmod(header *tar.Header, path string, fileMode os.FileMode) error {
+func lchmod(root *os.Root, header *tar.Header, path string, fileMode os.FileMode) error {
 	if header.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(header.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			return os.Chmod(path, fileMode)
+		if fi, err := root.Lstat(header.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			return root.Chmod(path, fileMode)
 		}
 	} else if header.Typeflag != tar.TypeSymlink {
-		return os.Chmod(path, fileMode)
+		return root.Chmod(path, fileMode)
 	}
 
 	return nil
 }
 
-func lchtimes(header *tar.Header, path string) error {
+func lchtimes(root *os.Root, header *tar.Header, path string) error {
 	aTime := header.AccessTime
 	mTime := header.ModTime
 	if aTime.Before(mTime) {
@@ -169,12 +212,20 @@ func lchtimes(header *tar.Header, path string) error {
 	}
 
 	if header.Typeflag == tar.TypeLink {
-		if fi, err := os.Lstat(header.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			return os.Chtimes(path, aTime, mTime)
+		if fi, err := root.Lstat(header.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
+			return root.Chtimes(path, aTime, mTime)
 		}
 	} else if header.Typeflag != tar.TypeSymlink {
-		return os.Chtimes(path, aTime, mTime)
+		return root.Chtimes(path, aTime, mTime)
 	}
 
 	return nil
+}
+
+func stripRoot(p string) string {
+	// On Unix this part does nothing. On Windows it strips `C:`
+	p = strings.TrimPrefix(p, filepath.VolumeName(p))
+	// Removes all leading forward and backwards slashes
+	p = strings.TrimLeft(p, `/\`)
+	return p
 }

--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -54,6 +54,16 @@ var _ = Describe("Extract", func() {
 			Link: "some-file",
 			Mode: 0755,
 		},
+		{
+			Name: "./symlink-dir/relative-symlink",
+			Link: "../some-file",
+			Mode: 0755,
+		},
+		{
+			Name: "./symlink-dir/absolute-symlink",
+			Link: "/some-file",
+			Mode: 0755,
+		},
 	}
 
 	BeforeEach(func() {
@@ -164,39 +174,81 @@ var _ = Describe("ExtractEntry", func() {
 		os.RemoveAll(dest)
 	})
 
-	It("returns a BreakoutError when a hard link points outside the destination", func() {
-		header := &tar.Header{
-			Typeflag: tar.TypeLink,
-			Name:     "malicious-link",
-			Linkname: "../outside-file",
-		}
+	Context("hard links", func() {
+		It("turns absolute paths into relative paths inside dest", func() {
+			header := &tar.Header{
+				Typeflag: tar.TypeLink,
+				Name:     "./hardlink",
+				Linkname: "/absolute/path/file",
+				Mode:     0755,
+			}
+			By("creating the target of the hard link", func() {
+				root, err := os.OpenRoot(dest)
+				Expect(err).ToNot(HaveOccurred())
+				err = root.MkdirAll("absolute/path/", 0755)
+				Expect(err).ToNot(HaveOccurred())
+				f, err := root.Create("absolute/path/file")
+				Expect(err).ToNot(HaveOccurred())
+				f.Close()
+			})
 
-		err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
-		Expect(err).To(HaveOccurred())
+			err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-		var breakoutErr tarfs.BreakoutError
-		Expect(err).To(BeAssignableToTypeOf(breakoutErr))
+		It("returns a BreakoutErr when a hard link points outside the destination", func() {
+			header := &tar.Header{
+				Typeflag: tar.TypeLink,
+				Name:     "malicious-link",
+				Linkname: "../outside-file",
+				Mode:     0755,
+			}
 
-		breakoutErr = err.(tarfs.BreakoutError)
-		Expect(breakoutErr.HeaderName).To(Equal("malicious-link"))
-		Expect(breakoutErr.LinkName).To(Equal("../outside-file"))
+			err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
+			Expect(err).To(HaveOccurred())
+
+			var breakoutErr tarfs.BreakoutError
+			Expect(err).To(BeAssignableToTypeOf(breakoutErr))
+
+			breakoutErr = err.(tarfs.BreakoutError)
+			Expect(breakoutErr.HeaderName).To(Equal("malicious-link"))
+			Expect(breakoutErr.LinkName).To(Equal("../outside-file"))
+		})
+
 	})
 
-	It("returns a BreakoutError when a symlink points outside the destination", func() {
-		header := &tar.Header{
-			Typeflag: tar.TypeSymlink,
-			Name:     "malicious-link",
-			Linkname: "../outside-file",
-		}
+	Context("symlinks", func() {
+		It("does not modify absolute paths", func() {
+			header := &tar.Header{
+				Typeflag: tar.TypeSymlink,
+				Name:     "abs",
+				Linkname: "/absolute/path/file",
+			}
 
-		err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
-		Expect(err).To(HaveOccurred())
+			err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
+			Expect(err).ToNot(HaveOccurred())
 
-		var breakoutErr tarfs.BreakoutError
-		Expect(err).To(BeAssignableToTypeOf(breakoutErr))
+			l, err := os.Readlink(filepath.Join(dest, "abs"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(l).To(Equal(header.Linkname))
+		})
 
-		breakoutErr = err.(tarfs.BreakoutError)
-		Expect(breakoutErr.HeaderName).To(Equal("malicious-link"))
-		Expect(breakoutErr.LinkName).To(Equal("../outside-file"))
+		It("returns a BreakoutErr when a symlink points outside the destination", func() {
+			header := &tar.Header{
+				Typeflag: tar.TypeSymlink,
+				Name:     "malicious-link",
+				Linkname: "../outside-path",
+			}
+
+			err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
+			Expect(err).To(HaveOccurred())
+
+			var breakoutErr tarfs.BreakoutError
+			Expect(err).To(BeAssignableToTypeOf(breakoutErr))
+
+			breakoutErr = err.(tarfs.BreakoutError)
+			Expect(breakoutErr.HeaderName).To(Equal("malicious-link"))
+			Expect(breakoutErr.LinkName).To(Equal("../outside-path"))
+		})
 	})
 })

--- a/go-archive/zipfs/extract.go
+++ b/go-archive/zipfs/extract.go
@@ -28,6 +28,11 @@ func Extract(srcFile string, dest string) error {
 		}
 
 		defer files.Close()
+		root, err := os.OpenRoot(dest)
+		if err != nil {
+			return err
+		}
+		defer root.Close()
 
 		for _, file := range files.File {
 			err = func() error {
@@ -37,7 +42,7 @@ func Extract(srcFile string, dest string) error {
 				}
 				defer readCloser.Close()
 
-				return extractZipArchiveFile(file, dest, readCloser)
+				return extractZipArchiveFile(root, file, readCloser)
 			}()
 
 			if err != nil {
@@ -49,17 +54,17 @@ func Extract(srcFile string, dest string) error {
 	}
 }
 
-func extractZipArchiveFile(file *zip.File, dest string, input io.Reader) error {
-	filePath := filepath.Join(dest, file.Name)
+func extractZipArchiveFile(root *os.Root, file *zip.File, input io.Reader) error {
+	filePath := file.Name
 	fileInfo := file.FileInfo()
 
 	if fileInfo.IsDir() {
-		err := os.MkdirAll(filePath, fileInfo.Mode())
+		err := root.MkdirAll(filePath, fileInfo.Mode().Perm())
 		if err != nil {
 			return err
 		}
 	} else {
-		err := os.MkdirAll(filepath.Dir(filePath), 0755)
+		err := root.MkdirAll(filepath.Dir(filePath), 0755)
 		if err != nil {
 			return err
 		}
@@ -69,10 +74,10 @@ func extractZipArchiveFile(file *zip.File, dest string, input io.Reader) error {
 			if err != nil {
 				return err
 			}
-			return os.Symlink(string(linkName), filePath)
+			return root.Symlink(string(linkName), filePath)
 		}
 
-		fileCopy, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileInfo.Mode())
+		fileCopy, err := root.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileInfo.Mode())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Changes proposed by this PR

closes #9597 

Basically reverting #9486, but adding one safe-guard against path escapes from symlinks when creating a relative symlink. [`os.Root`](https://pkg.go.dev/os#Root) is doing the heavy-lifting for us here. It'll protect us from extraction attacks that try to write outside the destination directory. It'll still allow us to create the symlink, but it'll fail if someone tries to do an extraction attack using the symlink.

I left a comment in the code path where we create symlinks explaining this a bit more.

I manually setup a pipeline using the test repo from Pix4D: https://github.com/Pix4D/concourse-tar-streaming-issue
```yaml
resources:
  - name: repo
    type: git
    source:
      uri: https://github.com/Pix4D/concourse-tar-streaming-issue.git

jobs:
  - name: job
    plan:
      - get: repo
      - task: windows
        config:
          platform: windows
          inputs:
            - name: repo
          run:
            path: powershell
            args:
              - -Command
              - |
                ls .
```

and streamed it from a linux to windows worker. I verified I could reproduce the issue from `master` first:
```
{"timestamp":"2026-06-15T16:14:50.724027700Z","level":"info","source":"worker","message":"worker.baggageclaim.api.volume-server.stream-in.bad-stream-payload","data":{"error":"entry './safe-intra-repo-windows/workers/images-vars.tf' links outside of target directory: ../shared/images-vars.tf","session":"2.2.1.11","volume":"bb0f01bf-1b35-4206-a0bc-9a40840081be"}}
```
<img width="637" height="189" alt="image" src="https://github.com/user-attachments/assets/8948a3ab-87ae-417f-acf4-74434b704889" />

Redeploying the windows worker with this PR, it worked:
<img width="678" height="416" alt="image" src="https://github.com/user-attachments/assets/6acc70bf-5b0b-459f-872b-ffd006a71690" />
