### PR TITLE
Add configurable stall timeout to auto-prune long-stalled workers

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -218,6 +218,8 @@ type RunCommand struct {
 		VarSourceRecyclePeriod time.Duration `long:"var-source-recycle-period" default:"5m" description:"Period after which to reap var_sources that are not used."`
 	} `group:"Garbage Collection" namespace:"gc"`
 
+	WorkerStallTimeout time.Duration `long:"worker-stall-timeout" default:"0" description:"Period after which stalled (unresponsive, non-ephemeral) workers will be automatically pruned along with their cache state. 0 (the default) means stalled workers are never automatically pruned and must be removed manually with 'fly prune-worker'."`
+
 	BuildTrackerInterval time.Duration `long:"build-tracker-interval" default:"10s" description:"Interval on which to run build tracking."`
 
 	TelemetryOptIn bool `long:"telemetry-opt-in" hidden:"true" description:"Enable anonymous concourse version reporting."`
@@ -1391,7 +1393,7 @@ func (cmd *RunCommand) gcComponents(
 
 	collectors := map[string]component.Runnable{
 		atc.ComponentCollectorBuilds:            gc.NewBuildCollector(dbBuildFactory),
-		atc.ComponentCollectorWorkers:           gc.NewWorkerCollector(dbWorkerLifecycle),
+		atc.ComponentCollectorWorkers:           gc.NewWorkerCollector(dbWorkerLifecycle, cmd.WorkerStallTimeout),
 		atc.ComponentCollectorResourceConfigs:   gc.NewResourceConfigCollector(dbResourceConfigFactory, unreferencedConfigGracePeriod),
 		atc.ComponentCollectorResourceCaches:    gc.NewResourceCacheCollector(dbResourceCacheLifecycle),
 		atc.ComponentCollectorTaskCaches:        gc.NewTaskCacheCollector(dbTaskCacheLifecycle),

--- a/atc/db/dbfakes/fake_worker_lifecycle.go
+++ b/atc/db/dbfakes/fake_worker_lifecycle.go
@@ -3,6 +3,7 @@ package dbfakes
 
 import (
 	"sync"
+	"time"
 
 	"github.com/concourse/concourse/atc/db"
 )
@@ -17,6 +18,19 @@ type FakeWorkerLifecycle struct {
 		result2 error
 	}
 	deleteFinishedRetiringWorkersReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
+	DeleteStalledWorkersStub        func(time.Duration) ([]string, error)
+	deleteStalledWorkersMutex       sync.RWMutex
+	deleteStalledWorkersArgsForCall []struct {
+		arg1 time.Duration
+	}
+	deleteStalledWorkersReturns struct {
+		result1 []string
+		result2 error
+	}
+	deleteStalledWorkersReturnsOnCall map[int]struct {
 		result1 []string
 		result2 error
 	}
@@ -123,6 +137,70 @@ func (fake *FakeWorkerLifecycle) DeleteFinishedRetiringWorkersReturnsOnCall(i in
 		})
 	}
 	fake.deleteFinishedRetiringWorkersReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeWorkerLifecycle) DeleteStalledWorkers(arg1 time.Duration) ([]string, error) {
+	fake.deleteStalledWorkersMutex.Lock()
+	ret, specificReturn := fake.deleteStalledWorkersReturnsOnCall[len(fake.deleteStalledWorkersArgsForCall)]
+	fake.deleteStalledWorkersArgsForCall = append(fake.deleteStalledWorkersArgsForCall, struct {
+		arg1 time.Duration
+	}{arg1})
+	stub := fake.DeleteStalledWorkersStub
+	fakeReturns := fake.deleteStalledWorkersReturns
+	fake.recordInvocation("DeleteStalledWorkers", []interface{}{arg1})
+	fake.deleteStalledWorkersMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeWorkerLifecycle) DeleteStalledWorkersCallCount() int {
+	fake.deleteStalledWorkersMutex.RLock()
+	defer fake.deleteStalledWorkersMutex.RUnlock()
+	return len(fake.deleteStalledWorkersArgsForCall)
+}
+
+func (fake *FakeWorkerLifecycle) DeleteStalledWorkersCalls(stub func(time.Duration) ([]string, error)) {
+	fake.deleteStalledWorkersMutex.Lock()
+	defer fake.deleteStalledWorkersMutex.Unlock()
+	fake.DeleteStalledWorkersStub = stub
+}
+
+func (fake *FakeWorkerLifecycle) DeleteStalledWorkersArgsForCall(i int) time.Duration {
+	fake.deleteStalledWorkersMutex.RLock()
+	defer fake.deleteStalledWorkersMutex.RUnlock()
+	argsForCall := fake.deleteStalledWorkersArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeWorkerLifecycle) DeleteStalledWorkersReturns(result1 []string, result2 error) {
+	fake.deleteStalledWorkersMutex.Lock()
+	defer fake.deleteStalledWorkersMutex.Unlock()
+	fake.DeleteStalledWorkersStub = nil
+	fake.deleteStalledWorkersReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeWorkerLifecycle) DeleteStalledWorkersReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.deleteStalledWorkersMutex.Lock()
+	defer fake.deleteStalledWorkersMutex.Unlock()
+	fake.DeleteStalledWorkersStub = nil
+	if fake.deleteStalledWorkersReturnsOnCall == nil {
+		fake.deleteStalledWorkersReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.deleteStalledWorkersReturnsOnCall[i] = struct {
 		result1 []string
 		result2 error
 	}{result1, result2}

--- a/atc/db/migration/migrations/1781568000_add_stalled_since_to_workers.down.sql
+++ b/atc/db/migration/migrations/1781568000_add_stalled_since_to_workers.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workers DROP COLUMN stalled_since;

--- a/atc/db/migration/migrations/1781568000_add_stalled_since_to_workers.up.sql
+++ b/atc/db/migration/migrations/1781568000_add_stalled_since_to_workers.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE workers ADD COLUMN stalled_since timestamp with time zone;
+
+-- Backfill existing stalled workers so they are subject to the stall timeout
+-- starting from the moment this migration runs, rather than being immortal due
+-- to a NULL stalled_since.
+UPDATE workers SET stalled_since = now() WHERE state = 'stalled';

--- a/atc/db/worker_factory.go
+++ b/atc/db/worker_factory.go
@@ -278,6 +278,10 @@ func (f *workerFactory) HeartbeatWorker(atcWorker atc.Worker, ttl time.Duration)
 		Set("active_containers", atcWorker.ActiveContainers).
 		Set("active_volumes", atcWorker.ActiveVolumes).
 		Set("state", sq.Expr("("+cSQL+")")).
+		// A worker that is heartbeating is responsive, so it can no longer be
+		// considered stalled. Clearing stalled_since ensures a worker that
+		// recovers from a transient disconnect resets its stall grace period.
+		Set("stalled_since", nil).
 		Where(sq.Eq{"name": atcWorker.Name}).
 		RunWith(tx).
 		Exec()

--- a/atc/db/worker_lifecycle.go
+++ b/atc/db/worker_lifecycle.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 )
@@ -10,6 +12,7 @@ import (
 type WorkerLifecycle interface {
 	DeleteUnresponsiveEphemeralWorkers() ([]string, error)
 	StallUnresponsiveWorkers() ([]string, error)
+	DeleteStalledWorkers(timeout time.Duration) ([]string, error)
 	LandFinishedLandingWorkers() ([]string, error)
 	DeleteFinishedRetiringWorkers() ([]string, error)
 	GetWorkerStateByName() (map[string]WorkerState, error)
@@ -47,11 +50,38 @@ func (lifecycle *workerLifecycle) DeleteUnresponsiveEphemeralWorkers() ([]string
 func (lifecycle *workerLifecycle) StallUnresponsiveWorkers() ([]string, error) {
 	query, args, err := psql.Update("workers").
 		SetMap(map[string]any{
-			"state":   string(WorkerStateStalled),
-			"expires": nil,
+			"state":         string(WorkerStateStalled),
+			"expires":       nil,
+			"stalled_since": sq.Expr("NOW()"),
 		}).
 		Where(sq.Eq{"state": string(WorkerStateRunning)}).
 		Where(sq.Expr("expires < NOW()")).
+		Suffix("RETURNING name").
+		ToSql()
+	if err != nil {
+		return []string{}, err
+	}
+
+	rows, err := lifecycle.conn.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return workersAffected(rows)
+}
+
+// DeleteStalledWorkers deletes workers that have been in the 'stalled' state
+// for longer than the given timeout. This gives operators the automatic
+// cleanup of ephemeral workers without the hair-trigger cache wipe: a
+// transiently-disconnected worker that reconnects within the timeout returns
+// to 'running' (clearing stalled_since) and keeps its caches, while genuinely
+// dead workers are eventually reaped.
+func (lifecycle *workerLifecycle) DeleteStalledWorkers(timeout time.Duration) ([]string, error) {
+	query, args, err := psql.Delete("workers").
+		Where(sq.Eq{"state": string(WorkerStateStalled)}).
+		Where(sq.Expr(
+			fmt.Sprintf("stalled_since < NOW() - '%d second'::INTERVAL", int(timeout.Seconds())),
+		)).
 		Suffix("RETURNING name").
 		ToSql()
 	if err != nil {

--- a/atc/db/worker_lifecycle_test.go
+++ b/atc/db/worker_lifecycle_test.go
@@ -102,6 +102,59 @@ var _ = Describe("Worker Lifecycle", func() {
 		})
 	})
 
+	Describe("DeleteStalledWorkers", func() {
+		Context("when there is a stalled worker", func() {
+			BeforeEach(func() {
+				_, err := workerFactory.SaveWorker(atcWorker, -1*time.Minute)
+				Expect(err).ToNot(HaveOccurred())
+
+				stalledWorkers, err := workerLifecycle.StallUnresponsiveWorkers()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stalledWorkers).To(ConsistOf("some-name"))
+			})
+
+			Context("when the worker has been stalled for less than the timeout", func() {
+				It("leaves the worker alone", func() {
+					deletedWorkers, err := workerLifecycle.DeleteStalledWorkers(time.Hour)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(deletedWorkers).To(BeEmpty())
+				})
+			})
+
+			Context("when the worker has been stalled for longer than the timeout", func() {
+				It("deletes the stalled worker", func() {
+					deletedWorkers, err := workerLifecycle.DeleteStalledWorkers(-1 * time.Hour)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(deletedWorkers).To(ConsistOf("some-name"))
+				})
+			})
+
+			Context("when the worker heartbeats again before the timeout", func() {
+				It("clears the stall and leaves the worker alone", func() {
+					_, err := workerFactory.HeartbeatWorker(atcWorker, 5*time.Minute)
+					Expect(err).ToNot(HaveOccurred())
+
+					deletedWorkers, err := workerLifecycle.DeleteStalledWorkers(-1 * time.Hour)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(deletedWorkers).To(BeEmpty())
+				})
+			})
+		})
+
+		Context("when the worker is running", func() {
+			BeforeEach(func() {
+				_, err := workerFactory.SaveWorker(atcWorker, 5*time.Minute)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("leaves the worker alone", func() {
+				deletedWorkers, err := workerLifecycle.DeleteStalledWorkers(-1 * time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deletedWorkers).To(BeEmpty())
+			})
+		})
+	})
+
 	Describe("DeleteFinishedRetiringWorkers", func() {
 		var (
 			dbWorker db.Worker

--- a/atc/gc/worker_collector.go
+++ b/atc/gc/worker_collector.go
@@ -12,11 +12,13 @@ import (
 
 type workerCollector struct {
 	workerLifecycle db.WorkerLifecycle
+	stallTimeout    time.Duration
 }
 
-func NewWorkerCollector(workerLifecycle db.WorkerLifecycle) *workerCollector {
+func NewWorkerCollector(workerLifecycle db.WorkerLifecycle, stallTimeout time.Duration) *workerCollector {
 	return &workerCollector{
 		workerLifecycle: workerLifecycle,
+		stallTimeout:    stallTimeout,
 	}
 }
 
@@ -51,6 +53,18 @@ func (wc *workerCollector) Run(ctx context.Context) error {
 
 	if len(affected) > 0 {
 		logger.Info("marked-workers-as-stalled", lager.Data{"count": len(affected), "workers": affected})
+	}
+
+	if wc.stallTimeout > 0 {
+		affected, err = wc.workerLifecycle.DeleteStalledWorkers(wc.stallTimeout)
+		if err != nil {
+			logger.Error("failed-to-delete-stalled-workers", err)
+			return err
+		}
+
+		if len(affected) > 0 {
+			logger.Info("stalled-workers-removed", lager.Data{"count": len(affected), "workers": affected})
+		}
 	}
 
 	affected, err = wc.workerLifecycle.DeleteFinishedRetiringWorkers()

--- a/atc/gc/worker_collector_test.go
+++ b/atc/gc/worker_collector_test.go
@@ -2,6 +2,7 @@ package gc_test
 
 import (
 	"context"
+	"time"
 
 	"github.com/concourse/concourse/atc/gc"
 
@@ -16,17 +17,22 @@ var _ = Describe("WorkerCollector", func() {
 	var (
 		workerCollector     GcCollector
 		fakeWorkerLifecycle *dbfakes.FakeWorkerLifecycle
+		stallTimeout        time.Duration
 	)
 
 	BeforeEach(func() {
 		fakeWorkerLifecycle = new(dbfakes.FakeWorkerLifecycle)
-
-		workerCollector = gc.NewWorkerCollector(fakeWorkerLifecycle)
+		stallTimeout = 0
 
 		fakeWorkerLifecycle.DeleteUnresponsiveEphemeralWorkersReturns(nil, nil)
 		fakeWorkerLifecycle.StallUnresponsiveWorkersReturns(nil, nil)
+		fakeWorkerLifecycle.DeleteStalledWorkersReturns(nil, nil)
 		fakeWorkerLifecycle.DeleteFinishedRetiringWorkersReturns(nil, nil)
 		fakeWorkerLifecycle.LandFinishedLandingWorkersReturns(nil, nil)
+	})
+
+	JustBeforeEach(func() {
+		workerCollector = gc.NewWorkerCollector(fakeWorkerLifecycle, stallTimeout)
 	})
 
 	Describe("Run", func() {
@@ -82,5 +88,39 @@ var _ = Describe("WorkerCollector", func() {
 			Expect(err).To(MatchError(returnedErr))
 		})
 
+		Context("when the stall timeout is disabled (zero)", func() {
+			BeforeEach(func() {
+				stallTimeout = 0
+			})
+
+			It("does not delete stalled workers", func() {
+				err := workerCollector.Run(context.TODO())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeWorkerLifecycle.DeleteStalledWorkersCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when the stall timeout is set", func() {
+			BeforeEach(func() {
+				stallTimeout = time.Hour
+			})
+
+			It("tells the worker factory to delete stalled workers with the configured timeout", func() {
+				err := workerCollector.Run(context.TODO())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeWorkerLifecycle.DeleteStalledWorkersCallCount()).To(Equal(1))
+				Expect(fakeWorkerLifecycle.DeleteStalledWorkersArgsForCall(0)).To(Equal(time.Hour))
+			})
+
+			It("returns an error if deleting stalled workers fails", func() {
+				returnedErr := errors.New("some-error")
+				fakeWorkerLifecycle.DeleteStalledWorkersReturns(nil, returnedErr)
+
+				err := workerCollector.Run(context.TODO())
+				Expect(err).To(MatchError(returnedErr))
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

closes #9603

Adds an opt-in stall timeout so operators can have stalled (unresponsive,
non-ephemeral) workers automatically pruned after a configurable grace period,
without resorting to `ephemeral` and its aggressive cache wipe.

* **New config `CONCOURSE_STALLED_WORKER_TIMEOUT` / `--stalled-worker-timeout`**
  (default `0` = disabled, preserving today's behavior). When set, the GC
  worker collector deletes workers that have been `stalled` longer than the
  timeout.
* **New `stalled_since` column on `workers`** (migration
  `1781568000_add_stalled_since_to_workers`). `StallUnresponsiveWorkers` stamps
  it when a worker transitions `running` → `stalled`; `HeartbeatWorker` clears
  it when a worker reconnects, so a recovered worker resets its grace period and
  keeps all of its container/volume/cache rows. The migration backfills existing
  stalled workers with `now()` so they aren't immortal due to a `NULL` value.
* **`DeleteStalledWorkers(timeout)`** added to `WorkerLifecycle` and wired into
  `workerCollector.Run`, analogous to `DeleteUnresponsiveEphemeralWorkers`. It
  only runs when the timeout is greater than zero.

### Why

On EC2 autoscaling/spot fleets, workers regularly disappear without a graceful
`retire`/`land` and accumulate in `stalled` forever — nothing ever deletes a
non-ephemeral worker once stalled. The only existing automatic cleanup,
`ephemeral`, deletes a worker ~60–90s after a heartbeat gap and cascades away
its entire cache footprint. That's far too aggressive: the worker→TSA reconnect
window is hardcoded to up to 5 minutes (`tsa/client.go`), so on an unclean break
a healthy worker can be deleted and cache-wiped while still running builds, only
to reconnect moments later and re-register empty.

A grace-period-based stall timeout (minutes/hours, operator's choice) comfortably
exceeds the worst-case reconnect window: transiently-disconnected workers recover
for free, and only genuinely-dead workers are reaped. This matches the approach
agreed with @taylorsilva in
https://github.com/concourse/concourse/issues/9603#issuecomment-4723686750
(build on `atc/gc/worker_collector.go`, add a column to track stall age).

## Notes to reviewer

* Behavior is unchanged unless the operator opts in by setting a non-zero
  `--worker-stall-timeout`.
* New unit tests cover the collector (timeout disabled vs. set, error path) and
  the DB lifecycle (`DeleteStalledWorkers` respects the timeout, leaves running
  workers alone, and a heartbeat clears the stall before the timeout).
* The config is exposed as a top-level flag to match the
  `CONCOURSE_STALLED_WORKER_TIMEOUT` name requested in the issue; happy to move it
  under the `gc` namespace (`CONCOURSE_GC_WORKER_STALL_TIMEOUT`) if maintainers
  prefer it grouped with the other grace periods.

## Release Note

* Added `CONCOURSE_STALLED_WORKER_TIMEOUT` to automatically prune workers that have
  been stalled longer than the configured duration. Defaults to `0` (disabled).
