### PR TITLE
fix: Resource cache cleanup errors with Postgresql 18

### DIFF
--- a/atc/db/pg_error.go
+++ b/atc/db/pg_error.go
@@ -1,0 +1,15 @@
+package db
+
+import (
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func isForeignKeyOrRestrictViolation(err error) bool {
+	pgErr, ok := err.(*pgconn.PgError)
+	if !ok {
+		return false
+	}
+
+	return pgErr.Code == pgerrcode.ForeignKeyViolation || pgErr.Code == pgerrcode.RestrictViolation
+}

--- a/atc/db/resource_cache_lifecycle.go
+++ b/atc/db/resource_cache_lifecycle.go
@@ -3,9 +3,6 @@ package db
 import (
 	"strings"
 
-	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
-
 	"code.cloudfoundry.org/lager/v3"
 	sq "github.com/Masterminds/squirrel"
 )
@@ -146,7 +143,7 @@ func (f *resourceCacheLifecycle) CleanUpInvalidCaches(logger lager.Logger) error
 
 	rows, err := f.conn.Query(query, args...)
 	if err != nil {
-		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.ForeignKeyViolation {
+		if isForeignKeyOrRestrictViolation(err) {
 			// this can happen if a use or resource cache is created referencing the
 			// config; as the subqueries above are not atomic
 			return nil

--- a/atc/db/resource_cache_test.go
+++ b/atc/db/resource_cache_test.go
@@ -1,9 +1,10 @@
 package db_test
 
 import (
+	"time"
+
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
-	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
@@ -58,7 +59,7 @@ var _ = Describe("ResourceCache", func() {
 			// ON DELETE RESTRICT from resource_cache_uses -> resource_caches
 			_, err = psql.Delete("resource_caches").Where(sq.Eq{"id": urc.ID()}).RunWith(dbConn).Exec()
 			Expect(err).To(HaveOccurred())
-			Expect(err.(*pgconn.PgError).Code).To(Equal(pgerrcode.ForeignKeyViolation))
+			Expect(err.(*pgconn.PgError).Code).To(BeElementOf(pgerrcode.ForeignKeyViolation, pgerrcode.RestrictViolation))
 		})
 
 		Context("when it already exists", func() {
@@ -114,7 +115,7 @@ var _ = Describe("ResourceCache", func() {
 			// ON DELETE RESTRICT from resource_cache_uses -> resource_caches
 			_, err = psql.Delete("resource_caches").Where(sq.Eq{"id": urc.ID()}).RunWith(dbConn).Exec()
 			Expect(err).To(HaveOccurred())
-			Expect(err.(*pgconn.PgError).Code).To(Equal(pgerrcode.ForeignKeyViolation))
+			Expect(err.(*pgconn.PgError).Code).To(BeElementOf(pgerrcode.ForeignKeyViolation, pgerrcode.RestrictViolation))
 		})
 	})
 })

--- a/atc/db/resource_config_factory.go
+++ b/atc/db/resource_config_factory.go
@@ -6,9 +6,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jackc/pgerrcode"
-	"github.com/jackc/pgx/v5/pgconn"
-
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db/lock"
@@ -272,7 +269,7 @@ func (f *resourceConfigFactory) CleanUnreferencedConfigs(gracePeriod time.Durati
 		PlaceholderFormat(sq.Dollar).
 		RunWith(f.conn).Exec()
 	if err != nil {
-		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == pgerrcode.ForeignKeyViolation {
+		if isForeignKeyOrRestrictViolation(err) {
 			// this can happen if a use or resource cache is created referencing the
 			// config; as the subqueries above are not atomic
 			return nil


### PR DESCRIPTION
## Changes proposed by this PR

closes #9619 

* created a new `pg_error.go` file, which has a method `isForeignKeyOrRestrictViolation` that checks if a PostgreSQL error is either a `ForeignKeyViolation` or `RestrictViolation`, as  PostgreSQL 18 changed the error code returned for ON DELETE RESTRICT violations from ForeignKeyViolation (23503) to RestrictViolation (23001)
* Browsed trough code and modified `atc/db/resource_cache_lifecycle.go`, `atc/db/resource_config_factory.go` and `atc/db/resource_cache_test.go`