### PR TITLE
add shared path support to credhub `CONCOURSE_CREDHUB_SHARED_PATH`

### DIFF
--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -306,6 +306,7 @@ var _ = Describe("Pipelines API", func() {
 					credhubManager := &credhub.CredHubManager{
 						URL:        credServer.URL(),
 						PathPrefix: "some-prefix",
+						SharedPath: "",
 						TLS:        tls,
 						UAA:        uaa,
 						Client:     &credhub.LazyCredhub{},
@@ -326,7 +327,8 @@ var _ = Describe("Pipelines API", func() {
 							"method": "/health"
 						},
 						"path_prefix": "some-prefix",
-						"uaa_client_id": "client-id"
+						"uaa_client_id": "client-id",
+						"shared_path": ""
 						}
 					}`))
 				})
@@ -345,6 +347,7 @@ var _ = Describe("Pipelines API", func() {
 							Method string `json:"method"`
 						} `json:"health"`
 						PathPrefix  string `json:"path_prefix"`
+						SharedPath  string `json:"shared_path"`
 						UAAClientId string `json:"uaa_client_id"`
 					} `json:"credhub"`
 				}
@@ -354,6 +357,7 @@ var _ = Describe("Pipelines API", func() {
 						URL:        "http://wrong.inexistent.tld",
 						PathPrefix: "some-prefix",
 						TLS:        tls,
+						SharedPath: "",
 						UAA:        uaa,
 						Client:     &credhub.LazyCredhub{},
 					}
@@ -371,6 +375,7 @@ var _ = Describe("Pipelines API", func() {
 					Expect(parsedResponse.CredHub.CACerts).To(BeEmpty())
 					Expect(parsedResponse.CredHub.PathPrefix).To(Equal("some-prefix"))
 					Expect(parsedResponse.CredHub.UAAClientId).To(Equal("client-id"))
+					Expect(parsedResponse.CredHub.SharedPath).To(Equal(""))
 					Expect(parsedResponse.CredHub.Health.Response).ToNot(BeNil())
 					Expect(parsedResponse.CredHub.Health.Response.Status).To(BeEmpty())
 					Expect(parsedResponse.CredHub.Health.Method).To(Equal("/health"))

--- a/atc/creds/credhub/credhub.go
+++ b/atc/creds/credhub/credhub.go
@@ -11,9 +11,10 @@ import (
 )
 
 type CredHubAtc struct {
-	CredHub *LazyCredhub
-	logger  lager.Logger
-	prefix  string
+	CredHub    *LazyCredhub
+	logger     lager.Logger
+	prefix     string
+	sharedPath string
 }
 
 // NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
@@ -25,6 +26,9 @@ func (c CredHubAtc) NewSecretLookupPaths(teamName string, pipelineName string, a
 	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(c.prefix, teamName)+"/"))
 	if allowRootPath {
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(c.prefix+"/"))
+	}
+	if c.sharedPath != "" {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(c.sharedPath+"/"))
 	}
 	return lookupPaths
 }

--- a/atc/creds/credhub/credhub.go
+++ b/atc/creds/credhub/credhub.go
@@ -28,7 +28,7 @@ func (c CredHubAtc) NewSecretLookupPaths(teamName string, pipelineName string, a
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(c.prefix+"/"))
 	}
 	if c.sharedPath != "" {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(c.sharedPath+"/"))
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(c.prefix, c.sharedPath)+"/"))
 	}
 	return lookupPaths
 }

--- a/atc/creds/credhub/credhub_factory.go
+++ b/atc/creds/credhub/credhub_factory.go
@@ -6,23 +6,26 @@ import (
 )
 
 type credhubFactory struct {
-	credhub *LazyCredhub
-	logger  lager.Logger
-	prefix  string
+	credhub    *LazyCredhub
+	logger     lager.Logger
+	prefix     string
+	sharedPath string
 }
 
-func NewCredHubFactory(logger lager.Logger, credhub *LazyCredhub, prefix string) *credhubFactory {
+func NewCredHubFactory(logger lager.Logger, credhub *LazyCredhub, prefix string, sharedPath string) *credhubFactory {
 	return &credhubFactory{
-		credhub: credhub,
-		logger:  logger,
-		prefix:  prefix,
+		credhub:    credhub,
+		logger:     logger,
+		prefix:     prefix,
+		sharedPath: sharedPath,
 	}
 }
 
 func (factory *credhubFactory) NewSecrets() creds.Secrets {
 	return &CredHubAtc{
-		CredHub: factory.credhub,
-		logger:  factory.logger,
-		prefix:  factory.prefix,
+		CredHub:    factory.credhub,
+		logger:     factory.logger,
+		prefix:     factory.prefix,
+		sharedPath: factory.sharedPath,
 	}
 }

--- a/atc/creds/credhub/manager.go
+++ b/atc/creds/credhub/manager.go
@@ -18,6 +18,8 @@ type CredHubManager struct {
 
 	PathPrefix string `long:"path-prefix" default:"/concourse" description:"Path under which to namespace credential lookup."`
 
+	SharedPath string `long:"shared-path" description:"CredHub parameter path used for shared parameters"`
+
 	TLS    TLS
 	UAA    UAA
 	Client *LazyCredhub
@@ -46,6 +48,7 @@ func (manager *CredHubManager) MarshalJSON() ([]byte, error) {
 		"path_prefix":   manager.PathPrefix,
 		"ca_certs":      manager.TLS.CACerts,
 		"uaa_client_id": manager.UAA.ClientId,
+		"shared_path":   manager.SharedPath,
 		"health":        health,
 	}
 
@@ -149,7 +152,7 @@ func (manager CredHubManager) Health() (*creds.HealthResponse, error) {
 }
 
 func (manager CredHubManager) NewSecretsFactory(logger lager.Logger) (creds.SecretsFactory, error) {
-	return NewCredHubFactory(logger, manager.Client, manager.PathPrefix), nil
+	return NewCredHubFactory(logger, manager.Client, manager.PathPrefix, manager.SharedPath), nil
 }
 
 type LazyCredhub struct {

--- a/atc/creds/credhub/manager.go
+++ b/atc/creds/credhub/manager.go
@@ -18,7 +18,7 @@ type CredHubManager struct {
 
 	PathPrefix string `long:"path-prefix" default:"/concourse" description:"Path under which to namespace credential lookup."`
 
-	SharedPath string `long:"shared-path" description:"CredHub parameter path used for shared parameters"`
+	SharedPath string `long:"shared-path" description:"Path under which to lookup shared credentials."`
 
 	TLS    TLS
 	UAA    UAA


### PR DESCRIPTION
## Changes proposed by this PR

As of now, it is not possible to configure shared paths for Credhub cred manager as opposed to other cred managers such as Vault,AWS. So I propose to add a new parameter --credhub-shared-path similar to the Vault cred manager. This parameter can be optional (as with Vault). This PR provides all the changes needed for this functionality.

### Notes to reviewer

Release Note

    Added `--credhub-shared-path` to configure shared secret paths for Credhub cred manager similarly to the one for Vault, SSM.

PR is for the issue: #9062 