### PR TITLE
Fix: Jobs stuck in pending state until resource manually checked or check interval elapsed

### DIFF
--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -27,6 +27,7 @@ type Checkable interface {
 	CheckEvery() *atc.CheckEvery
 	CheckTimeout() string
 	LastCheckEndTime() time.Time
+	NextCheckTime() time.Time
 	CurrentPinnedVersion() atc.Version
 
 	HasWebhook() bool
@@ -130,7 +131,7 @@ func (c *checkFactory) TryCreateCheck(ctx context.Context, checkable Checkable, 
 	}
 
 	skipInterval := manuallyTriggered
-	if !skipInterval && time.Now().Before(checkable.LastCheckEndTime().Add(interval.Interval)) {
+	if !skipInterval && time.Now().Before(checkable.NextCheckTime()) {
 		// skip creating the check if its interval hasn't elapsed yet
 		return nil, false, nil
 	}

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -166,7 +166,7 @@ var _ = Describe("CheckFactory", func() {
 
 				Context("when the interval has not elapsed", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(defaultCheckInterval))
+						fakeResource.NextCheckTimeReturns(time.Now().Add(defaultCheckInterval))
 					})
 
 					It("does not create a build for the resource", func() {
@@ -215,7 +215,7 @@ var _ = Describe("CheckFactory", func() {
 
 				Context("when the default webhook interval has not elapsed", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-(defaultWebhookCheckInterval / 2)))
+						fakeResource.NextCheckTimeReturns(time.Now().Add(defaultWebhookCheckInterval))
 					})
 
 					It("does not create a build for the resource", func() {
@@ -266,7 +266,7 @@ var _ = Describe("CheckFactory", func() {
 
 				Context("when the checkable's interval has elapsed", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-defaultCheckInterval))
+						fakeResource.NextCheckTimeReturns(time.Now().Add(-defaultCheckInterval))
 					})
 
 					It("creates a check plan", func() {

--- a/atc/db/dbfakes/fake_checkable.go
+++ b/atc/db/dbfakes/fake_checkable.go
@@ -121,6 +121,16 @@ type FakeCheckable struct {
 	nameReturnsOnCall map[int]struct {
 		result1 string
 	}
+	NextCheckTimeStub        func() time.Time
+	nextCheckTimeMutex       sync.RWMutex
+	nextCheckTimeArgsForCall []struct {
+	}
+	nextCheckTimeReturns struct {
+		result1 time.Time
+	}
+	nextCheckTimeReturnsOnCall map[int]struct {
+		result1 time.Time
+	}
 	PipelineStub        func() (db.Pipeline, bool, error)
 	pipelineMutex       sync.RWMutex
 	pipelineArgsForCall []struct {
@@ -756,6 +766,59 @@ func (fake *FakeCheckable) NameReturnsOnCall(i int, result1 string) {
 	}
 	fake.nameReturnsOnCall[i] = struct {
 		result1 string
+	}{result1}
+}
+
+func (fake *FakeCheckable) NextCheckTime() time.Time {
+	fake.nextCheckTimeMutex.Lock()
+	ret, specificReturn := fake.nextCheckTimeReturnsOnCall[len(fake.nextCheckTimeArgsForCall)]
+	fake.nextCheckTimeArgsForCall = append(fake.nextCheckTimeArgsForCall, struct {
+	}{})
+	stub := fake.NextCheckTimeStub
+	fakeReturns := fake.nextCheckTimeReturns
+	fake.recordInvocation("NextCheckTime", []interface{}{})
+	fake.nextCheckTimeMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeCheckable) NextCheckTimeCallCount() int {
+	fake.nextCheckTimeMutex.RLock()
+	defer fake.nextCheckTimeMutex.RUnlock()
+	return len(fake.nextCheckTimeArgsForCall)
+}
+
+func (fake *FakeCheckable) NextCheckTimeCalls(stub func() time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = stub
+}
+
+func (fake *FakeCheckable) NextCheckTimeReturns(result1 time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = nil
+	fake.nextCheckTimeReturns = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakeCheckable) NextCheckTimeReturnsOnCall(i int, result1 time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = nil
+	if fake.nextCheckTimeReturnsOnCall == nil {
+		fake.nextCheckTimeReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+		})
+	}
+	fake.nextCheckTimeReturnsOnCall[i] = struct {
+		result1 time.Time
 	}{result1}
 }
 

--- a/atc/db/dbfakes/fake_prototype.go
+++ b/atc/db/dbfakes/fake_prototype.go
@@ -151,6 +151,16 @@ type FakePrototype struct {
 	nameReturnsOnCall map[int]struct {
 		result1 string
 	}
+	NextCheckTimeStub        func() time.Time
+	nextCheckTimeMutex       sync.RWMutex
+	nextCheckTimeArgsForCall []struct {
+	}
+	nextCheckTimeReturns struct {
+		result1 time.Time
+	}
+	nextCheckTimeReturnsOnCall map[int]struct {
+		result1 time.Time
+	}
 	ParamsStub        func() atc.Params
 	paramsMutex       sync.RWMutex
 	paramsArgsForCall []struct {
@@ -1008,6 +1018,59 @@ func (fake *FakePrototype) NameReturnsOnCall(i int, result1 string) {
 	}
 	fake.nameReturnsOnCall[i] = struct {
 		result1 string
+	}{result1}
+}
+
+func (fake *FakePrototype) NextCheckTime() time.Time {
+	fake.nextCheckTimeMutex.Lock()
+	ret, specificReturn := fake.nextCheckTimeReturnsOnCall[len(fake.nextCheckTimeArgsForCall)]
+	fake.nextCheckTimeArgsForCall = append(fake.nextCheckTimeArgsForCall, struct {
+	}{})
+	stub := fake.NextCheckTimeStub
+	fakeReturns := fake.nextCheckTimeReturns
+	fake.recordInvocation("NextCheckTime", []interface{}{})
+	fake.nextCheckTimeMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePrototype) NextCheckTimeCallCount() int {
+	fake.nextCheckTimeMutex.RLock()
+	defer fake.nextCheckTimeMutex.RUnlock()
+	return len(fake.nextCheckTimeArgsForCall)
+}
+
+func (fake *FakePrototype) NextCheckTimeCalls(stub func() time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = stub
+}
+
+func (fake *FakePrototype) NextCheckTimeReturns(result1 time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = nil
+	fake.nextCheckTimeReturns = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakePrototype) NextCheckTimeReturnsOnCall(i int, result1 time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = nil
+	if fake.nextCheckTimeReturnsOnCall == nil {
+		fake.nextCheckTimeReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+		})
+	}
+	fake.nextCheckTimeReturnsOnCall[i] = struct {
+		result1 time.Time
 	}{result1}
 }
 

--- a/atc/db/dbfakes/fake_resource_type.go
+++ b/atc/db/dbfakes/fake_resource_type.go
@@ -163,6 +163,16 @@ type FakeResourceType struct {
 	nameReturnsOnCall map[int]struct {
 		result1 string
 	}
+	NextCheckTimeStub        func() time.Time
+	nextCheckTimeMutex       sync.RWMutex
+	nextCheckTimeArgsForCall []struct {
+	}
+	nextCheckTimeReturns struct {
+		result1 time.Time
+	}
+	nextCheckTimeReturnsOnCall map[int]struct {
+		result1 time.Time
+	}
 	ParamsStub        func() atc.Params
 	paramsMutex       sync.RWMutex
 	paramsArgsForCall []struct {
@@ -1078,6 +1088,59 @@ func (fake *FakeResourceType) NameReturnsOnCall(i int, result1 string) {
 	}
 	fake.nameReturnsOnCall[i] = struct {
 		result1 string
+	}{result1}
+}
+
+func (fake *FakeResourceType) NextCheckTime() time.Time {
+	fake.nextCheckTimeMutex.Lock()
+	ret, specificReturn := fake.nextCheckTimeReturnsOnCall[len(fake.nextCheckTimeArgsForCall)]
+	fake.nextCheckTimeArgsForCall = append(fake.nextCheckTimeArgsForCall, struct {
+	}{})
+	stub := fake.NextCheckTimeStub
+	fakeReturns := fake.nextCheckTimeReturns
+	fake.recordInvocation("NextCheckTime", []interface{}{})
+	fake.nextCheckTimeMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeResourceType) NextCheckTimeCallCount() int {
+	fake.nextCheckTimeMutex.RLock()
+	defer fake.nextCheckTimeMutex.RUnlock()
+	return len(fake.nextCheckTimeArgsForCall)
+}
+
+func (fake *FakeResourceType) NextCheckTimeCalls(stub func() time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = stub
+}
+
+func (fake *FakeResourceType) NextCheckTimeReturns(result1 time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = nil
+	fake.nextCheckTimeReturns = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakeResourceType) NextCheckTimeReturnsOnCall(i int, result1 time.Time) {
+	fake.nextCheckTimeMutex.Lock()
+	defer fake.nextCheckTimeMutex.Unlock()
+	fake.NextCheckTimeStub = nil
+	if fake.nextCheckTimeReturnsOnCall == nil {
+		fake.nextCheckTimeReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+		})
+	}
+	fake.nextCheckTimeReturnsOnCall[i] = struct {
+		result1 time.Time
 	}{result1}
 }
 

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -504,7 +504,7 @@ func (builder Builder) WithResourceTypeVersions(resourceTypeName string, version
 			return fmt.Errorf("save versions: %w", err)
 		}
 
-		resourceType.SetResourceConfigScope(scope)
+		err = resourceType.SetResourceConfigScope(scope)
 		if err != nil {
 			return fmt.Errorf("set resource scope: %w", err)
 		}
@@ -595,7 +595,7 @@ func (builder Builder) WithPrototypeVersions(prototypeName string, versions ...a
 			return fmt.Errorf("save versions: %w", err)
 		}
 
-		prototype.SetResourceConfigScope(scope)
+		err = prototype.SetResourceConfigScope(scope)
 		if err != nil {
 			return fmt.Errorf("set resource scope: %w", err)
 		}

--- a/atc/db/prototype.go
+++ b/atc/db/prototype.go
@@ -33,6 +33,7 @@ type Prototype interface {
 	CheckTimeout() string
 	LastCheckStartTime() time.Time
 	LastCheckEndTime() time.Time
+	NextCheckTime() time.Time
 	CurrentPinnedVersion() atc.Version
 	ResourceConfigID() int
 	ResourceConfigScopeID() int
@@ -88,6 +89,7 @@ var prototypesQuery = psql.Select(
 	"ro.id",
 	"ro.last_check_start_time",
 	"ro.last_check_end_time",
+	"ro.next_check_time",
 ).
 	From("prototypes pt").
 	Join("pipelines p ON p.id = pt.pipeline_id").
@@ -102,6 +104,9 @@ var prototypesQuery = psql.Select(
 		LIMIT 1
 	) AS rcv ON true`).
 	Where(sq.Eq{"pt.active": true})
+
+var _ Prototype = (*prototype)(nil)
+var _ Checkable = (*prototype)(nil)
 
 type prototype struct {
 	pipelineRef
@@ -122,6 +127,7 @@ type prototype struct {
 	checkEvery            *atc.CheckEvery
 	lastCheckStartTime    time.Time
 	lastCheckEndTime      time.Time
+	nextCheckTime         time.Time
 }
 
 func (p *prototype) ID() int                       { return p.id }
@@ -134,6 +140,7 @@ func (p *prototype) CheckEvery() *atc.CheckEvery   { return p.checkEvery }
 func (p *prototype) CheckTimeout() string          { return "" }
 func (p *prototype) LastCheckStartTime() time.Time { return p.lastCheckStartTime }
 func (p *prototype) LastCheckEndTime() time.Time   { return p.lastCheckEndTime }
+func (p *prototype) NextCheckTime() time.Time      { return p.nextCheckTime }
 func (p *prototype) Source() atc.Source            { return p.source }
 func (p *prototype) Defaults() atc.Source          { return p.defaults }
 func (p *prototype) Params() atc.Params            { return p.params }
@@ -249,20 +256,21 @@ func (p *prototype) CreateInMemoryBuild(context.Context, atc.Plan, util.Sequence
 
 func scanPrototype(p *prototype, row scannable) error {
 	var (
-		configJSON                           sql.NullString
-		rcsID, version, nonce                sql.NullString
-		lastCheckStartTime, lastCheckEndTime sql.NullTime
-		pipelineInstanceVars                 sql.NullString
-		resourceConfigID                     sql.NullInt64
+		configJSON                                          sql.NullString
+		rcsID, version, nonce                               sql.NullString
+		lastCheckStartTime, lastCheckEndTime, nextCheckTime sql.NullTime
+		pipelineInstanceVars                                sql.NullString
+		resourceConfigID                                    sql.NullInt64
 	)
 
-	err := row.Scan(&p.id, &p.pipelineID, &p.name, &p.type_, &configJSON, &version, &nonce, &p.pipelineName, &pipelineInstanceVars, &p.teamID, &p.teamName, &resourceConfigID, &rcsID, &lastCheckStartTime, &lastCheckEndTime)
+	err := row.Scan(&p.id, &p.pipelineID, &p.name, &p.type_, &configJSON, &version, &nonce, &p.pipelineName, &pipelineInstanceVars, &p.teamID, &p.teamName, &resourceConfigID, &rcsID, &lastCheckStartTime, &lastCheckEndTime, &nextCheckTime)
 	if err != nil {
 		return err
 	}
 
 	p.lastCheckStartTime = lastCheckStartTime.Time
 	p.lastCheckEndTime = lastCheckEndTime.Time
+	p.nextCheckTime = nextCheckTime.Time
 
 	if version.Valid {
 		err = json.Unmarshal([]byte(version.String), &p.version)

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -13,9 +13,10 @@ import (
 )
 
 type LastCheck struct {
-	StartTime time.Time
-	EndTime   time.Time
-	Succeeded bool
+	StartTime     time.Time
+	EndTime       time.Time
+	NextCheckTime time.Time
+	Succeeded     bool
 }
 
 //counterfeiter:generate . ResourceConfigScope
@@ -61,22 +62,23 @@ func (r *resourceConfigScope) ResourceID() *int               { return r.resourc
 func (r *resourceConfigScope) ResourceConfig() ResourceConfig { return r.resourceConfig }
 
 func (r *resourceConfigScope) LastCheck() (LastCheck, error) {
-	var lastCheckStartTime, lastCheckEndTime time.Time
+	var lastCheckStartTime, lastCheckEndTime, nextCheckTime time.Time
 	var lastCheckSucceeded bool
-	err := psql.Select("last_check_start_time", "last_check_end_time", "last_check_succeeded").
+	err := psql.Select("last_check_start_time", "last_check_end_time", "last_check_succeeded", "next_check_time").
 		From("resource_config_scopes").
 		Where(sq.Eq{"id": r.id}).
 		RunWith(r.conn).
 		QueryRow().
-		Scan(&lastCheckStartTime, &lastCheckEndTime, &lastCheckSucceeded)
+		Scan(&lastCheckStartTime, &lastCheckEndTime, &lastCheckSucceeded, &nextCheckTime)
 	if err != nil {
 		return LastCheck{}, err
 	}
 
 	return LastCheck{
-		StartTime: lastCheckStartTime,
-		EndTime:   lastCheckEndTime,
-		Succeeded: lastCheckSucceeded,
+		StartTime:     lastCheckStartTime,
+		EndTime:       lastCheckEndTime,
+		NextCheckTime: nextCheckTime,
+		Succeeded:     lastCheckSucceeded,
 	}, nil
 }
 

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -41,6 +41,7 @@ type ResourceType interface {
 	CheckTimeout() string
 	LastCheckStartTime() time.Time
 	LastCheckEndTime() time.Time
+	NextCheckTime() time.Time
 	CurrentPinnedVersion() atc.Version
 	ResourceConfigID() int
 	ResourceConfigScopeID() int
@@ -162,6 +163,7 @@ var resourceTypesQuery = psql.Select(
 	"ro.id",
 	"ro.last_check_start_time",
 	"ro.last_check_end_time",
+	"ro.next_check_time",
 ).
 	From("resource_types r").
 	Join("pipelines p ON p.id = r.pipeline_id").
@@ -169,6 +171,9 @@ var resourceTypesQuery = psql.Select(
 	LeftJoin("resource_configs c ON c.id = r.resource_config_id").
 	LeftJoin("resource_config_scopes ro ON ro.resource_config_id = c.id AND ro.resource_id IS NULL").
 	Where(sq.Eq{"r.active": true})
+
+var _ ResourceType = (*resourceType)(nil)
+var _ Checkable = (*resourceType)(nil)
 
 type resourceType struct {
 	pipelineRef
@@ -188,6 +193,7 @@ type resourceType struct {
 	checkEvery            *atc.CheckEvery
 	lastCheckStartTime    time.Time
 	lastCheckEndTime      time.Time
+	nextCheckTime         time.Time
 }
 
 func (t *resourceType) ID() int                           { return t.id }
@@ -200,6 +206,7 @@ func (t *resourceType) CheckEvery() *atc.CheckEvery       { return t.checkEvery 
 func (t *resourceType) CheckTimeout() string              { return "" }
 func (r *resourceType) LastCheckStartTime() time.Time     { return r.lastCheckStartTime }
 func (r *resourceType) LastCheckEndTime() time.Time       { return r.lastCheckEndTime }
+func (r *resourceType) NextCheckTime() time.Time          { return r.nextCheckTime }
 func (t *resourceType) Source() atc.Source                { return t.source }
 func (t *resourceType) Defaults() atc.Source              { return t.defaults }
 func (t *resourceType) Params() atc.Params                { return t.params }
@@ -353,23 +360,24 @@ func (r *resourceType) SharedResourcesAndTypes() (atc.ResourcesAndTypes, error) 
 
 func scanResourceType(t *resourceType, row scannable) error {
 	var (
-		configJSON                           sql.NullString
-		rcsID, nonce                         sql.NullString
-		lastCheckStartTime, lastCheckEndTime sql.NullTime
-		pipelineInstanceVars                 sql.NullString
-		resourceConfigID                     sql.NullInt64
+		configJSON                                          sql.NullString
+		rcsID, nonce                                        sql.NullString
+		lastCheckStartTime, lastCheckEndTime, nextCheckTime sql.NullTime
+		pipelineInstanceVars                                sql.NullString
+		resourceConfigID                                    sql.NullInt64
 	)
 
 	err := row.Scan(&t.id, &t.pipelineID, &t.name, &t.type_, &configJSON,
 		&nonce, &t.pipelineName, &pipelineInstanceVars,
 		&t.teamID, &t.teamName, &resourceConfigID, &rcsID,
-		&lastCheckStartTime, &lastCheckEndTime)
+		&lastCheckStartTime, &lastCheckEndTime, &nextCheckTime)
 	if err != nil {
 		return err
 	}
 
 	t.lastCheckStartTime = lastCheckStartTime.Time
 	t.lastCheckEndTime = lastCheckEndTime.Time
+	t.nextCheckTime = nextCheckTime.Time
 
 	es := t.conn.EncryptionStrategy()
 

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -121,12 +121,10 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 		}
 	}
 
-	interval := d.plan.Interval.Interval
-
 	var lock lock.Lock = lock.NoopLock{}
 	if d.plan.IsResourceCheck() {
 		for {
-			run, err := d.shouldPeriodicCheckRun(scope, interval)
+			run, err := d.shouldPeriodicCheckRun(scope)
 			if err != nil {
 				return nil, false, err
 			}
@@ -143,7 +141,7 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 				// After acquired the lock, see if needs to run again. Because for global
 				// resources, a previous check will result in current check no longer need
 				// to run.
-				run, err := d.shouldPeriodicCheckRun(scope, interval)
+				run, err := d.shouldPeriodicCheckRun(scope)
 				if err != nil {
 					err2 := lock.Release()
 					if err2 != nil {
@@ -176,7 +174,7 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 		// of this check, OR the check interval has no elapsed since the last check
 		// end time of a successful check and it is not a manual check then don't run
 		if lastCheck.Succeeded {
-			if lastCheck.EndTime.After(d.build.StartTime()) || (d.clock.Now().Before(lastCheck.EndTime.Add(interval)) && !d.plan.SkipInterval) {
+			if lastCheck.EndTime.After(d.build.StartTime()) || (d.clock.Now().Before(lastCheck.NextCheckTime) && !d.plan.SkipInterval) {
 				return nil, false, nil
 			}
 		}
@@ -185,7 +183,7 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 	return lock, true, nil
 }
 
-func (d *checkDelegate) shouldPeriodicCheckRun(scope db.ResourceConfigScope, checkInterval time.Duration) (bool, error) {
+func (d *checkDelegate) shouldPeriodicCheckRun(scope db.ResourceConfigScope) (bool, error) {
 	lastCheck, err := scope.LastCheck()
 	if err != nil {
 		return false, err
@@ -204,7 +202,7 @@ func (d *checkDelegate) shouldPeriodicCheckRun(scope db.ResourceConfigScope, che
 	} else {
 		// For periodic checks, if the current time is before the end of the last
 		// check + the interval, do not run
-		if d.clock.Now().Before(lastCheck.EndTime.Add(checkInterval)) {
+		if d.clock.Now().Before(lastCheck.NextCheckTime) {
 			return false, nil
 		}
 	}

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -303,9 +303,10 @@ var _ = Describe("CheckDelegate", func() {
 				Context("when the interval has not elapsed since the last check", func() {
 					BeforeEach(func() {
 						fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-							StartTime: now.Add(-(interval + 10)),
-							EndTime:   now.Add(-(interval - 1)),
-							Succeeded: true,
+							StartTime:     now.Add(-(interval + 10)),
+							EndTime:       now.Add(-(interval - 1)),
+							NextCheckTime: now.Add(interval),
+							Succeeded:     true,
 						}, nil)
 					})
 
@@ -321,9 +322,10 @@ var _ = Describe("CheckDelegate", func() {
 				Context("when the interval has elapsed since the last check", func() {
 					BeforeEach(func() {
 						fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-							StartTime: now.Add(-(interval + 10)),
-							EndTime:   now.Add(-(interval + 1)),
-							Succeeded: true,
+							StartTime:     now.Add(-(interval + 10)),
+							EndTime:       now.Add(-(interval + 1)),
+							NextCheckTime: now.Add(-(interval + 1)),
+							Succeeded:     true,
 						}, nil)
 					})
 
@@ -335,14 +337,16 @@ var _ = Describe("CheckDelegate", func() {
 				Context("when the last check value gets updated after the first loop of attempting to acquire lock", func() {
 					BeforeEach(func() {
 						fakeResourceConfigScope.LastCheckReturnsOnCall(0, db.LastCheck{
-							StartTime: now.Add(-(interval + 10)),
-							EndTime:   now.Add(-(interval + 1)),
-							Succeeded: true,
+							StartTime:     now.Add(-(interval + 10)),
+							EndTime:       now.Add(-(interval + 1)),
+							NextCheckTime: now.Add(-(interval + 1)),
+							Succeeded:     true,
 						}, nil)
 						fakeResourceConfigScope.LastCheckReturnsOnCall(1, db.LastCheck{
-							StartTime: now.Add(time.Second).Add(-(interval + 10)),
-							EndTime:   now.Add(time.Second).Add(-(interval - 1)),
-							Succeeded: true,
+							StartTime:     now.Add(time.Second).Add(-(interval + 10)),
+							EndTime:       now.Add(time.Second).Add(-(interval - 1)),
+							NextCheckTime: now.Add(time.Second).Add((interval - 1)),
+							Succeeded:     true,
 						}, nil)
 						fakeResourceConfigScope.AcquireResourceCheckingLockReturns(nil, false, nil)
 						go fakeClock.WaitForWatcherAndIncrement(time.Second)
@@ -400,9 +404,10 @@ var _ = Describe("CheckDelegate", func() {
 			Context("when last check failed", func() {
 				BeforeEach(func() {
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-						StartTime: now.Add(-10),
-						EndTime:   now.Add(-1),
-						Succeeded: false,
+						StartTime:     now.Add(-10),
+						EndTime:       now.Add(-1),
+						NextCheckTime: now.Add(-1),
+						Succeeded:     false,
 					}, nil)
 				})
 
@@ -414,9 +419,10 @@ var _ = Describe("CheckDelegate", func() {
 			Context("when last check ended before build start time", func() {
 				BeforeEach(func() {
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-						StartTime: now.Add(-10 * time.Second),
-						EndTime:   now.Add(-time.Second),
-						Succeeded: true,
+						StartTime:     now.Add(-10 * time.Second),
+						EndTime:       now.Add(-time.Second),
+						NextCheckTime: now.Add(-time.Second),
+						Succeeded:     true,
 					}, nil)
 					fakeBuild.StartTimeReturns(now.Add(time.Second))
 				})
@@ -429,9 +435,10 @@ var _ = Describe("CheckDelegate", func() {
 			Context("when last check succeeds after build starts", func() {
 				BeforeEach(func() {
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-						StartTime: now.Add(-10 * time.Second),
-						EndTime:   now.Add(-time.Second),
-						Succeeded: true,
+						StartTime:     now.Add(-10 * time.Second),
+						EndTime:       now.Add(-time.Second),
+						NextCheckTime: now.Add(-time.Second),
+						Succeeded:     true,
 					}, nil)
 					fakeBuild.StartTimeReturns(now.Add(-5 * time.Second))
 				})
@@ -444,9 +451,10 @@ var _ = Describe("CheckDelegate", func() {
 			Context("when the checking interval has elapsed since the last check end time", func() {
 				BeforeEach(func() {
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-						StartTime: now.Add(-6 * time.Minute),
-						EndTime:   now.Add(-5 * time.Minute),
-						Succeeded: true,
+						StartTime:     now.Add(-6 * time.Minute),
+						EndTime:       now.Add(-5 * time.Minute),
+						NextCheckTime: now.Add(-4 * time.Minute),
+						Succeeded:     true,
 					}, nil)
 					fakeBuild.StartTimeReturns(now)
 				})
@@ -460,9 +468,10 @@ var _ = Describe("CheckDelegate", func() {
 				BeforeEach(func() {
 					plan.Check.SkipInterval = true
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-						StartTime: now.Add(-6 * time.Minute),
-						EndTime:   now.Add(-5 * time.Minute),
-						Succeeded: true,
+						StartTime:     now.Add(-6 * time.Minute),
+						EndTime:       now.Add(-5 * time.Minute),
+						NextCheckTime: now.Add(-4 * time.Minute),
+						Succeeded:     true,
 					}, nil)
 					fakeBuild.StartTimeReturns(now)
 				})
@@ -477,9 +486,10 @@ var _ = Describe("CheckDelegate", func() {
 					plan.Check.Interval.Interval = time.Hour
 					plan.Check.SkipInterval = false
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-						StartTime: now,
-						EndTime:   now,
-						Succeeded: true,
+						StartTime:     now,
+						EndTime:       now,
+						NextCheckTime: now.Add(2 * time.Hour),
+						Succeeded:     true,
 					}, nil)
 					fakeBuild.StartTimeReturns(now.Add(1 * time.Minute))
 				})
@@ -494,9 +504,10 @@ var _ = Describe("CheckDelegate", func() {
 					plan.Check.Interval.Interval = time.Hour
 					plan.Check.SkipInterval = true
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-						StartTime: now,
-						EndTime:   now,
-						Succeeded: true,
+						StartTime:     now,
+						EndTime:       now,
+						NextCheckTime: now.Add(2 * time.Hour),
+						Succeeded:     true,
 					}, nil)
 					fakeBuild.StartTimeReturns(now.Add(1 * time.Minute))
 				})
@@ -510,9 +521,10 @@ var _ = Describe("CheckDelegate", func() {
 				BeforeEach(func() {
 					plan.Check.Interval.Interval = time.Hour
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
-						StartTime: now,
-						EndTime:   now,
-						Succeeded: false,
+						StartTime:     now,
+						EndTime:       now,
+						NextCheckTime: now.Add(2 * time.Hour),
+						Succeeded:     false,
 					}, nil)
 					fakeBuild.StartTimeReturns(now.Add(1 * time.Minute))
 				})


### PR DESCRIPTION
## Changes proposed by this PR

closes #9620 

We have MULTIPLE places where we check "has the interval for this resource elapsed?". We were previously using `LastCheckEndTime + interval` to answer this question in all these different places across the code base (db and runtime layers).

When I made the latest change to the scheduler, I added the `next_check_time` column to resource config scopes. I added that column because there wasn't an existing way to pull out the interval of a resource and determine if it had elapsed. The interval of a resource is stored in the config column of the resources table, which makes it not queriable. Therefore I had us store `lastCheckEndTime + interval` in `next_check_time` so I could easily determine if the interval had elapsed or not. This created two sources of truth that could conflict, which is what resulted in this bug.

This PR now migrates everything (I think) to use NextCheckTime instead of `LastCheckEndTime + interval` to determine if a resource needs to be checked or not.

Issue #9620 has steps for manually reproducing. I verified that this PR resolves the issue by following those steps.

