### PR TITLE
Prevent wall banner from overlapping page content when scrolling

### DIFF
--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -582,24 +582,12 @@ view model =
             , SideBar.tooltip model.session
                 |> Maybe.map (Tooltip.view model.session)
                 |> Maybe.withDefault (Html.text "")
-            , case model.wallMessage of
-                Just msg ->
-                    if model.wallEditor.isOpen then
-                        Html.text ""
-
-                    else
-                        Html.div [ id "wall-banner", style "white-space" "pre-wrap" ] <|
-                            wallLinks msg
-
-                Nothing ->
-                    Html.text ""
-            , if model.wallEditor.isOpen then
-                wallEditorView model.wallEditor model.wallMessage model.session.hovered
-
-              else
-                Html.text ""
             , Html.div
-                ([ id "page-wrapper", style "height" "100%" ]
+                ([ id "page-wrapper"
+                 , style "height" "100%"
+                 , style "display" "flex"
+                 , style "flex-direction" "column"
+                 ]
                     ++ (if model.session.draggingSideBar then
                             Styles.disableInteraction
 
@@ -607,7 +595,24 @@ view model =
                             []
                        )
                 )
-                [ body ]
+                [ case model.wallMessage of
+                    Just msg ->
+                        if model.wallEditor.isOpen then
+                            Html.text ""
+
+                        else
+                            Html.div [ id "wall-banner", style "white-space" "pre-wrap" ] <|
+                                wallLinks msg
+
+                    Nothing ->
+                        Html.text ""
+                , if model.wallEditor.isOpen then
+                    wallEditorView model.wallEditor model.wallMessage model.session.hovered
+
+                  else
+                    Html.text ""
+                , body
+                ]
             ]
     }
 

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -442,7 +442,7 @@ view session model =
             isPaused model.pipeline
                 && not (isArchived model.pipeline)
     in
-    Html.div [ Html.Attributes.style "height" "100%" ]
+    Html.div [ Html.Attributes.style "flex" "1", Html.Attributes.style "min-height" "0", Html.Attributes.style "display" "flex", Html.Attributes.style "flex-direction" "column" ]
         [ Html.div
             (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
             [ Html.div

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -442,7 +442,12 @@ view session model =
             isPaused model.pipeline
                 && not (isArchived model.pipeline)
     in
-    Html.div [ Html.Attributes.style "flex" "1", Html.Attributes.style "min-height" "0", Html.Attributes.style "display" "flex", Html.Attributes.style "flex-direction" "column" ]
+    Html.div
+        [ Html.Attributes.style "flex" "1"
+        , Html.Attributes.style "min-height" "0"
+        , Html.Attributes.style "display" "flex"
+        , Html.Attributes.style "flex-direction" "column"
+        ]
         [ Html.div
             (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
             [ Html.div

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -72,7 +72,8 @@ pageHeaderHeight =
 
 pageIncludingTopBar : List (Html.Attribute msg)
 pageIncludingTopBar =
-    [ style "height" "100%"
+    [ style "flex" "1"
+    , style "min-height" "0"
     ]
 
 

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -930,14 +930,16 @@ givenMultiplePinnedResources =
 testTopBarPositioning : String -> String -> Test
 testTopBarPositioning pageName url =
     describe pageName
-        [ test "whole page fills the whole screen" <|
+        [ test "top section fills the whole screen" <|
             \_ ->
                 Common.init url
                     |> Common.queryView
-                    |> Query.has
+                    |> Query.findAll
                         [ id "page-including-top-bar"
-                        , style "height" "100%"
+                        , style "flex" "1"
+                        , style "min-height" "0"
                         ]
+                    |> Query.count (Expect.equal 1)
         , test "lower section fills the whole screen as well" <|
             \_ ->
                 Common.init url


### PR DESCRIPTION
## Changes proposed by this PR

closes #9623 

The wall banner (`#wall-banner`) is using `position: sticky`, which requires a scrolling ancestor to work correctly. The banner sits outside the scroll container and because of that `position: sticky` had no effect. At the end the banner scrolled with the page content and overlapped job names and team panel.

## Notes to reviewer

* `Application.elm` - `#wall-banner` and `.wall-editor-bar` moved inside `#page-wrapper`, which now has `display: flex; flex-direction: column`. The banner is a natural flex item above the page content.

## Release Note

Prevent wall banner from overlapping page content when scrolling.

<img width="1141" height="761" alt="test_broadcast_message_fix" src="https://github.com/user-attachments/assets/4f50a16b-d345-4203-b933-7ece44529172" />
