### PR TITLE
Add job and step-level `tags` for `do` and `in_parallel` steps

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -24,6 +24,7 @@ func (planner Planner) Create(
 	prototypes atc.Prototypes,
 	inputs []db.BuildInput,
 	manuallyTriggered bool,
+	tags atc.Tags,
 ) (atc.Plan, error) {
 	visitor := &planVisitor{
 		planFactory: planner.planFactory,
@@ -33,6 +34,8 @@ func (planner Planner) Create(
 		prototypes:        prototypes,
 		inputs:            inputs,
 		manuallyTriggered: manuallyTriggered,
+
+		tags: tags,
 	}
 
 	err := planConfig.Visit(visitor)
@@ -52,7 +55,17 @@ type planVisitor struct {
 	inputs            []db.BuildInput
 	manuallyTriggered bool
 
+	tags atc.Tags
 	plan atc.Plan
+}
+
+// effectiveTags returns the tags a leaf step should use: its own tags when set,
+// otherwise the tags inherited from the enclosing job / do / in_parallel.
+func (visitor *planVisitor) effectiveTags(stepTags atc.Tags) atc.Tags {
+	if len(stepTags) > 0 {
+		return stepTags
+	}
+	return visitor.tags
 }
 
 func (visitor *planVisitor) VisitTask(step *atc.TaskStep) error {
@@ -64,7 +77,7 @@ func (visitor *planVisitor) VisitTask(step *atc.TaskStep) error {
 		Config:            step.Config,
 		ConfigPath:        step.ConfigPath,
 		Vars:              step.Vars,
-		Tags:              step.Tags,
+		Tags:              visitor.effectiveTags(step.Tags),
 		Params:            step.Params,
 		InputMapping:      step.InputMapping,
 		OutputMapping:     step.OutputMapping,
@@ -91,7 +104,7 @@ func (visitor *planVisitor) VisitRun(step *atc.RunStep) error {
 		Type:       step.Type,
 		Object:     atc.Params(object),
 		Privileged: step.Privileged,
-		Tags:       step.Tags,
+		Tags:       visitor.effectiveTags(step.Tags),
 		Limits:     step.Limits,
 		Timeout:    step.Timeout,
 	})
@@ -124,6 +137,8 @@ func (visitor *planVisitor) VisitGet(step *atc.GetStep) error {
 
 	resource.ApplySourceDefaults(visitor.resourceTypes)
 
+	tags := visitor.effectiveTags(step.Tags)
+
 	plan := visitor.planFactory.NewPlan(atc.GetPlan{
 		Name: step.Name,
 
@@ -132,11 +147,11 @@ func (visitor *planVisitor) VisitGet(step *atc.GetStep) error {
 		Source:   resource.Source,
 		Params:   step.Params,
 		Version:  &version,
-		Tags:     step.Tags,
+		Tags:     tags,
 		Timeout:  step.Timeout,
 	})
 
-	plan.Get.TypeImage = visitor.resourceTypes.ImageForType(plan.ID, resource.Type, step.Tags, false)
+	plan.Get.TypeImage = visitor.resourceTypes.ImageForType(plan.ID, resource.Type, tags, false)
 	visitor.plan = plan
 	return nil
 }
@@ -156,20 +171,22 @@ func (visitor *planVisitor) VisitPut(step *atc.PutStep) error {
 
 	resource.ApplySourceDefaults(visitor.resourceTypes)
 
+	tags := visitor.effectiveTags(step.Tags)
+
 	plan := visitor.planFactory.NewPlan(atc.PutPlan{
 		Type:     resource.Type,
 		Name:     logicalName,
 		Resource: resourceName,
 		Source:   resource.Source,
 		Params:   step.Params,
-		Tags:     step.Tags,
+		Tags:     tags,
 		Inputs:   step.Inputs,
 		Timeout:  step.Timeout,
 
 		ExposeBuildCreatedBy: resource.ExposeBuildCreatedBy,
 	})
 
-	plan.Put.TypeImage = visitor.resourceTypes.ImageForType(plan.ID, resource.Type, step.Tags, visitor.manuallyTriggered)
+	plan.Put.TypeImage = visitor.resourceTypes.ImageForType(plan.ID, resource.Type, tags, visitor.manuallyTriggered)
 
 	if step.NoGet {
 		visitor.plan = plan
@@ -184,11 +201,11 @@ func (visitor *planVisitor) VisitPut(step *atc.PutStep) error {
 		Params:      step.GetParams,
 		VersionFrom: &plan.ID,
 
-		Tags:    step.Tags,
+		Tags:    tags,
 		Timeout: step.Timeout,
 	})
 
-	dependentGetPlan.Get.TypeImage = visitor.resourceTypes.ImageForType(dependentGetPlan.ID, resource.Type, step.Tags, visitor.manuallyTriggered)
+	dependentGetPlan.Get.TypeImage = visitor.resourceTypes.ImageForType(dependentGetPlan.ID, resource.Type, tags, visitor.manuallyTriggered)
 
 	visitor.plan = visitor.planFactory.NewPlan(atc.OnSuccessPlan{
 		Step: plan,
@@ -199,6 +216,12 @@ func (visitor *planVisitor) VisitPut(step *atc.PutStep) error {
 }
 
 func (visitor *planVisitor) VisitDo(step *atc.DoStep) error {
+	if len(step.Tags) > 0 {
+		prev := visitor.tags
+		visitor.tags = step.Tags
+		defer func() { visitor.tags = prev }()
+	}
+
 	do := atc.DoPlan{}
 
 	for _, step := range step.Steps {
@@ -216,6 +239,12 @@ func (visitor *planVisitor) VisitDo(step *atc.DoStep) error {
 }
 
 func (visitor *planVisitor) VisitInParallel(step *atc.InParallelStep) error {
+	if len(step.Tags) > 0 {
+		prev := visitor.tags
+		visitor.tags = step.Tags
+		defer func() { visitor.tags = prev }()
+	}
+
 	var steps []atc.Plan
 
 	for _, sub := range step.Config.Steps {

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -29,6 +29,9 @@ type PlannerTest struct {
 	Config atc.StepConfig
 	Inputs []db.BuildInput
 
+	// Representing job-level tags
+	Tags atc.Tags
+
 	CompareIDs             bool
 	ManuallyTriggered      bool
 	OverwriteResourceTypes atc.ResourceTypes
@@ -1586,6 +1589,235 @@ var factoryTests = []PlannerTest{
 		}`,
 	},
 	{
+		Title: "do step with tags is inherited by child steps",
+
+		Config: &atc.DoStep{
+			Tags: atc.Tags{"do-tag"},
+			Steps: []atc.Step{
+				{
+					Config: &atc.GetStep{
+						Name:     "inherits",
+						Resource: "some-base-resource",
+					},
+				},
+				{
+					Config: &atc.GetStep{
+						Name:     "overrides",
+						Resource: "some-base-resource",
+						Tags:     atc.Tags{"own-tag"},
+					},
+				},
+			},
+		},
+		Inputs: []db.BuildInput{
+			{Name: "inherits", Version: atc.Version{"some": "version"}},
+			{Name: "overrides", Version: atc.Version{"some": "version"}},
+		},
+
+		PlanJSON: `{
+			"id": "(unique)",
+			"do": [
+				{
+					"id": "(unique)",
+					"get": {
+						"name": "inherits",
+						"type": "some-base-resource-type",
+						"resource": "some-base-resource",
+						"source": {"some":"source","default-key":"default-value"},
+						"version": {"some":"version"},
+						"tags": ["do-tag"],
+						"image": {"base_type": "some-base-resource-type"}
+					}
+				},
+				{
+					"id": "(unique)",
+					"get": {
+						"name": "overrides",
+						"type": "some-base-resource-type",
+						"resource": "some-base-resource",
+						"source": {"some":"source","default-key":"default-value"},
+						"version": {"some":"version"},
+						"tags": ["own-tag"],
+						"image": {"base_type": "some-base-resource-type"}
+					}
+				}
+			]
+		}`,
+	},
+	{
+		Title: "in_parallel step with tags is inherited by child steps",
+
+		Config: &atc.InParallelStep{
+			Tags: atc.Tags{"parallel-tag"},
+			Config: atc.InParallelConfig{
+				Steps: []atc.Step{
+					{
+						Config: &atc.GetStep{
+							Name:     "inherits",
+							Resource: "some-base-resource",
+						},
+					},
+				},
+			},
+		},
+		Inputs: []db.BuildInput{
+			{Name: "inherits", Version: atc.Version{"some": "version"}},
+		},
+
+		PlanJSON: `{
+			"id": "(unique)",
+			"in_parallel": {
+				"steps": [
+					{
+						"id": "(unique)",
+						"get": {
+							"name": "inherits",
+							"type": "some-base-resource-type",
+							"resource": "some-base-resource",
+							"source": {"some":"source","default-key":"default-value"},
+							"version": {"some":"version"},
+							"tags": ["parallel-tag"],
+							"image": {"base_type": "some-base-resource-type"}
+						}
+					}
+				]
+			}
+		}`,
+	},
+	{
+		Title: "job-level tags are inherited by child steps and hooks",
+
+		Tags: atc.Tags{"job-tag"},
+		Config: &atc.OnSuccessStep{
+			Step: &atc.DoStep{
+				Steps: []atc.Step{
+					{
+						Config: &atc.GetStep{
+							Name:     "plan-step",
+							Resource: "some-base-resource",
+						},
+					},
+				},
+			},
+			Hook: atc.Step{
+				Config: &atc.GetStep{
+					Name:     "hook-step",
+					Resource: "some-base-resource",
+				},
+			},
+		},
+		Inputs: []db.BuildInput{
+			{Name: "plan-step", Version: atc.Version{"some": "version"}},
+			{Name: "hook-step", Version: atc.Version{"some": "version"}},
+		},
+
+		PlanJSON: `{
+			"id": "(unique)",
+			"on_success": {
+				"step": {
+					"id": "(unique)",
+					"do": [
+						{
+							"id": "(unique)",
+							"get": {
+								"name": "plan-step",
+								"type": "some-base-resource-type",
+								"resource": "some-base-resource",
+								"source": {"some":"source","default-key":"default-value"},
+								"version": {"some":"version"},
+								"tags": ["job-tag"],
+								"image": {"base_type": "some-base-resource-type"}
+							}
+						}
+					]
+				},
+				"on_success": {
+					"id": "(unique)",
+					"get": {
+						"name": "hook-step",
+						"type": "some-base-resource-type",
+						"resource": "some-base-resource",
+						"source": {"some":"source","default-key":"default-value"},
+						"version": {"some":"version"},
+						"tags": ["job-tag"],
+						"image": {"base_type": "some-base-resource-type"}
+					}
+				}
+			}
+		}`,
+	},
+	{
+		Title: "inner tags override tags from parent steps",
+
+		Tags: atc.Tags{"job-tag"},
+		Config: &atc.DoStep{
+			Steps: []atc.Step{
+				{
+					Config: &atc.InParallelStep{
+						Tags: atc.Tags{"inner-tag"},
+						Config: atc.InParallelConfig{
+							Steps: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:     "inner",
+										Resource: "some-base-resource",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Config: &atc.GetStep{
+						Name:     "outer",
+						Resource: "some-base-resource",
+					},
+				},
+			},
+		},
+		Inputs: []db.BuildInput{
+			{Name: "inner", Version: atc.Version{"some": "version"}},
+			{Name: "outer", Version: atc.Version{"some": "version"}},
+		},
+
+		PlanJSON: `{
+			"id": "(unique)",
+			"do": [
+				{
+					"id": "(unique)",
+					"in_parallel": {
+						"steps": [
+							{
+								"id": "(unique)",
+								"get": {
+									"name": "inner",
+									"type": "some-base-resource-type",
+									"resource": "some-base-resource",
+									"source": {"some":"source","default-key":"default-value"},
+									"version": {"some":"version"},
+									"tags": ["inner-tag"],
+									"image": {"base_type": "some-base-resource-type"}
+								}
+							}
+						]
+					}
+				},
+				{
+					"id": "(unique)",
+					"get": {
+						"name": "outer",
+						"type": "some-base-resource-type",
+						"resource": "some-base-resource",
+						"source": {"some":"source","default-key":"default-value"},
+						"version": {"some":"version"},
+						"tags": ["job-tag"],
+						"image": {"base_type": "some-base-resource-type"}
+					}
+				}
+			]
+		}`,
+	},
+	{
 		Title: "across step",
 
 		Config: &atc.AcrossStep{
@@ -1883,7 +2115,7 @@ func (test PlannerTest) Run(s *PlannerSuite) {
 	if test.OverwriteResourceTypes != nil {
 		resourceTypes = test.OverwriteResourceTypes
 	}
-	actualPlan, actualErr := factory.Create(test.Config, resources, resourceTypes, prototypes, test.Inputs, test.ManuallyTriggered)
+	actualPlan, actualErr := factory.Create(test.Config, resources, resourceTypes, prototypes, test.Inputs, test.ManuallyTriggered, test.Tags)
 
 	if test.Err != nil {
 		s.Equal(test.Err, actualErr)

--- a/atc/job.go
+++ b/atc/job.go
@@ -49,11 +49,11 @@ type JobOutput struct {
 }
 
 type BuildInput struct {
-	Name     string   `json:"name"`
-	Resource string   `json:"resource"`
-	Type     string   `json:"type"`
-	Source   Source   `json:"source"`
-	Params   Params   `json:"params,omitempty"`
-	Version  Version  `json:"version"`
-	Tags     []string `json:"tags,omitempty"`
+	Name     string  `json:"name"`
+	Resource string  `json:"resource"`
+	Type     string  `json:"type"`
+	Source   Source  `json:"source"`
+	Params   Params  `json:"params,omitempty"`
+	Version  Version `json:"version"`
+	Tags     Tags    `json:"tags,omitempty"`
 }

--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -11,6 +11,7 @@ type JobConfig struct {
 	Interruptible        bool     `json:"interruptible,omitempty"`
 	SerialGroups         []string `json:"serial_groups,omitempty"`
 	RawMaxInFlight       int      `json:"max_in_flight,omitempty"`
+	Tags                 Tags     `json:"tags,omitempty"`
 
 	// Deprecated: users should use BuildLogRetention
 	BuildLogsToRetain int `json:"build_logs_to_retain,omitempty"`

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -24,7 +24,7 @@ type BuildStarter interface {
 
 //counterfeiter:generate . BuildPlanner
 type BuildPlanner interface {
-	Create(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool) (atc.Plan, error)
+	Create(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags) (atc.Plan, error)
 }
 
 type Build interface {
@@ -297,7 +297,7 @@ func (s *buildStarter) tryStartNextPendingBuild(
 		return startResults{}, fmt.Errorf("config: %w", err)
 	}
 
-	plan, err := s.planner.Create(config.StepConfig(), job.Resources, job.ResourceTypes, job.Prototypes, buildInputs, nextPendingBuild.IsManuallyTriggered())
+	plan, err := s.planner.Create(config.StepConfig(), job.Resources, job.ResourceTypes, job.Prototypes, buildInputs, nextPendingBuild.IsManuallyTriggered(), config.Tags)
 	if err != nil {
 		logger.Error("failed-to-create-build-plan", err)
 

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -505,7 +505,7 @@ var _ = Describe("BuildStarter", func() {
 								})
 
 								It("creates the build plan with manually triggered", func() {
-									_, _, _, _, _, actualManuallyTriggered := fakePlanner.CreateArgsForCall(0)
+									_, _, _, _, _, actualManuallyTriggered, _ := fakePlanner.CreateArgsForCall(0)
 									Expect(actualManuallyTriggered).To(Equal(true))
 								})
 							})
@@ -796,29 +796,32 @@ var _ = Describe("BuildStarter", func() {
 									It("creates build plans for all builds", func() {
 										Expect(fakePlanner.CreateCallCount()).To(Equal(3))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered := fakePlanner.CreateArgsForCall(0)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags := fakePlanner.CreateArgsForCall(0)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))
 										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
 										Expect(actualManuallyTriggered).To(Equal(false))
+										Expect(actualJobTags).To(Equal(jobConfig.Tags))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered = fakePlanner.CreateArgsForCall(1)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags = fakePlanner.CreateArgsForCall(1)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))
 										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
 										Expect(actualManuallyTriggered).To(Equal(false))
+										Expect(actualJobTags).To(Equal(jobConfig.Tags))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered = fakePlanner.CreateArgsForCall(2)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags = fakePlanner.CreateArgsForCall(2)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))
 										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
 										Expect(actualManuallyTriggered).To(Equal(false))
+										Expect(actualJobTags).To(Equal(jobConfig.Tags))
 									})
 
 									Context("when starting the build fails", func() {

--- a/atc/scheduler/schedulerfakes/fake_build_planner.go
+++ b/atc/scheduler/schedulerfakes/fake_build_planner.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FakeBuildPlanner struct {
-	CreateStub        func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool) (atc.Plan, error)
+	CreateStub        func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags) (atc.Plan, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
 		arg1 atc.StepConfig
@@ -19,6 +19,7 @@ type FakeBuildPlanner struct {
 		arg4 atc.Prototypes
 		arg5 []db.BuildInput
 		arg6 bool
+		arg7 atc.Tags
 	}
 	createReturns struct {
 		result1 atc.Plan
@@ -32,7 +33,7 @@ type FakeBuildPlanner struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResources, arg3 atc.ResourceTypes, arg4 atc.Prototypes, arg5 []db.BuildInput, arg6 bool) (atc.Plan, error) {
+func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResources, arg3 atc.ResourceTypes, arg4 atc.Prototypes, arg5 []db.BuildInput, arg6 bool, arg7 atc.Tags) (atc.Plan, error) {
 	var arg5Copy []db.BuildInput
 	if arg5 != nil {
 		arg5Copy = make([]db.BuildInput, len(arg5))
@@ -47,13 +48,14 @@ func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResou
 		arg4 atc.Prototypes
 		arg5 []db.BuildInput
 		arg6 bool
-	}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
+		arg7 atc.Tags
+	}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
 	stub := fake.CreateStub
 	fakeReturns := fake.createReturns
-	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
+	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
 	fake.createMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -67,17 +69,17 @@ func (fake *FakeBuildPlanner) CreateCallCount() int {
 	return len(fake.createArgsForCall)
 }
 
-func (fake *FakeBuildPlanner) CreateCalls(stub func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool) (atc.Plan, error)) {
+func (fake *FakeBuildPlanner) CreateCalls(stub func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags) (atc.Plan, error)) {
 	fake.createMutex.Lock()
 	defer fake.createMutex.Unlock()
 	fake.CreateStub = stub
 }
 
-func (fake *FakeBuildPlanner) CreateArgsForCall(i int) (atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool) {
+func (fake *FakeBuildPlanner) CreateArgsForCall(i int) (atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags) {
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	argsForCall := fake.createArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
 }
 
 func (fake *FakeBuildPlanner) CreateReturns(result1 atc.Plan, result2 error) {

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -413,6 +413,7 @@ func (step *TryStep) Visit(v StepVisitor) error {
 
 type DoStep struct {
 	Steps []Step `json:"do"`
+	Tags  Tags   `json:"tags,omitempty"`
 }
 
 func (step *DoStep) Visit(v StepVisitor) error {
@@ -421,6 +422,7 @@ func (step *DoStep) Visit(v StepVisitor) error {
 
 type InParallelStep struct {
 	Config InParallelConfig `json:"in_parallel"`
+	Tags   Tags             `json:"tags,omitempty"`
 }
 
 func (step *InParallelStep) Visit(v StepVisitor) error {

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -280,6 +280,28 @@ var factoryTests = []StepTest{
 		},
 	},
 	{
+		Title: "do step with tags",
+
+		ConfigYAML: `
+			tags: [some-tag]
+			do:
+			- load_var: some-var
+			  file: some-file
+		`,
+
+		StepConfig: &atc.DoStep{
+			Tags: atc.Tags{"some-tag"},
+			Steps: []atc.Step{
+				{
+					Config: &atc.LoadVarStep{
+						Name: "some-var",
+						File: "some-file",
+					},
+				},
+			},
+		},
+	},
+	{
 		Title: "in_parallel step with simple list",
 
 		ConfigYAML: `
@@ -341,6 +363,30 @@ var factoryTests = []StepTest{
 				},
 				Limit:    3,
 				FailFast: true,
+			},
+		},
+	},
+	{
+		Title: "in_parallel step with tags",
+
+		ConfigYAML: `
+			tags: [some-tag]
+			in_parallel:
+			- load_var: some-var
+			  file: some-file
+		`,
+
+		StepConfig: &atc.InParallelStep{
+			Tags: atc.Tags{"some-tag"},
+			Config: atc.InParallelConfig{
+				Steps: []atc.Step{
+					{
+						Config: &atc.LoadVarStep{
+							Name: "some-var",
+							File: "some-file",
+						},
+					},
+				},
 			},
 		},
 	},


### PR DESCRIPTION
## Changes proposed by this PR

closes #371 

These are then passed down into all child steps. Child steps can override parent tags with their own tags.

Job-level tags are also passed into the job-level `on_*` hook steps.

Example pipeline using this new feature:
```yaml
resources:
  - name: v2
    type: mock
    source:
      initial_version: v1

  - name: v1
    type: mock
    source:
      initial_version: v2

jobs:
  - name: job-level
    tags: ["some-tag"] # job-level
    plan:
      - in_parallel:
        - get: v1
        - get: v2

  - name: parallel-step
    plan:
      - tags: ["some-tag"] # in_parallel step
        in_parallel:
        - get: v1
        - get: v2

  - name: do-step
    plan:
      - tags: ["some-tag"] # do step
        do:
        - get: v1
        - get: v2

  - name: child-steps-override
    plan:
      - tags: ["some-tag"]
        do:
        - get: v1
        - get: v2
          tags: ["other-tag"] # overriding parent tags
```

One thing that some users may want that I'm not implementing in this, is a way to **not** inherit the tags from a parent step. For users that want that, you'll have to structure your job plan in such a way that your desired step(s) does not receive the tags from the parent step. I think we've given enough tooling here to allow users to do that now.