### PR TITLE
Add `hide_ui` query param to hide web UI elements

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -138,7 +138,7 @@ buildView session model =
                 ++ [ Login.view session.userState model ]
             )
         , Html.div
-            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.hideUI route)
             [ SideBar.view session
                 (currentJob model
                     |> Maybe.map
@@ -707,6 +707,7 @@ sampleSession =
             { id = 1
             , highlight = Routes.HighlightNothing
             }
+    , hideUI = False
     }
 
 

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -82,6 +82,9 @@ init flags url =
                         }
                     )
 
+        hideUI =
+            Routes.parseHideUI url
+
         session =
             { userState = UserStateUnknown
             , hovered = HoverState.NoHover
@@ -106,6 +109,7 @@ init flags url =
             , favoritedPipelines = Set.empty
             , favoritedInstanceGroups = Set.empty
             , route = route
+            , hideUI = hideUI
             }
 
         ( subModel, subEffects ) =
@@ -129,7 +133,7 @@ init flags url =
 
             else
                 [ SaveToken flags.csrfToken
-                , Effects.ModifyUrl <| Routes.toString route
+                , Effects.ModifyUrl <| Routes.withHideUIParam hideUI <| Routes.toString route
                 ]
     in
     ( model
@@ -485,7 +489,12 @@ handleDeliveryForApplication delivery model =
                 Browser.Internal url ->
                     case Routes.parsePath url of
                         Just route ->
-                            ( model, [ NavigateTo <| Routes.toString route ] )
+                            ( model
+                            , [ NavigateTo <|
+                                    Routes.withHideUIParam model.session.hideUI <|
+                                        Routes.toString route
+                              ]
+                            )
 
                         Nothing ->
                             ( model, [ LoadExternal <| Url.toString url ] )

--- a/web/elm/src/Application/Models.elm
+++ b/web/elm/src/Application/Models.elm
@@ -18,4 +18,5 @@ type alias Session =
         , authToken : String
         , pipelineRunningKeyframes : String
         , timeZone : Time.Zone
+        , hideUI : Bool
         }

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -692,15 +692,16 @@ view session model =
     in
     Html.div
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-        [ Html.div
+        [ Views.Styles.hideIf session.hideUI (Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
             (SideBar.sideBarIcon session
                 :: breadcrumbs session model
                 ++ [ Login.view session.userState model ]
             )
+          )
         , Html.div
-            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
-            [ SideBar.view session
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.hideUI route)
+            [ Views.Styles.hideIf session.hideUI (SideBar.view session
                 (model.job
                     |> Maybe.map
                         (\j ->
@@ -710,6 +711,7 @@ view session model =
                             }
                         )
                 )
+              )
             , viewBuildPage session model
             ]
         ]

--- a/web/elm/src/Causality/Causality.elm
+++ b/web/elm/src/Causality/Causality.elm
@@ -242,21 +242,23 @@ view session model =
     in
     Html.div
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-        [ Html.div
+        [ Views.Styles.hideIf session.hideUI (Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
             (SideBar.sideBarIcon session
                 :: TopBar.breadcrumbs session route
                 ++ [ Login.view session.userState model ]
             )
+          )
         , Html.div
-            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
-            [ SideBar.view session
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.hideUI route)
+            [ Views.Styles.hideIf session.hideUI (SideBar.view session
                 (Just
                     { pipelineName = model.versionId.pipelineName
                     , pipelineInstanceVars = model.versionId.pipelineInstanceVars
                     , teamName = model.versionId.teamName
                     }
                 )
+              )
             , viewGraph model
             ]
         ]

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -855,10 +855,16 @@ view : Session -> Model -> Html Message
 view session model =
     Html.div
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-        [ topBar session model
+        [ Views.Styles.hideIf session.hideUI (topBar session model)
         , Html.div
             [ id "page-below-top-bar"
-            , style "padding-top" "54px"
+            , style "padding-top"
+                (if session.hideUI then
+                    "0"
+
+                 else
+                    "54px"
+                )
             , style "box-sizing" "border-box"
             , style "display" "flex"
             , style "height" "100%"
@@ -870,10 +876,10 @@ view session model =
                     "50px"
             ]
           <|
-            [ SideBar.view session Nothing
+            [ Views.Styles.hideIf session.hideUI (SideBar.view session Nothing)
             , dashboardView session model
             ]
-        , Footer.view session model
+        , Views.Styles.hideIf session.hideUI (Footer.view session model)
         ]
 
 

--- a/web/elm/src/DownloadFly/DownloadFly.elm
+++ b/web/elm/src/DownloadFly/DownloadFly.elm
@@ -71,7 +71,7 @@ view : Session -> Model -> Html Message
 view session model =
     Html.div
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-        [ Html.div
+        [ Views.Styles.hideIf session.hideUI (Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
             [ Html.div
                 [ style "display" "flex", style "align-items" "center" ]
@@ -80,9 +80,10 @@ view session model =
                 )
             , Login.view session.userState model
             ]
+          )
         , Html.div
-            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar Routes.DownloadFly)
-            [ SideBar.view session Nothing
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.hideUI Routes.DownloadFly)
+            [ Views.Styles.hideIf session.hideUI (SideBar.view session Nothing)
             , Html.div [ class "download-fly-card" ]
                 [ Html.p
                     [ class "title" ]

--- a/web/elm/src/FlySuccess/FlySuccess.elm
+++ b/web/elm/src/FlySuccess/FlySuccess.elm
@@ -130,19 +130,20 @@ documentTitle =
     "Fly Login"
 
 
-view : UserState -> Model -> Html Message
-view userState model =
+view : Bool -> UserState -> Model -> Html Message
+view hideUI userState model =
     Html.div []
         [ Html.div
             (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-            [ Html.div
+            [ Views.Styles.hideIf hideUI (Html.div
                 (id "top-bar-app" :: Views.Styles.topBar False)
                 [ TopBar.concourseLogo
                 , Login.view userState model
                 ]
+              )
             , Html.div
                 (id "page-below-top-bar"
-                    :: (Views.Styles.pageBelowTopBar <|
+                    :: (Views.Styles.pageBelowTopBar hideUI <|
                             Routes.FlySuccess False Nothing
                        )
                 )

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -425,21 +425,23 @@ view : Session -> Model -> Html Message
 view session model =
     Html.div
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-        [ Html.div
+        [ Views.Styles.hideIf session.hideUI (Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
             (SideBar.sideBarIcon session
                 :: TopBar.breadcrumbs session session.route
                 ++ [ Login.view session.userState model ]
             )
+          )
         , Html.div
-            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.route)
-            [ SideBar.view session
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.hideUI session.route)
+            [ Views.Styles.hideIf session.hideUI (SideBar.view session
                 (Just
                     { pipelineName = model.jobIdentifier.pipelineName
                     , pipelineInstanceVars = model.jobIdentifier.pipelineInstanceVars
                     , teamName = model.jobIdentifier.teamName
                     }
                 )
+              )
             , viewMainJobsSection session model
             ]
         ]

--- a/web/elm/src/NotFound/NotFound.elm
+++ b/web/elm/src/NotFound/NotFound.elm
@@ -54,15 +54,16 @@ view : Session -> Model -> Html Message
 view session model =
     Html.div
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-        [ Html.div
+        [ Views.Styles.hideIf session.hideUI (Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
             (SideBar.sideBarIcon session
                 :: TopBar.breadcrumbs session model.route
                 ++ [ Login.view session.userState model ]
             )
+          )
         , Html.div
-            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar model.route)
-            [ SideBar.view session Nothing
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.hideUI model.route)
+            [ Views.Styles.hideIf session.hideUI (SideBar.view session Nothing)
             , Html.div [ class "notfound" ]
                 [ Html.div [ class "title" ] [ Html.text "404" ]
                 , Html.div [ class "reason" ] [ Html.text "this page was not found" ]

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -445,7 +445,7 @@ view session model =
     Html.div [ Html.Attributes.style "height" "100%" ]
         [ Html.div
             (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-            [ Html.div
+            [ Views.Styles.hideIf session.hideUI (Html.div
                 (id "top-bar-app" :: Views.Styles.topBar displayPaused)
                 [ Html.div
                     [ style "display" "flex"
@@ -515,10 +515,11 @@ view session model =
                     , Login.view session.userState model
                     ]
                 ]
+              )
             , Html.div
-                (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
+                (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.hideUI route)
               <|
-                [ SideBar.view session (Just model.pipelineLocator)
+                [ Views.Styles.hideIf session.hideUI (SideBar.view session (Just model.pipelineLocator))
                 , viewSubPage session model
                 ]
             ]
@@ -648,7 +649,7 @@ backgroundImage pipeline =
 
 
 viewSubPage :
-    { a | hovered : HoverState.HoverState, version : String, screenSize : ScreenSize }
+    { a | hovered : HoverState.HoverState, version : String, screenSize : ScreenSize, hideUI : Bool }
     -> Model
     -> Html Message
 viewSubPage session model =
@@ -681,7 +682,7 @@ viewSubPage session model =
                     , Html.p [ class "explanation" ] []
                     ]
                 ]
-            , if model.hideLegend then
+            , if model.hideLegend || session.hideUI then
                 Html.text ""
 
               else
@@ -711,7 +712,7 @@ viewSubPage session model =
                     , Html.dt [ class "solid" ] [ Html.text "-" ]
                     , Html.dd [] [ Html.text "dependency (trigger)" ]
                     ]
-            , Html.table [ class "lower-right-info" ]
+            , Views.Styles.hideIf session.hideUI (Html.table [ class "lower-right-info" ]
                 [ Html.tr []
                     [ Html.td [ class "label" ]
                         [ Html.a
@@ -751,6 +752,7 @@ viewSubPage session model =
                         ]
                     ]
                 ]
+              )
             ]
         ]
 

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -1003,21 +1003,23 @@ view session model =
     in
     Html.div
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
-        [ Html.div
+        [ Views.Styles.hideIf session.hideUI (Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
             (SideBar.sideBarIcon session
                 :: TopBar.breadcrumbs session route
                 ++ [ Login.view session.userState model ]
             )
+          )
         , Html.div
-            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
-            [ SideBar.view session
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.hideUI route)
+            [ Views.Styles.hideIf session.hideUI (SideBar.view session
                 (Just
                     { pipelineName = model.resourceIdentifier.pipelineName
                     , pipelineInstanceVars = model.resourceIdentifier.pipelineInstanceVars
                     , teamName = model.resourceIdentifier.teamName
                     }
                 )
+              )
             , if model.pageStatus == Err Models.Empty then
                 Html.text ""
 

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -10,6 +10,7 @@ module Routes exposing
     , extractQuery
     , getGroups
     , jobRoute
+    , parseHideUI
     , parsePath
     , pipelineRoute
     , resourceRoute
@@ -19,6 +20,7 @@ module Routes exposing
     , tokenToFlyRoute
     , versionQueryParams
     , withGroups
+    , withHideUIParam
     )
 
 import Api.Pagination
@@ -723,3 +725,51 @@ withGroups groups route =
 
         DownloadFly ->
             route
+
+
+hideUIParamName : String
+hideUIParamName =
+    "hide_ui"
+
+
+hideUIQuery : Query.Parser Bool
+hideUIQuery =
+    Query.string hideUIParamName
+        |> Query.map (\value -> Maybe.map String.toLower value == Just "true")
+
+
+parseHideUI : Url.Url -> Bool
+parseHideUI url =
+    -- Neutralize the path so the query parser matches regardless of which
+    -- page the URL points at, then read the hide_ui flag from the query.
+    { url | path = "/" }
+        |> parse (top <?> hideUIQuery)
+        |> Maybe.withDefault False
+
+
+withHideUIParam : Bool -> String -> String
+withHideUIParam hideUI url =
+    if hideUI then
+        let
+            addParam path =
+                path
+                    ++ (if String.contains "?" path then
+                            "&"
+
+                        else
+                            "?"
+                       )
+                    ++ hideUIParamName
+                    ++ "=true"
+        in
+        -- Insert the param before any URL fragment (e.g. build log
+        -- highlights like #L1:2) so the fragment is preserved.
+        case String.split "#" url of
+            base :: fragmentHead :: fragmentTail ->
+                addParam base ++ "#" ++ String.join "#" (fragmentHead :: fragmentTail)
+
+            _ ->
+                addParam url
+
+    else
+        url

--- a/web/elm/src/SubPage/SubPage.elm
+++ b/web/elm/src/SubPage/SubPage.elm
@@ -428,7 +428,7 @@ view ({ userState } as session) mdl =
 
         FlySuccessModel model ->
             ( FlySuccess.documentTitle
-            , FlySuccess.view userState model
+            , FlySuccess.view session.hideUI userState model
             )
 
         DownloadFlyModel model ->

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -16,6 +16,7 @@ module Views.Styles exposing
     , fontWeightBold
     , fontWeightDefault
     , fontWeightLight
+    , hideIf
     , instanceGroupBadge
     , pageBelowTopBar
     , pageHeaderHeight
@@ -76,9 +77,24 @@ pageIncludingTopBar =
     ]
 
 
-pageBelowTopBar : Routes.Route -> List (Html.Attribute msg)
-pageBelowTopBar route =
-    style "padding-top" "54px"
+hideIf : Bool -> Html.Html msg -> Html.Html msg
+hideIf condition element =
+    if condition then
+        Html.text ""
+
+    else
+        element
+
+
+pageBelowTopBar : Bool -> Routes.Route -> List (Html.Attribute msg)
+pageBelowTopBar hideUI route =
+    style "padding-top"
+        (if hideUI then
+            "0"
+
+         else
+            "54px"
+        )
         :: (case route of
                 Routes.FlySuccess _ _ ->
                     [ style "height" "100%" ]

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -466,6 +466,7 @@ session =
     , favoritedPipelines = Set.empty
     , favoritedInstanceGroups = Set.empty
     , route = Routes.Build { id = Data.jobBuildId, highlight = Routes.HighlightNothing, groups = [] }
+    , hideUI = False
     }
 
 

--- a/web/elm/tests/HideUITests.elm
+++ b/web/elm/tests/HideUITests.elm
@@ -1,0 +1,220 @@
+module HideUITests exposing (all)
+
+import Application.Application as Application
+import Browser
+import Common exposing (queryView)
+import Data
+import Dict
+import Expect
+import Message.Callback as Callback
+import Message.Effects as Effects
+import Message.Subscription exposing (Delivery(..))
+import Routes
+import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (class, id)
+import Url
+
+
+all : Test
+all =
+    describe "hide_ui query parameter"
+        [ describe "Routes.parseHideUI"
+            [ test "is True when hide_ui=true is present" <|
+                \_ ->
+                    "http://example.com/teams/t/pipelines/p?hide_ui=true"
+                        |> Url.fromString
+                        |> Maybe.map Routes.parseHideUI
+                        |> Expect.equal (Just True)
+            , test "is True alongside other query params" <|
+                \_ ->
+                    "http://example.com/teams/t/pipelines/p?group=a&hide_ui=true"
+                        |> Url.fromString
+                        |> Maybe.map Routes.parseHideUI
+                        |> Expect.equal (Just True)
+            , test "is False when the param is absent" <|
+                \_ ->
+                    "http://example.com/teams/t/pipelines/p"
+                        |> Url.fromString
+                        |> Maybe.map Routes.parseHideUI
+                        |> Expect.equal (Just False)
+            , test "is False for hide_ui=false" <|
+                \_ ->
+                    "http://example.com/teams/t/pipelines/p?hide_ui=false"
+                        |> Url.fromString
+                        |> Maybe.map Routes.parseHideUI
+                        |> Expect.equal (Just False)
+            ]
+        , describe "Routes.withHideUIParam"
+            [ test "appends with ? when there is no existing query" <|
+                \_ ->
+                    Routes.withHideUIParam True "/teams/t/pipelines/p"
+                        |> Expect.equal "/teams/t/pipelines/p?hide_ui=true"
+            , test "appends with & when a query already exists" <|
+                \_ ->
+                    Routes.withHideUIParam True "/teams/t/pipelines/p?group=a"
+                        |> Expect.equal "/teams/t/pipelines/p?group=a&hide_ui=true"
+            , test "inserts the param before a fragment" <|
+                \_ ->
+                    Routes.withHideUIParam True "/teams/t/pipelines/p/jobs/j/builds/b#L1:2"
+                        |> Expect.equal "/teams/t/pipelines/p/jobs/j/builds/b?hide_ui=true#L1:2"
+            , test "is a no-op when hideUI is False" <|
+                \_ ->
+                    Routes.withHideUIParam False "/teams/t/pipelines/p"
+                        |> Expect.equal "/teams/t/pipelines/p"
+            ]
+        , describe "hiding the top bar"
+            [ test "top bar is hidden on the pipeline page when hide_ui=true" <|
+                \_ ->
+                    hideUIAt "/teams/t/pipelines/p"
+                        |> queryView
+                        |> Query.findAll [ id "top-bar-app" ]
+                        |> Query.count (Expect.equal 0)
+            , test "top bar is hidden on the resource page when hide_ui=true" <|
+                \_ ->
+                    hideUIAt "/teams/t/pipelines/p/resources/r"
+                        |> queryView
+                        |> Query.findAll [ id "top-bar-app" ]
+                        |> Query.count (Expect.equal 0)
+            , test "top bar is hidden on the build page when hide_ui=true" <|
+                \_ ->
+                    hideUIAt "/teams/t/pipelines/p/jobs/j/builds/b"
+                        |> queryView
+                        |> Query.findAll [ id "top-bar-app" ]
+                        |> Query.count (Expect.equal 0)
+            , test "top bar is hidden on the dashboard when hide_ui=true" <|
+                \_ ->
+                    hideUIAt "/"
+                        |> queryView
+                        |> Query.findAll [ id "top-bar-app" ]
+                        |> Query.count (Expect.equal 0)
+            , test "top bar is shown when hide_ui is absent" <|
+                \_ ->
+                    Common.init "/teams/t/pipelines/p"
+                        |> queryView
+                        |> Query.has [ id "top-bar-app" ]
+            ]
+        , describe "hiding the side bar"
+            [ test "side bar is hidden when hide_ui=true" <|
+                \_ ->
+                    hideUIAt "/teams/team/pipelines/pipeline"
+                        |> withVisibleSideBar
+                        |> queryView
+                        |> Query.hasNot [ id "side-bar" ]
+            , test "side bar is shown when hide_ui is absent (control)" <|
+                \_ ->
+                    Common.init "/teams/team/pipelines/pipeline"
+                        |> withVisibleSideBar
+                        |> queryView
+                        |> Query.has [ id "side-bar" ]
+            ]
+        , describe "pipeline legend and lower-right info"
+            [ test "legend is hidden when hide_ui=true" <|
+                \_ ->
+                    hideUIAt "/teams/t/pipelines/p"
+                        |> queryView
+                        |> Query.hasNot [ id "legend" ]
+            , test "lower-right info is hidden when hide_ui=true" <|
+                \_ ->
+                    hideUIAt "/teams/t/pipelines/p"
+                        |> queryView
+                        |> Query.hasNot [ class "lower-right-info" ]
+            , test "legend and lower-right info are shown when hide_ui is absent" <|
+                \_ ->
+                    Common.init "/teams/t/pipelines/p"
+                        |> queryView
+                        |> Expect.all
+                            [ Query.has [ id "legend" ]
+                            , Query.has [ class "lower-right-info" ]
+                            ]
+            ]
+        , describe "persistence across navigation"
+            [ test "navigating keeps hideUI active in the session" <|
+                \_ ->
+                    hideUIAt "/teams/t/pipelines/p"
+                        |> Application.handleDelivery (RouteChanged buildRoute)
+                        |> Tuple.first
+                        |> .session
+                        |> .hideUI
+                        |> Expect.equal True
+            , test "clicking an internal link keeps ?hide_ui=true in the URL" <|
+                \_ ->
+                    hideUIAt "/teams/t/pipelines/p"
+                        |> Application.handleDelivery
+                            (clickInternalLink "/teams/t/pipelines/p/jobs/j")
+                        |> Tuple.second
+                        |> Common.contains
+                            (Effects.NavigateTo "/teams/t/pipelines/p/jobs/j?hide_ui=true")
+            , test "clicking an internal link does not add the param when hideUI is inactive" <|
+                \_ ->
+                    Common.init "/teams/t/pipelines/p"
+                        |> Application.handleDelivery
+                            (clickInternalLink "/teams/t/pipelines/p/jobs/j")
+                        |> Tuple.second
+                        |> Common.contains
+                            (Effects.NavigateTo "/teams/t/pipelines/p/jobs/j")
+            , test "initial load keeps ?hide_ui=true in the URL" <|
+                \_ ->
+                    Application.init Data.flags
+                        { protocol = Url.Http
+                        , host = "test.com"
+                        , port_ = Nothing
+                        , path = "/teams/t/pipelines/p"
+                        , query = Just "hide_ui=true"
+                        , fragment = Nothing
+                        }
+                        |> Tuple.second
+                        |> Common.contains
+                            (Effects.ModifyUrl "/teams/t/pipelines/p?hide_ui=true")
+            ]
+        ]
+
+
+clickInternalLink : String -> Delivery
+clickInternalLink path =
+    UrlRequest <|
+        Browser.Internal
+            { protocol = Url.Http
+            , host = "test.com"
+            , port_ = Nothing
+            , path = path
+            , query = Nothing
+            , fragment = Nothing
+            }
+
+
+hideUIAt : String -> Application.Model
+hideUIAt path =
+    Common.initCustom { initCustomOpts | query = Just "hide_ui=true" } path
+
+
+initCustomOpts =
+    Common.initCustomOpts
+
+
+withVisibleSideBar : Application.Model -> Application.Model
+withVisibleSideBar =
+    Common.whenOnDesktop
+        >> Application.handleCallback
+            (Callback.AllPipelinesFetched <|
+                Ok [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+            )
+        >> Tuple.first
+        >> Application.handleDelivery
+            (SideBarStateReceived (Ok { isOpen = True, width = 275 }))
+        >> Tuple.first
+
+
+buildRoute : Routes.Route
+buildRoute =
+    Routes.Build
+        { id =
+            { teamName = "t"
+            , pipelineName = "p"
+            , pipelineInstanceVars = Dict.empty
+            , jobName = "j"
+            , buildName = "b"
+            }
+        , highlight = Routes.HighlightNothing
+        , groups = []
+        }

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -4070,4 +4070,5 @@ session =
     , screenSize = ScreenSize.Desktop
     , timeZone = Time.utc
     , route = Routes.Resource { id = Data.resourceId, page = Nothing, version = Nothing, groups = [] }
+    , hideUI = False
     }


### PR DESCRIPTION
## Changes proposed by this PR

closes #1477

Users can manually add `?hide_ui=true` to their Concourse URL and the page will render without any of the navigation elements:

- Top and side nav bars
- Footer
- Pipeline Legend
- Docs/Download Fly/Version links are hidden

Here's a video showing what this looks like:

https://github.com/user-attachments/assets/a3676f25-c44d-4fc1-ae17-5a9d39ff8ffa

There is no UI toggle for this. We will document this somewhere in the docs.