### PR TITLE
Privileged mode `fuse-only` supports buildkit-based container building

### DIFF
--- a/worker/runtime/spec/seccomp.go
+++ b/worker/runtime/spec/seccomp.go
@@ -438,8 +438,21 @@ var fuse_syscalls = []specs.LinuxSyscall{
 			"umount",
 			"umount2",
 			"pidfd_getfd",
+			"keyctl",
+			"sethostname",
 		},
 		Action: specs.ActAllow,
+	},
+	{
+		// Allow setns only for mount namespaces (CLONE_NEWNS = 0x20000).
+		// This is needed for BuildKit/runc to join mount namespaces during
+		// image builds without allowing user namespace joins which could
+		// be used for container escape.
+		Names:  []string{"setns"},
+		Action: specs.ActAllow,
+		Args: []specs.LinuxSeccompArg{
+			{Index: 1, Value: unix.CLONE_NEWNS, Op: specs.OpEqualTo},
+		},
 	},
 }
 

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -588,6 +588,63 @@ func (s *SpecSuite) TestContainerSpec() {
 			},
 		},
 		{
+			desc: "seccomp allows setns for FUSE-only",
+			gdn: garden.ContainerSpec{
+				Handle: "handle", RootFSPath: "raw:///rootfs",
+				Privileged: true,
+			},
+			privilegedMode: spec.FUSEOnlyPrivilegedMode,
+			check: func(oci *specs.Spec) {
+				s.NotEmpty(oci.Linux.Seccomp)
+				var found bool
+				for _, syscall := range oci.Linux.Seccomp.Syscalls {
+					if slices.Contains(syscall.Names, "setns") && syscall.Action == specs.ActAllow {
+						found = true
+						break
+					}
+				}
+				s.True(found, "setns syscall should be allowed")
+			},
+		},
+		{
+			desc: "seccomp allows keyctl for FUSE-only",
+			gdn: garden.ContainerSpec{
+				Handle: "handle", RootFSPath: "raw:///rootfs",
+				Privileged: true,
+			},
+			privilegedMode: spec.FUSEOnlyPrivilegedMode,
+			check: func(oci *specs.Spec) {
+				s.NotEmpty(oci.Linux.Seccomp)
+				var found bool
+				for _, syscall := range oci.Linux.Seccomp.Syscalls {
+					if slices.Contains(syscall.Names, "keyctl") && syscall.Action == specs.ActAllow {
+						found = true
+						break
+					}
+				}
+				s.True(found, "keyctl syscall should be allowed")
+			},
+		},
+		{
+			desc: "seccomp allows sethostname for FUSE-only",
+			gdn: garden.ContainerSpec{
+				Handle: "handle", RootFSPath: "raw:///rootfs",
+				Privileged: true,
+			},
+			privilegedMode: spec.FUSEOnlyPrivilegedMode,
+			check: func(oci *specs.Spec) {
+				s.NotEmpty(oci.Linux.Seccomp)
+				var found bool
+				for _, syscall := range oci.Linux.Seccomp.Syscalls {
+					if slices.Contains(syscall.Names, "sethostname") && syscall.Action == specs.ActAllow {
+						found = true
+						break
+					}
+				}
+				s.True(found, "sethostname syscall should be allowed")
+			},
+		},
+		{
 			desc: "seccomp is empty for privileged",
 			gdn: garden.ContainerSpec{
 				Handle: "handle", RootFSPath: "raw:///rootfs",


### PR DESCRIPTION
## Problem

The fuse-only privileged mode introduced in #9017 does not work with
`oci-build-task` or any BuildKit-based image build. Any Dockerfile
containing a `RUN` step fails with:

  runc run failed: unable to start container process: error spawning
  mount remapping thread: mount source thread: join container mntns:
  setns: operation not permitted

This is because BuildKit's runc needs to join the container's mount
namespace for each `RUN` step, which requires `setns` — a syscall not
present in the fuse-only allowlist.

## Changes

Added three syscalls to `fuse_syscalls` in `worker/runtime/spec/seccomp.go`:

- **`setns`** — scoped to mount namespaces only via `OpEqualTo CLONE_NEWNS`
  (arg index 1). This allows runc to join mount namespaces for build steps
  without permitting user namespace joins, which would be the dangerous
  escalation path.
- **`keyctl`** — needed by runc container init to create and configure a
  session keyring. Kernel keyrings are session-scoped and cannot affect
  the host or other container sessions.
- **`sethostname`** — needed by runc container init. Operates within the
  container's own UTS namespace.

## Security verification

Tested inside a fuse-only privileged container after the change:

- `unshare --user` succeeds but produces `CapEff: 0000000000000000` —
  no capabilities gained
- `unshare --user sh -c "mount -t proc proc /tmp/x"` — blocked, mount
  inside a user namespace is not permitted
- `mount -t proc proc /tmp/escape` — blocked
- `echo h > /proc/sysrq-trigger` — blocked
- Host keyrings not visible (`/proc/keys` empty)
- `setns` to user namespace blocked by argument filter

The known container escape vectors remain closed. `unshare --user` is
permitted by the existing fuse_syscalls list but is harmless — the
resulting user namespace has zero capabilities and cannot mount.

## Testing

Verified end-to-end `oci-build-task` build with a Dockerfile containing
`RUN`, `COPY`, `ARG`, `WORKDIR`, `USER`, `ENTRYPOINT` and `LABEL` steps
succeeds under fuse-only mode. Only `RUN` steps were affected by the
missing syscalls — all other Dockerfile instructions work without changes
as they do not spawn container processes via runc.

## Pipeline used for the tests Before/After docker compose rebuild:
```yaml
---
resources:
- name: my-image
  type: registry-image
  source:
    repository: ((dockerhub_username))/test-image # create the Repo on DockerHub before running the pipeline
    tag: poc-oci-build
    username: ((dockerhub_username))
    password: ((dockerhub_password))

jobs:
- name: build-and-push
  plan:
  - task: create-dockerfile
    config:
      platform: linux
      image_resource:
        type: registry-image
        source:
          repository: busybox
      outputs:
      - name: build-context
      run:
        path: sh
        args:
        - -c
        - |
          cat > build-context/Dockerfile <<'EOF'
          FROM alpine
          ARG BUILD_VERSION=1.0.0
          LABEL test=poc-oci-build-task version=${BUILD_VERSION}
          WORKDIR /app
          COPY Dockerfile /app/Dockerfile
          RUN echo "Hello, World!" && echo "Build version: ${BUILD_VERSION}"
          USER nobody
          ENTRYPOINT ["echo", "container started"]
          EOF
          cp build-context/Dockerfile build-context/Dockerfile.bak

  - task: build
    privileged: true 
    config:
      platform: linux
      image_resource:
        type: registry-image
        source:
          repository: concourse/oci-build-task
      inputs:
      - name: build-context
        path: .
      outputs:
      - name: image
      run:
        path: build

  - put: my-image
    params:
      image: image/image.tar

```
Note: `#9017` was only tested with `buildah`/`podman`. This change extends
compatibility to BuildKit-based workflows.