### PR TITLE
Make aborting jobs faster when the worker disappears

### DIFF
--- a/atc/worker/gardenruntime/container.go
+++ b/atc/worker/gardenruntime/container.go
@@ -56,12 +56,18 @@ func (c Container) Run(_ context.Context, spec runtime.ProcessSpec, io runtime.P
 	if err != nil {
 		return nil, fmt.Errorf("get properties: %w", err)
 	}
-	// Using context.Background() since GardenContainer.Run uses the passed in
-	// ctx to stream the process output. Since we send a SIGTERM on ctx
-	// cancellation, using the same ctx for streaming results in those logs not
-	// showing up.
-	process, err := c.GardenContainer.Run(context.Background(), toGardenProcessSpec(spec, properties), toGardenProcessIO(io))
+	// GardenContainer.Run uses the passed in ctx to stream the process output,
+	// so we deliberately do NOT use the build's ctx here: cancelling it on
+	// abort would tear the stream down immediately and drop the logs emitted
+	// while the process handles the SIGTERM we send on cancellation.
+	//
+	// Instead we use our own cancellable context. It is only cancelled by
+	// Process.Wait as a last resort, to forcibly tear down the stream when a
+	// stalled/disconnected worker would otherwise make Wait block forever.
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	process, err := c.GardenContainer.Run(streamCtx, toGardenProcessSpec(spec, properties), toGardenProcessIO(io))
 	if err != nil {
+		cancelStream()
 		var exeNotFound garden.ExecutableNotFoundError
 		if errors.As(err, &exeNotFound) {
 			return nil, runtime.ExecutableNotFoundError{Message: exeNotFound.Message}
@@ -69,7 +75,7 @@ func (c Container) Run(_ context.Context, spec runtime.ProcessSpec, io runtime.P
 		return nil, fmt.Errorf("start process: %w", err)
 	}
 
-	return Process{GardenContainer: c.GardenContainer, GardenProcess: process}, nil
+	return Process{GardenContainer: c.GardenContainer, GardenProcess: process, cancelStream: cancelStream}, nil
 }
 
 func (c Container) Attach(_ context.Context, id string, io runtime.ProcessIO) (runtime.Process, error) {
@@ -81,16 +87,18 @@ func (c Container) Attach(_ context.Context, id string, io runtime.ProcessIO) (r
 		}
 	}
 
-	// Using context.Background() since GardenContainer.Attach uses the passed
-	// in ctx to stream the process output. Since we send a SIGTERM on ctx
-	// cancellation, using the same ctx for streaming results in those logs not
-	// showing up.
-	process, err := c.GardenContainer.Attach(context.Background(), id, toGardenProcessIO(io))
+	// Same as in Run(), we use our own cancellable context for streaming rather
+	// than the build's ctx, so that cancellation on abort doesn't drop the logs
+	// emitted while the process handles its SIGTERM. Process.Wait cancels it
+	// only as a last resort to unblock from a stalled/disconnected worker.
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	process, err := c.GardenContainer.Attach(streamCtx, id, toGardenProcessIO(io))
 	if err != nil {
+		cancelStream()
 		return nil, fmt.Errorf("attach to process: %w", err)
 	}
 
-	return Process{GardenContainer: c.GardenContainer, GardenProcess: process}, nil
+	return Process{GardenContainer: c.GardenContainer, GardenProcess: process, cancelStream: cancelStream}, nil
 }
 
 func (c Container) SetProperty(name string, value string) error {

--- a/atc/worker/gardenruntime/gclient/connection/stream_handler.go
+++ b/atc/worker/gardenruntime/gclient/connection/stream_handler.go
@@ -48,7 +48,10 @@ type waitReturn struct {
 }
 
 func (sh *streamHandler) wait(decoder *json.Decoder) <-chan waitReturn {
-	result := make(chan waitReturn)
+	// Buffered channel so that the goroutine can always deliver its result and
+	// exit, even when the consuming select in streamProcess has exited due to
+	// something like an abort
+	result := make(chan waitReturn, 1)
 	go func() {
 		for {
 			payload := &transport.ProcessPayload{}

--- a/atc/worker/gardenruntime/process.go
+++ b/atc/worker/gardenruntime/process.go
@@ -4,16 +4,31 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagerctx"
 	"github.com/concourse/concourse/atc/runtime"
 	"github.com/concourse/concourse/atc/worker/gardenruntime/gclient"
-	"github.com/hashicorp/go-multierror"
 )
+
+// How long Process.Wait waits for a process to exit after sending it a SIGTERM
+// (on abort) before forcibly tearing things down. This bounds aborts even when
+// the worker has disconnected: rather than blocking forever waiting for a
+// process stream that a dead worker will never complete, we force-kill and
+// cancel the stream once this elapses.
+var gardenProcessStopGracePeriod = 10 * time.Second
 
 type Process struct {
 	GardenContainer gclient.Container
 	GardenProcess   garden.Process
+
+	// cancelStream cancels the context that backs the process output stream.
+	// Cancelling it closes the underlying (possibly hung) connection, which
+	// unblocks GardenProcess.Wait. It may be nil for processes that were not
+	// created via Container.Run/Attach (e.g. ExitedProcess).
+	cancelStream context.CancelFunc
 }
 
 func (p Process) ID() string {
@@ -21,6 +36,12 @@ func (p Process) ID() string {
 }
 
 func (p Process) Wait(ctx context.Context) (runtime.ProcessResult, error) {
+	logger := lagerctx.FromContext(ctx).Session("process-wait")
+
+	if p.cancelStream != nil {
+		defer p.cancelStream()
+	}
+
 	type result struct {
 		exitStatus int
 		err        error
@@ -34,16 +55,43 @@ func (p Process) Wait(ctx context.Context) (runtime.ProcessResult, error) {
 
 	select {
 	case <-ctx.Done():
-		err := p.GardenContainer.Stop(false)
-		// TODO: forcibly stop after timeout?
-		<-waitResult
-		return runtime.ProcessResult{}, multierror.Append(ctx.Err(), err)
+		go p.gracefulStop(logger)
+
+		select {
+		case <-waitResult:
+			// Exited within the grace period.
+		case <-time.After(gardenProcessStopGracePeriod):
+			logger.Info("grace-period-expired-forcing-stop")
+			go p.forcefulStop(logger)
+			if p.cancelStream != nil {
+				p.cancelStream()
+			}
+
+			select {
+			case <-waitResult:
+			case <-time.After(gardenProcessStopGracePeriod):
+				logger.Info("forced-stop-timed-out-abandoning-wait")
+			}
+		}
+		return runtime.ProcessResult{}, ctx.Err()
 	case r := <-waitResult:
 		if r.err != nil {
 			return runtime.ProcessResult{}, fmt.Errorf("wait for process completion: %w", r.err)
 		}
 		p.GardenContainer.SetProperty(exitStatusPropertyName, strconv.Itoa(r.exitStatus))
 		return runtime.ProcessResult{ExitStatus: r.exitStatus}, nil
+	}
+}
+
+func (p Process) gracefulStop(logger lager.Logger) {
+	if err := p.GardenContainer.Stop(false); err != nil {
+		logger.Error("failed-to-stop-container", err)
+	}
+}
+
+func (p Process) forcefulStop(logger lager.Logger) {
+	if err := p.GardenContainer.Stop(true); err != nil {
+		logger.Error("failed-to-force-stop-container", err)
 	}
 }
 

--- a/atc/worker/gardenruntime/process_internal_test.go
+++ b/atc/worker/gardenruntime/process_internal_test.go
@@ -1,0 +1,134 @@
+package gardenruntime
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"code.cloudfoundry.org/garden/gardenfakes"
+	"github.com/concourse/concourse/atc/worker/gardenruntime/gclient/gclientfakes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Process.Wait", func() {
+	var (
+		fakeProcess   *gardenfakes.FakeProcess
+		fakeContainer *gclientfakes.FakeContainer
+		streamCtx     context.Context
+		cancelStream  context.CancelFunc
+		process       Process
+		origGrace     time.Duration
+	)
+
+	BeforeEach(func() {
+		origGrace = gardenProcessStopGracePeriod
+		gardenProcessStopGracePeriod = 50 * time.Millisecond
+
+		fakeProcess = new(gardenfakes.FakeProcess)
+		fakeContainer = new(gclientfakes.FakeContainer)
+		streamCtx, cancelStream = context.WithCancel(context.Background())
+
+		process = Process{
+			GardenContainer: fakeContainer,
+			GardenProcess:   fakeProcess,
+			cancelStream:    cancelStream,
+		}
+	})
+
+	AfterEach(func() {
+		gardenProcessStopGracePeriod = origGrace
+		cancelStream()
+	})
+
+	Context("when the worker has disconnected and the process never exits on its own", func() {
+		BeforeEach(func() {
+			// Simulate a disconnected worker: the wait only unblocks once the
+			// stream's context is cancelled, which in production closes the hung
+			// connection.
+			fakeProcess.WaitStub = func() (int, error) {
+				<-streamCtx.Done()
+				return 0, errors.New("stream closed")
+			}
+		})
+
+		It("forcibly stops the container and cancels the stream so Wait returns", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // abort
+
+			done := make(chan error, 1)
+			go func() {
+				defer GinkgoRecover()
+				_, err := process.Wait(ctx)
+				done <- err
+			}()
+
+			var err error
+			Eventually(done, 5*time.Second).Should(Receive(&err))
+			Expect(err).To(MatchError(context.Canceled))
+
+			Expect(streamCtx.Err()).To(HaveOccurred(), "expected the stream context to be cancelled")
+			Expect(fakeContainer.StopCallCount()).To(Equal(2), "expected SIGTERM then SIGKILL")
+			Expect(fakeContainer.StopArgsForCall(0)).To(BeFalse(), "first Stop should be graceful (kill=false)")
+			Expect(fakeContainer.StopArgsForCall(1)).To(BeTrue(), "second Stop should be forceful (kill=true)")
+		})
+	})
+
+	Context("when the process exits within the grace period after SIGTERM", func() {
+		var release chan struct{}
+
+		BeforeEach(func() {
+			gardenProcessStopGracePeriod = time.Second
+
+			release = make(chan struct{})
+			fakeProcess.WaitStub = func() (int, error) {
+				<-release
+				return 0, nil
+			}
+			// Let the process "handle" the SIGTERM and exit promptly.
+			fakeContainer.StopStub = func(kill bool) error {
+				close(release)
+				return nil
+			}
+		})
+
+		It("does not force-kill the container", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // abort
+
+			done := make(chan error, 1)
+			go func() {
+				defer GinkgoRecover()
+				_, err := process.Wait(ctx)
+				done <- err
+			}()
+
+			var err error
+			Eventually(done, 5*time.Second).Should(Receive(&err))
+			Expect(err).To(MatchError(context.Canceled))
+
+			Expect(fakeContainer.StopCallCount()).To(Equal(1), "expected a single graceful Stop")
+			Expect(fakeContainer.StopArgsForCall(0)).To(BeFalse(), "Stop should be graceful (kill=false)")
+		})
+	})
+
+	Context("when the process completes normally (no abort)", func() {
+		BeforeEach(func() {
+			fakeProcess.WaitReturns(42, nil)
+		})
+
+		It("records the exit status and releases the stream", func() {
+			result, err := process.Wait(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.ExitStatus).To(Equal(42))
+
+			Expect(fakeContainer.SetPropertyCallCount()).To(Equal(1))
+			name, value := fakeContainer.SetPropertyArgsForCall(0)
+			Expect(name).To(Equal(exitStatusPropertyName))
+			Expect(value).To(Equal("42"))
+
+			Expect(streamCtx.Err()).To(HaveOccurred(), "expected the stream context to be released on completion")
+			Expect(fakeContainer.StopCallCount()).To(Equal(0), "expected no Stop calls on normal completion")
+		})
+	})
+})

--- a/integration/internal/cmdtest/cmd.go
+++ b/integration/internal/cmdtest/cmd.go
@@ -67,6 +67,7 @@ func (cmd Cmd) ExpectExit(code int) Cmd {
 	return cmd
 }
 
+// Starts the command but does not wait for it to finish
 func (cmd Cmd) Start(t *testing.T, args ...string) *exec.Cmd {
 	execCmd, err := cmd.TryStart(args...)
 	if err != nil {
@@ -75,6 +76,7 @@ func (cmd Cmd) Start(t *testing.T, args ...string) *exec.Cmd {
 	return execCmd
 }
 
+// Runs a command to completion and fails the test if the exit code is not zero
 func (cmd Cmd) Run(t *testing.T, args ...string) {
 	err := cmd.Try(args...)
 	if err != nil {
@@ -91,6 +93,7 @@ func (cmd Cmd) Run(t *testing.T, args ...string) {
 	}
 }
 
+// Runs the command to completion and returns its stdout
 func (cmd Cmd) Output(t *testing.T, args ...string) string {
 	buf := new(bytes.Buffer)
 	cmd.Stdout = buf

--- a/integration/worker/abort_test.go
+++ b/integration/worker/abort_test.go
@@ -1,0 +1,40 @@
+package worker_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/concourse/concourse/integration/internal/dctest"
+	"github.com/concourse/concourse/integration/internal/flytest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbort_WorkerDisappears(t *testing.T) {
+	t.Parallel()
+
+	dc := dctest.Init(t, "../docker-compose.yml")
+	dc.Run(t, "up", "-d")
+
+	fly := flytest.Init(t, dc)
+	fly.Run(t, "set-pipeline", "-n", "-c", "pipelines/wait.yml", "-p", "test")
+	fly.Run(t, "unpause-pipeline", "-p", "test")
+
+	buf := new(Buffer)
+	tjCmd := fly.OutputTo(buf).Start(t, "trigger-job", "-j", "test/wait", "--watch")
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.buffer.String(), "waiting for /tmp/stop-waiting to exist")
+	}, 1*time.Minute, 1*time.Second)
+
+	dc.Run(t, "rm", "--stop", "worker")
+
+	fly.Run(t, "abort-build", "-j", "test/wait", "-b", "1")
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Contains(c, buf.String(), "interrupted")
+	}, 1*time.Minute, 1*time.Second)
+
+	err := tjCmd.Wait()
+	require.Error(t, err)
+}

--- a/integration/worker/pipelines/wait.yml
+++ b/integration/worker/pipelines/wait.yml
@@ -1,0 +1,20 @@
+jobs:
+  - name: wait
+    plan:
+      - task: wait
+        config:
+          platform: linux
+
+          image_resource:
+            type: mock
+            source: { mirror_self: true }
+
+          run:
+            path: sh
+            args:
+              - -c
+              - |
+                until test -f /tmp/stop-waiting; do
+                  echo 'waiting for /tmp/stop-waiting to exist'
+                  sleep 1
+                done


### PR DESCRIPTION
## Changes proposed by this PR

This is covering the case where a build is running and the worker it's running on disappears. In this case the web node would eventually error after ~5mins due to the GardenRequest timeout. If a user tries to abort a build in such a state before the GardenRequest timeout, nothing will happen as we would get stuck waiting for GardenContainer.Stop() to hit its own 5min timeout.

We wrap these calls in a shorter timeout of 10s. In this scenario we know the user has called abort, so a shorter timeout makes sense to override GardenRequest's longer timeout of 5mins.

There is an integration tests that I've added which reproduces the abort state I observed on `master`.