### PR TITLE
add --force flag to fly's abort-build command

### DIFF
--- a/atc/api/builds_test.go
+++ b/atc/api/builds_test.go
@@ -1027,12 +1027,22 @@ var _ = Describe("Builds API", func() {
 	Describe("PUT /api/v1/builds/:build_id/abort", func() {
 		var (
 			response *http.Response
+			force    bool
 		)
+
+		BeforeEach(func() {
+			force = false
+		})
 
 		JustBeforeEach(func() {
 			var err error
 
-			req, err := http.NewRequest("PUT", server.URL+"/api/v1/builds/128/abort", nil)
+			url := server.URL + "/api/v1/builds/128/abort"
+			if force {
+				url += "?force="
+			}
+
+			req, err := http.NewRequest("PUT", url, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			response, err = client.Do(req)
@@ -1113,6 +1123,57 @@ var _ = Describe("Builds API", func() {
 
 						It("returns 204", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusNoContent))
+						})
+
+						It("does not finish the build", func() {
+							Expect(build.FinishCallCount()).To(Equal(0))
+						})
+
+						Context("when the force flag is set", func() {
+							BeforeEach(func() {
+								force = true
+								build.StatusReturns(db.BuildStatusStarted)
+							})
+
+							It("returns 204", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNoContent))
+							})
+
+							It("immediately marks the build as aborted", func() {
+								Expect(build.FinishCallCount()).To(Equal(1))
+								Expect(build.FinishArgsForCall(0)).To(Equal(db.BuildStatusAborted))
+							})
+
+							Context("when finishing the build fails", func() {
+								BeforeEach(func() {
+									build.FinishReturns(errors.New("nope"))
+								})
+
+								It("returns 500", func() {
+									Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+								})
+							})
+
+							Context("when the build is already finished", func() {
+								DescribeTableSubtree("", func(status db.BuildStatus) {
+									BeforeEach(func() {
+										build.StatusReturns(db.BuildStatusAborted)
+									})
+
+									It("doesn't mark the build as aborted again", func() {
+										Expect(build.FinishCallCount()).To(Equal(0))
+									})
+
+									It("returns 204", func() {
+										Expect(response.StatusCode).To(Equal(http.StatusNoContent))
+									})
+								},
+									Entry("build aborted", db.BuildStatusAborted),
+									Entry("build failed", db.BuildStatusFailed),
+									Entry("build errored", db.BuildStatusErrored),
+									Entry("build succeeded", db.BuildStatusSucceeded),
+								)
+							})
 						})
 					})
 				})

--- a/atc/api/buildserver/abort.go
+++ b/atc/api/buildserver/abort.go
@@ -3,6 +3,7 @@ package buildserver
 import (
 	"net/http"
 
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 )
 
@@ -15,6 +16,19 @@ func (s *Server) AbortBuild(build db.BuildForAPI) http.Handler {
 			aLog.Error("failed-to-abort-build", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
+		}
+
+		if _, force := r.URL.Query()[atc.AbortBuildForce]; force {
+			if build.Status() == db.BuildStatusPending || build.Status() == db.BuildStatusStarted {
+				// Don't wait for containers to be cleaned up. Mark the build as
+				// aborted immediately.
+				err := build.Finish(db.BuildStatusAborted)
+				if err != nil {
+					aLog.Error("failed-to-force-abort-build", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			}
 		}
 
 		w.WriteHeader(http.StatusNoContent)

--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -62,6 +62,7 @@ type BuildForAPI interface {
 	Preparation() (BuildPreparation, bool, error)
 
 	MarkAsAborted() error
+	Finish(BuildStatus) error
 	SetComment(string) error
 }
 

--- a/atc/db/build_in_memory_check.go
+++ b/atc/db/build_in_memory_check.go
@@ -243,6 +243,9 @@ func (b *inMemoryCheckBuildForApi) Resources() ([]BuildInput, []BuildOutput, err
 func (b *inMemoryCheckBuildForApi) MarkAsAborted() error {
 	return errors.New("not implemented for in memory build")
 }
+func (b *inMemoryCheckBuildForApi) Finish(status BuildStatus) error {
+	return errors.New("not implemented for in memory build")
+}
 func (b *inMemoryCheckBuildForApi) Preparation() (BuildPreparation, bool, error) {
 	return BuildPreparation{}, false, errors.New("not implemented for in memory build")
 }

--- a/atc/db/dbfakes/fake_build_for_api.go
+++ b/atc/db/dbfakes/fake_build_for_api.go
@@ -77,6 +77,17 @@ type FakeBuildForAPI struct {
 		result1 db.EventSource
 		result2 error
 	}
+	FinishStub        func(db.BuildStatus) error
+	finishMutex       sync.RWMutex
+	finishArgsForCall []struct {
+		arg1 db.BuildStatus
+	}
+	finishReturns struct {
+		result1 error
+	}
+	finishReturnsOnCall map[int]struct {
+		result1 error
+	}
 	HasPlanStub        func() bool
 	hasPlanMutex       sync.RWMutex
 	hasPlanArgsForCall []struct {
@@ -728,6 +739,67 @@ func (fake *FakeBuildForAPI) EventsReturnsOnCall(i int, result1 db.EventSource, 
 		result1 db.EventSource
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeBuildForAPI) Finish(arg1 db.BuildStatus) error {
+	fake.finishMutex.Lock()
+	ret, specificReturn := fake.finishReturnsOnCall[len(fake.finishArgsForCall)]
+	fake.finishArgsForCall = append(fake.finishArgsForCall, struct {
+		arg1 db.BuildStatus
+	}{arg1})
+	stub := fake.FinishStub
+	fakeReturns := fake.finishReturns
+	fake.recordInvocation("Finish", []interface{}{arg1})
+	fake.finishMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuildForAPI) FinishCallCount() int {
+	fake.finishMutex.RLock()
+	defer fake.finishMutex.RUnlock()
+	return len(fake.finishArgsForCall)
+}
+
+func (fake *FakeBuildForAPI) FinishCalls(stub func(db.BuildStatus) error) {
+	fake.finishMutex.Lock()
+	defer fake.finishMutex.Unlock()
+	fake.FinishStub = stub
+}
+
+func (fake *FakeBuildForAPI) FinishArgsForCall(i int) db.BuildStatus {
+	fake.finishMutex.RLock()
+	defer fake.finishMutex.RUnlock()
+	argsForCall := fake.finishArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeBuildForAPI) FinishReturns(result1 error) {
+	fake.finishMutex.Lock()
+	defer fake.finishMutex.Unlock()
+	fake.FinishStub = nil
+	fake.finishReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBuildForAPI) FinishReturnsOnCall(i int, result1 error) {
+	fake.finishMutex.Lock()
+	defer fake.finishMutex.Unlock()
+	fake.FinishStub = nil
+	if fake.finishReturnsOnCall == nil {
+		fake.finishReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.finishReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeBuildForAPI) HasPlan() bool {

--- a/atc/routes.go
+++ b/atc/routes.go
@@ -133,6 +133,7 @@ const (
 const (
 	ClearTaskCacheQueryPath = "cache_path"
 	SaveConfigCheckCreds    = "check_creds"
+	AbortBuildForce         = "force"
 )
 
 var Routes = rata.Routes([]rata.Route{

--- a/fly/commands/abort_build.go
+++ b/fly/commands/abort_build.go
@@ -15,6 +15,7 @@ type AbortBuildCommand struct {
 	Job   flaghelpers.JobFlag  `short:"j" long:"job" value-name:"PIPELINE/JOB"   description:"Name of a job to cancel"`
 	Build string               `short:"b" long:"build" required:"true" description:"If job is specified: build number to cancel. If job not specified: build id"`
 	Team  flaghelpers.TeamFlag `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Force bool                 `long:"force" description:"WARNING: Only use as a last resort! Try regular aborting first and wait 1min. Marks the build as aborted immediately and does not wait for the build's containers to stop."`
 }
 
 func (command *AbortBuildCommand) Execute([]string) error {
@@ -49,10 +50,14 @@ func (command *AbortBuildCommand) Execute([]string) error {
 		return fmt.Errorf("build does not exist")
 	}
 
-	if err := target.Client().AbortBuild(strconv.Itoa(build.ID)); err != nil {
+	if err := target.Client().AbortBuild(strconv.Itoa(build.ID), command.Force); err != nil {
 		return err
 	}
 
-	fmt.Println("build successfully aborted")
+	doneMsg := "build successfully aborted"
+	if command.Force {
+		doneMsg = "build forcefully aborted"
+	}
+	fmt.Println(doneMsg)
 	return nil
 }

--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -232,7 +232,7 @@ func abortOnSignal(
 
 	fmt.Fprintf(ui.Stderr, "\naborting...\n")
 
-	err := client.AbortBuild(strconv.Itoa(build.ID))
+	err := client.AbortBuild(strconv.Itoa(build.ID), false)
 	if err != nil {
 		fmt.Fprintln(ui.Stderr, "failed to abort:", err)
 		os.Exit(2)

--- a/fly/integration/abort_build_test.go
+++ b/fly/integration/abort_build_test.go
@@ -60,6 +60,39 @@ var _ = Describe("abort-build", func() {
 			})
 		})
 
+		Context("and the --force flag is specified", func() {
+			BeforeEach(func() {
+				expectedURL := "/api/v1/builds/23"
+
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", expectedURL),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuild),
+					),
+
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", expectedAbortURL, "force="),
+						ghttp.RespondWith(http.StatusNoContent, ""),
+					),
+				)
+			})
+
+			It("aborts the build with the force query param", func() {
+				Expect(func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "abort-build", "-b", "23", "--force")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+
+					Expect(sess.Out).To(gbytes.Say("build forcefully aborted"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(3))
+			})
+		})
+
 		Context("and the build id does not exist", func() {
 			BeforeEach(func() {
 				expectedURL := "/api/v1/builds/42"

--- a/go-concourse/concourse/builds.go
+++ b/go-concourse/concourse/builds.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/go-concourse/concourse/internal"
@@ -184,14 +185,20 @@ func (client *client) Builds(page Page) ([]atc.Build, Pagination, error) {
 	}
 }
 
-func (client *client) AbortBuild(buildID string) error {
+func (client *client) AbortBuild(buildID string, force bool) error {
 	params := rata.Params{
 		"build_id": buildID,
+	}
+
+	queryParams := url.Values{}
+	if force {
+		queryParams.Add(atc.AbortBuildForce, "")
 	}
 
 	return client.connection.Send(internal.Request{
 		RequestName: atc.AbortBuild,
 		Params:      params,
+		Query:       queryParams,
 	}, nil)
 }
 

--- a/go-concourse/concourse/builds_test.go
+++ b/go-concourse/concourse/builds_test.go
@@ -446,24 +446,48 @@ var _ = Describe("ATC Handler Builds", func() {
 	})
 
 	Describe("AbortBuild", func() {
-		BeforeEach(func() {
-			expectedURL := "/api/v1/builds/123/abort"
+		Context("without force", func() {
+			BeforeEach(func() {
+				expectedURL := "/api/v1/builds/123/abort"
 
-			atcServer.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("PUT", expectedURL),
-					ghttp.RespondWith(http.StatusNoContent, ""),
-				),
-			)
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", expectedURL),
+						ghttp.RespondWith(http.StatusNoContent, ""),
+					),
+				)
+			})
+
+			It("sends an abort request to ATC", func() {
+				Expect(func() {
+					err := client.AbortBuild("123", false)
+					Expect(err).NotTo(HaveOccurred())
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(1))
+			})
 		})
 
-		It("sends an abort request to ATC", func() {
-			Expect(func() {
-				err := client.AbortBuild("123")
-				Expect(err).NotTo(HaveOccurred())
-			}).To(Change(func() int {
-				return len(atcServer.ReceivedRequests())
-			}).By(1))
+		Context("with force", func() {
+			BeforeEach(func() {
+				expectedURL := "/api/v1/builds/123/abort"
+
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", expectedURL, "force="),
+						ghttp.RespondWith(http.StatusNoContent, ""),
+					),
+				)
+			})
+
+			It("sends an abort request to ATC with the force query param", func() {
+				Expect(func() {
+					err := client.AbortBuild("123", true)
+					Expect(err).NotTo(HaveOccurred())
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(1))
+			})
 		})
 	})
 

--- a/go-concourse/concourse/client.go
+++ b/go-concourse/concourse/client.go
@@ -20,7 +20,7 @@ type Client interface {
 	BuildEvents(buildID string) (Events, error)
 	BuildResources(buildID int) (atc.BuildInputsOutputs, bool, error)
 	ListBuildArtifacts(buildID string) ([]atc.WorkerArtifact, error)
-	AbortBuild(buildID string) error
+	AbortBuild(buildID string, force bool) error
 	BuildPlan(buildID int) (atc.PublicBuildPlan, bool, error)
 	SaveWorker(atc.Worker, *time.Duration) (*atc.Worker, error)
 	ListWorkers() ([]atc.Worker, error)

--- a/go-concourse/concourse/concoursefakes/fake_client.go
+++ b/go-concourse/concourse/concoursefakes/fake_client.go
@@ -12,10 +12,11 @@ import (
 )
 
 type FakeClient struct {
-	AbortBuildStub        func(string) error
+	AbortBuildStub        func(string, bool) error
 	abortBuildMutex       sync.RWMutex
 	abortBuildArgsForCall []struct {
 		arg1 string
+		arg2 bool
 	}
 	abortBuildReturns struct {
 		result1 error
@@ -381,18 +382,19 @@ type FakeClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) AbortBuild(arg1 string) error {
+func (fake *FakeClient) AbortBuild(arg1 string, arg2 bool) error {
 	fake.abortBuildMutex.Lock()
 	ret, specificReturn := fake.abortBuildReturnsOnCall[len(fake.abortBuildArgsForCall)]
 	fake.abortBuildArgsForCall = append(fake.abortBuildArgsForCall, struct {
 		arg1 string
-	}{arg1})
+		arg2 bool
+	}{arg1, arg2})
 	stub := fake.AbortBuildStub
 	fakeReturns := fake.abortBuildReturns
-	fake.recordInvocation("AbortBuild", []interface{}{arg1})
+	fake.recordInvocation("AbortBuild", []interface{}{arg1, arg2})
 	fake.abortBuildMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -406,17 +408,17 @@ func (fake *FakeClient) AbortBuildCallCount() int {
 	return len(fake.abortBuildArgsForCall)
 }
 
-func (fake *FakeClient) AbortBuildCalls(stub func(string) error) {
+func (fake *FakeClient) AbortBuildCalls(stub func(string, bool) error) {
 	fake.abortBuildMutex.Lock()
 	defer fake.abortBuildMutex.Unlock()
 	fake.AbortBuildStub = stub
 }
 
-func (fake *FakeClient) AbortBuildArgsForCall(i int) string {
+func (fake *FakeClient) AbortBuildArgsForCall(i int) (string, bool) {
 	fake.abortBuildMutex.RLock()
 	defer fake.abortBuildMutex.RUnlock()
 	argsForCall := fake.abortBuildArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) AbortBuildReturns(result1 error) {


### PR DESCRIPTION
## Changes proposed by this PR

**Users should NOT use this flag unless they've tried regular aborting first and it has failed to abort for more than 1min.**

When the API handler sees this flag set it'll go ahead and mark the build as aborted in the database. It still sends the abort command to the atc/engine running the build as usual, so container's in-flight still get interrupted and `on_*` hook steps still run.

This is meant to help resolve some edge-cases I've seen where builds are stuck "running", even though the worker(s) they were running on are very much dead and gone. In these situations the build is stuck in the running state and pressing abort does nothing. I've not been able to reproduce these cases (I have seen them myself two times over the years), but they are very frustrating as it feels like Concourse is just "hanging" dealing with these "zombie" builds. This `--force` will help users kill off these zombie builds.

This flag should only be used as a last resort. I did some testing to see what happens to normal in-flight builds. `on_*` hook steps still fire, but streaming logs does get a bit messed up if you look at them with `fly watch`. You won't get any logs after the "abort". If you look in the web UI you'll see any logs that happened after "abort". Not horrible and probably preferable to having the build stuck in a running state.

Visually here's what happens.

**Build aborted normally**
<img width="2812" height="1378" alt="image" src="https://github.com/user-attachments/assets/c048437a-59c0-4b6a-a10c-d534970fda4e" />

**Build aborted with `--force`**
<img width="2812" height="1384" alt="image" src="https://github.com/user-attachments/assets/e8505934-e6da-49fa-9ef6-99e52ea9fcd4" />

You can see the "interrupted" build event isn't logged. If you do `fly watch` on the `--force`'d build, you won't see any logs from the `on_*` hook steps either. I did confirm that in-flight containers are still interrupted though, so still gets you the end result desired.

I've added a warning message in the `--help` text for `fly abort-build` to urge users to do a regular abort first before trying again with `--force`.