### PR TITLE
fix: split container property labels on rune boundaries

### DIFF
--- a/worker/runtime/properties.go
+++ b/worker/runtime/properties.go
@@ -45,6 +45,11 @@ func propertiesToLabels(properties garden.Properties) (map[string]string, error)
 			chunkKey := key + "." + strconv.Itoa(sequenceNum)
 			valueLen := min(maxLabelLen-len(chunkKey), len(value))
 
+			// Avoid splitting a multi-byte UTF-8 rune across the chunk boundary
+			for valueLen > 0 && valueLen < len(value) && !utf8.RuneStart(value[valueLen]) {
+				valueLen--
+			}
+
 			labelSet[chunkKey] = value[:valueLen]
 			value = value[valueLen:]
 

--- a/worker/runtime/properties_internal_test.go
+++ b/worker/runtime/properties_internal_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"code.cloudfoundry.org/garden"
+	"github.com/stretchr/testify/require"
+)
+
+// Chunking a long value must split on rune boundaries, else a multi-byte rune
+// is bisected and the chunk is invalid UTF-8, which containerd rejects.
+func TestPropertiesToLabels_DoesNotSplitMultiByteRunes(t *testing.T) {
+	// 9000 bytes of em dashes (3 bytes each): over the 4096-byte label limit,
+	// and 4096 isn't a multiple of 3 so a byte-wise split must bisect a rune.
+	value := strings.Repeat("—", 3000)
+
+	labels, err := propertiesToLabels(garden.Properties{"prop": value})
+	require.NoError(t, err)
+	require.Greater(t, len(labels), 1, "value should have been split into multiple chunks")
+
+	for key, chunk := range labels {
+		require.True(t, utf8.ValidString(chunk),
+			"chunk %q is not valid UTF-8 - a multi-byte rune was split across the boundary", key)
+	}
+
+	// The chunks must still reassemble to the exact original value.
+	require.Equal(t,
+		garden.Properties{"prop": value},
+		labelsToProperties(labels),
+	)
+}


### PR DESCRIPTION
Property values over containerd's 4096-byte label limit are split into multiple labels. The split used a raw byte offset, so a multi-byte UTF-8 rune straddling the boundary was bisected, leaving a chunk that is invalid UTF-8. containerd then rejects it ("set label: grpc: error while marshaling: string field contains invalid UTF-8"), erroring the build.

Back the chunk boundary off to the nearest rune start before slicing.

Discussion from closed git-resource PR: https://github.com/concourse/git-resource/pull/475