### PR TITLE
web: instance groups: add list view

### DIFF
--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -299,10 +299,10 @@ handleCallback action ( model, effects ) =
                     ( model, effects )
 
         BuildJobDetailsFetched (Ok job) ->
-                        ( { model
-                                | disableManualTrigger = job.disableManualTrigger
-                                , disableReruns = job.disableReruns
-                            }
+            ( { model
+                | disableManualTrigger = job.disableManualTrigger
+                , disableReruns = job.disableReruns
+              }
             , effects
             )
 

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -875,8 +875,10 @@ viewStepWithBody model session depth step body =
                     Just status ->
                         if status /= 0 then
                             Html.span [ class "exit-status", style "display" "flex", style "align-items" "center", style "margin-right" "10px", style "color" Colors.error, style "font-weight" "bold" ] [ Html.text ("exit: " ++ String.fromInt status) ]
+
                         else
                             Html.text ""
+
                     Nothing ->
                         Html.text ""
                 , viewStepState step.state (Just step.id)

--- a/web/elm/src/Colors.elm
+++ b/web/elm/src/Colors.elm
@@ -18,6 +18,7 @@ module Colors exposing
     , cliIconHover
     , dashboardPipelineHeaderText
     , dashboardText
+    , dropTargetHighlight
     , dropdownFaded
     , dropdownItemInputText
     , dropdownItemSelectedBackground
@@ -384,6 +385,11 @@ card =
 
 
 -----
+
+
+dropTargetHighlight : String
+dropTargetHighlight =
+    "#2196F3"
 
 
 instanceGroupBanner : String

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1229,6 +1229,15 @@ dashboardView session model =
         turbulenceView session.turbulenceImgSrc
 
     else
+        let
+            noPipelines =
+                case model.pipelines of
+                    Nothing ->
+                        True
+
+                    Just pipelines ->
+                        pipelines |> Dict.values |> List.all List.isEmpty
+        in
         Html.div
             ([ class (.pageBodyClass Message.Effects.stickyHeaderConfig)
              , id (toHtmlID Dashboard)
@@ -1240,7 +1249,7 @@ dashboardView session model =
                         Styles.groupPageContent model.groupListView
 
                     else
-                        Styles.content model.highDensity
+                        Styles.content (model.highDensity && not noPipelines)
                    )
             )
             (case model.pipelines of
@@ -1419,8 +1428,19 @@ cardsView session params teamCards =
         viewingInstanceGroups =
             Filter.isViewingInstanceGroups params.query
 
+        noPipelines =
+            case params.pipelines of
+                Nothing ->
+                    True
+
+                Just pipelines ->
+                    pipelines |> Dict.values |> List.all List.isEmpty
+
+        highDensity =
+            params.highDensity && not noPipelines
+
         ( headerView, offsetHeight ) =
-            if (params.highDensity && not viewingInstanceGroups) || (params.groupListView && viewingInstanceGroups) then
+            if (highDensity && not viewingInstanceGroups) || (params.groupListView && viewingInstanceGroups) then
                 ( [], 0 )
 
             else
@@ -1524,7 +1544,7 @@ cardsView session params teamCards =
                             session
                             session.hovered
 
-                    else if params.highDensity && not viewingInstanceGroups then
+                    else if highDensity && not viewingInstanceGroups then
                         List.concatMap
                             (Group.hdView
                                 { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1532,13 +1532,10 @@ cardsView session params teamCards =
                                 , jobs = jobs
                                 , dashboardView = params.dashboardView
                                 , query = params.query
-                                , highDensity = params.highDensity
-                                , now = params.now
                                 , dragState = params.dragState
                                 , dropState = params.dropState
                                 }
                                 session
-                                session.hovered
                             )
 
                     else

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1189,16 +1189,17 @@ showArchivedToggleView model =
     else
         Toggle.toggleSwitch
             { ariaLabel = "Toggle whether archived pipelines are displayed"
-            , hrefRoute = Just <|
-                Routes.Dashboard
-                    { searchType = Routes.Normal model.query
-                    , dashboardView =
-                        if on then
-                            Routes.ViewNonArchivedPipelines
+            , hrefRoute =
+                Just <|
+                    Routes.Dashboard
+                        { searchType = Routes.Normal model.query
+                        , dashboardView =
+                            if on then
+                                Routes.ViewNonArchivedPipelines
 
-                        else
-                            Routes.ViewAllPipelines
-                    }
+                            else
+                                Routes.ViewAllPipelines
+                        }
             , onToggle = NoOp
             , text = "show archived"
             , textDirection = Toggle.Left
@@ -1350,7 +1351,8 @@ turbulenceView path =
 dashboardCardsView : Session -> Model -> List (Html Message)
 dashboardCardsView session model =
     let
-        isViewingInstanceGroups = Filter.isViewingInstanceGroups model.query
+        isViewingInstanceGroups =
+            Filter.isViewingInstanceGroups model.query
     in
     if isViewingInstanceGroups then
         instanceGroupCardsView session model

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -109,7 +109,8 @@ init f =
       , hideFooter = False
       , hideFooterCounter = 0
       , showHelp = False
-      , highDensity = f.searchType == Routes.HighDensity
+      , highDensity = False -- will be loaded from localStorage
+      , groupListView = False -- will be loaded from localStorage
       , query = Routes.extractQuery f.searchType
       , dashboardView = f.dashboardView
       , pipelinesWithResourceErrors = Set.empty
@@ -141,6 +142,8 @@ init f =
       , FetchAllResources
       , FetchAllJobs
       , FetchAllPipelines
+      , LoadHighDensity
+      , LoadGroupListView
       , LoadCachedJobs
       , LoadCachedPipelines
       , LoadCachedTeams
@@ -162,8 +165,7 @@ changeRoute f ( model, effects ) =
             Filter.isViewingInstanceGroups newQuery
     in
     ( { model
-        | highDensity = f.searchType == Routes.HighDensity
-        , dashboardView = f.dashboardView
+        | dashboardView = f.dashboardView
         , query = newQuery
       }
     , effects
@@ -417,12 +419,7 @@ handleCallback callback ( model, effects ) =
                 ++ [ NavigateTo <|
                         Routes.toString <|
                             Routes.Dashboard
-                                { searchType =
-                                    if model.highDensity then
-                                        Routes.HighDensity
-
-                                    else
-                                        Routes.Normal ""
+                                { searchType = Routes.Normal ""
                                 , dashboardView = model.dashboardView
                                 }
                    , FetchAllTeams
@@ -528,6 +525,18 @@ handleDeliveryBody delivery ( model, effects ) =
 
         SideBarStateReceived _ ->
             ( model, effects ++ [ GetViewportOf Dashboard ] )
+
+        HighDensityReceived (Ok highDensity) ->
+            ( { model | highDensity = highDensity }, effects )
+
+        HighDensityReceived (Err _) ->
+            ( model, effects )
+
+        GroupListViewReceived (Ok groupListView) ->
+            ( { model | groupListView = groupListView }, effects )
+
+        GroupListViewReceived (Err _) ->
+            ( model, effects )
 
         CachedPipelinesReceived (Ok pipelines) ->
             if model.pipelines == Nothing then
@@ -689,6 +698,24 @@ updateBody session msg ( model, effects ) =
 
         DragOver target ->
             ( { model | dropState = Models.Dropping target }, effects )
+
+        ToggleHighDensity ->
+            let
+                newHighDensity =
+                    not model.highDensity
+            in
+            ( { model | highDensity = newHighDensity }
+            , effects ++ [ SaveHighDensity newHighDensity ]
+            )
+
+        ToggleGroupListView ->
+            let
+                newGroupListView =
+                    not model.groupListView
+            in
+            ( { model | groupListView = newGroupListView }
+            , effects ++ [ SaveGroupListView newGroupListView ]
+            )
 
         DragEnd ->
             case ( model.dragState, model.dropState ) of
@@ -1162,14 +1189,9 @@ showArchivedToggleView model =
     else
         Toggle.toggleSwitch
             { ariaLabel = "Toggle whether archived pipelines are displayed"
-            , hrefRoute =
+            , hrefRoute = Just <|
                 Routes.Dashboard
-                    { searchType =
-                        if model.highDensity then
-                            Routes.HighDensity
-
-                        else
-                            Routes.Normal model.query
+                    { searchType = Routes.Normal model.query
                     , dashboardView =
                         if on then
                             Routes.ViewNonArchivedPipelines
@@ -1177,6 +1199,7 @@ showArchivedToggleView model =
                         else
                             Routes.ViewAllPipelines
                     }
+            , onToggle = NoOp
             , text = "show archived"
             , textDirection = Toggle.Left
             , on = on
@@ -1206,12 +1229,18 @@ dashboardView session model =
 
     else
         Html.div
-            (class (.pageBodyClass Message.Effects.stickyHeaderConfig)
-                :: id (toHtmlID Dashboard)
-                :: onScroll Scrolled
-                :: onMouseEnter (Hover <| Just Dashboard)
-                :: onMouseLeave (Hover Nothing)
-                :: Styles.content model.highDensity
+            ([ class (.pageBodyClass Message.Effects.stickyHeaderConfig)
+             , id (toHtmlID Dashboard)
+             , onScroll Scrolled
+             , onMouseEnter (Hover <| Just Dashboard)
+             , onMouseLeave (Hover Nothing)
+             ]
+                ++ (if Filter.isViewingInstanceGroups model.query then
+                        Styles.groupPageContent model.groupListView
+
+                    else
+                        Styles.content model.highDensity
+                   )
             )
             (case model.pipelines of
                 Nothing ->
@@ -1320,7 +1349,10 @@ turbulenceView path =
 
 dashboardCardsView : Session -> Model -> List (Html Message)
 dashboardCardsView session model =
-    if Filter.isViewingInstanceGroups model.query then
+    let
+        isViewingInstanceGroups = Filter.isViewingInstanceGroups model.query
+    in
+    if isViewingInstanceGroups then
         instanceGroupCardsView session model
 
     else
@@ -1386,7 +1418,7 @@ cardsView session params teamCards =
             Filter.isViewingInstanceGroups params.query
 
         ( headerView, offsetHeight ) =
-            if params.highDensity then
+            if (params.highDensity && not viewingInstanceGroups) || (params.groupListView && viewingInstanceGroups) then
                 ( [], 0 )
 
             else
@@ -1476,7 +1508,21 @@ cardsView session params teamCards =
 
         groupViews =
             teamCards
-                |> (if params.highDensity then
+                |> (if params.groupListView && viewingInstanceGroups then
+                        Group.listView
+                            { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
+                            , pipelineJobs = params.pipelineJobs
+                            , jobs = jobs
+                            , dashboardView = params.dashboardView
+                            , query = params.query
+                            , now = params.now
+                            , dragState = params.dragState
+                            , dropState = params.dropState
+                            }
+                            session
+                            session.hovered
+
+                    else if params.highDensity && not viewingInstanceGroups then
                         List.concatMap
                             (Group.hdView
                                 { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
@@ -1484,8 +1530,13 @@ cardsView session params teamCards =
                                 , jobs = jobs
                                 , dashboardView = params.dashboardView
                                 , query = params.query
+                                , highDensity = params.highDensity
+                                , now = params.now
+                                , dragState = params.dragState
+                                , dropState = params.dropState
                                 }
                                 session
+                                session.hovered
                             )
 
                     else

--- a/web/elm/src/Dashboard/DashboardPreview.elm
+++ b/web/elm/src/Dashboard/DashboardPreview.elm
@@ -1,7 +1,6 @@
 module Dashboard.DashboardPreview exposing (groupByRank, view)
 
 import Concourse
-import Concourse.PipelineStatus exposing (PipelineStatus(..), StatusDetails(..))
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
 import HoverState

--- a/web/elm/src/Dashboard/Drag.elm
+++ b/web/elm/src/Dashboard/Drag.elm
@@ -24,29 +24,28 @@ dragCardIndices card target cards =
         fromIndex =
             cardIndex card
     in
-    case fromIndex of
-        Nothing ->
-            Nothing
+    fromIndex
+        |> Maybe.andThen
+            (\from ->
+                let
+                    toIndex =
+                        case target of
+                            Before id ->
+                                cardIndex id
+                                    |> Maybe.map
+                                        (\targetIdx ->
+                                            if from < targetIdx then
+                                                targetIdx
 
-        Just from ->
-            let
-                toIndex =
-                    case target of
-                        Before id ->
-                            cardIndex id
-                                |> Maybe.map
-                                    (\targetIdx ->
-                                        if from < targetIdx then
-                                            targetIdx
+                                            else
+                                                targetIdx + 1
+                                        )
 
-                                        else
-                                            targetIdx + 1
-                                    )
-
-                        End ->
-                            Just (List.length cards)
-            in
-            toIndex |> Maybe.map (Tuple.pair from)
+                            End ->
+                                Just (List.length cards)
+                in
+                toIndex |> Maybe.map (Tuple.pair from)
+            )
 
 
 reverseIndices : Int -> ( Int, Int ) -> ( Int, Int )

--- a/web/elm/src/Dashboard/Drag.elm
+++ b/web/elm/src/Dashboard/Drag.elm
@@ -23,18 +23,30 @@ dragCardIndices card target cards =
 
         fromIndex =
             cardIndex card
-
-        toIndex =
-            (case target of
-                Before id ->
-                    cardIndex id
-
-                End ->
-                    List.length cards |> Just
-            )
-                |> Maybe.map ((+) 1)
     in
-    Maybe.map2 Tuple.pair fromIndex toIndex
+    case fromIndex of
+        Nothing ->
+            Nothing
+
+        Just from ->
+            let
+                toIndex =
+                    case target of
+                        Before id ->
+                            cardIndex id
+                                |> Maybe.map
+                                    (\targetIdx ->
+                                        if from < targetIdx then
+                                            targetIdx
+
+                                        else
+                                            targetIdx + 1
+                                    )
+
+                        End ->
+                            Just (List.length cards)
+            in
+            toIndex |> Maybe.map (Tuple.pair from)
 
 
 reverseIndices : Int -> ( Int, Int ) -> ( Int, Int )

--- a/web/elm/src/Dashboard/Footer.elm
+++ b/web/elm/src/Dashboard/Footer.elm
@@ -174,7 +174,7 @@ legend session model =
                     , PipelineStatusSucceeded PipelineStatus.Running
                     ]
                 ++ legendSeparator session.screenSize
-   ++ toggleView model
+                ++ toggleView model
 
 
 concourseInfo :

--- a/web/elm/src/Dashboard/Footer.elm
+++ b/web/elm/src/Dashboard/Footer.elm
@@ -14,7 +14,6 @@ import Keyboard
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..))
 import Message.Subscription exposing (Delivery(..), Interval(..))
-import Routes
 import ScreenSize
 import Views.Icon as Icon
 import Views.SearchBar exposing (Dropdown(..))
@@ -174,13 +173,8 @@ legend session model =
                     , PipelineStatusAborted PipelineStatus.Running
                     , PipelineStatusSucceeded PipelineStatus.Running
                     ]
-                ++ (if Filter.isViewingInstanceGroups model.query then
-                        []
-
-                    else
-                        legendSeparator session.screenSize
-                            ++ [ toggleView model ]
-                   )
+                ++ legendSeparator session.screenSize
+   ++ toggleView model
 
 
 concourseInfo :
@@ -242,25 +236,34 @@ legendItem status =
         ]
 
 
-toggleView : FooterModel r -> Html Message
-toggleView { highDensity, dashboardView } =
-    Toggle.toggleSwitch
-        { ariaLabel = "Toggle high-density view"
-        , hrefRoute =
-            Routes.Dashboard
-                { searchType =
-                    if highDensity then
-                        Routes.Normal ""
-
-                    else
-                        Routes.HighDensity
-                , dashboardView = dashboardView
+toggleView : FooterModel r -> List (Html Message)
+toggleView { highDensity, groupListView, query } =
+    let
+        hdToggle =
+            Toggle.toggleSwitch
+                { ariaLabel = "Toggle high-density view"
+                , hrefRoute = Nothing
+                , onToggle = ToggleHighDensity
+                , text = "high-density"
+                , textDirection = Toggle.Right
+                , on = highDensity
+                , styles = Styles.highDensityToggle
                 }
-        , text = "high-density"
-        , textDirection = Toggle.Right
-        , on = highDensity
-        , styles = Styles.highDensityToggle
-        }
+    in
+    if Filter.isViewingInstanceGroups query then
+        [ Toggle.toggleSwitch
+            { ariaLabel = "Toggle group list view"
+            , hrefRoute = Nothing
+            , onToggle = ToggleGroupListView
+            , text = "list view"
+            , textDirection = Toggle.Right
+            , on = groupListView
+            , styles = Styles.highDensityToggle
+            }
+        ]
+
+    else
+        [ hdToggle ]
 
 
 legendSeparator : ScreenSize.ScreenSize -> List (Html Message)

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -15,7 +15,7 @@ import Concourse exposing (flattenJson)
 import Concourse.PipelineStatus
 import Dashboard.Grid as Grid
 import Dashboard.Grid.Constants as GridConstants
-import Dashboard.Group.Models exposing (Card(..), Pipeline, cardIdentifier, cardTeamName)
+import Dashboard.Group.Models exposing (Card(..), Pipeline, cardIdentifier, cardPipeline, cardTeamName)
 import Dashboard.Group.Tag as Tag
 import Dashboard.InstanceGroup as InstanceGroup
 import Dashboard.Models exposing (DragState(..), DropState(..))
@@ -274,22 +274,29 @@ hdView :
     , jobs : Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
     , dashboardView : Routes.DashboardView
     , query : String
-    , highDensity : Bool
-    , now : Maybe Time.Posix
     , dragState : DragState
     , dropState : DropState
     }
     -> Session
-    -> HoverState.HoverState
     -> Section Card
     -> List (Html Message)
-hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query, dragState, dropState } session _ { teamName, cards, header } =
+hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query, dragState, dropState } session { teamName, cards, header } =
     let
         headerElement =
             Html.div
                 [ class "dashboard-team-name" ]
                 [ Html.text header ]
                 :: (Maybe.Extra.toList <| Maybe.map (Tag.view True) (tag session teamName))
+
+        hdPipelineArgs p =
+            { pipeline = p
+            , resourceError = Set.member p.id pipelinesWithResourceErrors
+            , existingJobs =
+                pipelineJobs
+                    |> Dict.get p.id
+                    |> Maybe.withDefault []
+                    |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
+            }
 
         teamPipelines =
             if List.isEmpty cards then
@@ -299,160 +306,53 @@ hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query, 
                 let
                     createCardWithDropZone card =
                         let
-                            cardHtml =
+                            isBeingDragged =
+                                case dragState of
+                                    Dragging currCard ->
+                                        cardIdentifier currCard == cardIdentifier card
+
+                                    _ ->
+                                        False
+
+                            dragAttributes =
+                                if cardIdentifier card /= "" then
+                                    [ attribute
+                                        "ondragstart"
+                                        "event.dataTransfer.setData('text/plain', '');"
+                                    , draggable "true"
+                                    , on "dragstart" (Json.Decode.succeed (DragStart card))
+                                    , on "dragend" (Json.Decode.succeed DragEnd)
+                                    ]
+
+                                else
+                                    []
+
+                            cardBody =
                                 case card of
                                     PipelineCard p ->
-                                        Html.div
-                                            ([ style "display" "flex"
-                                             , style "flex-direction" "column"
-                                             , style "width" "100%"
-                                             , style "min-width" "800px"
-                                             , style "margin-bottom" "3px"
-                                             ]
-                                                ++ (if cardIdentifier card /= "" then
-                                                        [ attribute
-                                                            "ondragstart"
-                                                            "event.dataTransfer.setData('text/plain', '');"
-                                                        , draggable "true"
-                                                        , on "dragstart"
-                                                            (Json.Decode.succeed (DragStart card))
-                                                        , on "dragend" (Json.Decode.succeed DragEnd)
-                                                        ]
-
-                                                    else
-                                                        []
-                                                   )
-                                                ++ (case dragState of
-                                                        Dragging currCard ->
-                                                            if cardIdentifier currCard == cardIdentifier card then
-                                                                [ style "width" "0"
-                                                                , style "margin" "0 12.5px"
-                                                                , style "overflow" "hidden"
-                                                                ]
-
-                                                            else
-                                                                []
-
-                                                        _ ->
-                                                            []
-                                                   )
-                                            )
-                                            [ Pipeline.hdPipelineView
-                                                session
-                                                { pipeline = p
-                                                , resourceError =
-                                                    pipelinesWithResourceErrors
-                                                        |> Set.member p.id
-                                                , existingJobs =
-                                                    pipelineJobs
-                                                        |> Dict.get p.id
-                                                        |> Maybe.withDefault []
-                                                        |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
-                                                }
-                                            ]
+                                        Pipeline.hdPipelineView session (hdPipelineArgs p)
 
                                     InstancedPipelineCard p ->
-                                        Html.div
-                                            ([ style "display" "flex"
-                                             , style "flex-direction" "column"
-                                             , style "width" "100%"
-                                             , style "min-width" "800px"
-                                             , style "margin-bottom" "3px"
-                                             ]
-                                                ++ (if cardIdentifier card /= "" then
-                                                        [ attribute
-                                                            "ondragstart"
-                                                            "event.dataTransfer.setData('text/plain', '');"
-                                                        , draggable "true"
-                                                        , on "dragstart"
-                                                            (Json.Decode.succeed (DragStart card))
-                                                        , on "dragend" (Json.Decode.succeed DragEnd)
-                                                        ]
-
-                                                    else
-                                                        []
-                                                   )
-                                                ++ (case dragState of
-                                                        Dragging currCard ->
-                                                            if cardIdentifier currCard == cardIdentifier card then
-                                                                [ style "width" "0"
-                                                                , style "margin" "0 12.5px"
-                                                                , style "overflow" "hidden"
-                                                                ]
-
-                                                            else
-                                                                []
-
-                                                        _ ->
-                                                            []
-                                                   )
-                                            )
-                                            [ Pipeline.hdPipelineView
-                                                session
-                                                { pipeline = p
-                                                , resourceError =
-                                                    pipelinesWithResourceErrors
-                                                        |> Set.member p.id
-                                                , existingJobs =
-                                                    pipelineJobs
-                                                        |> Dict.get p.id
-                                                        |> Maybe.withDefault []
-                                                        |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
-                                                }
-                                            ]
+                                        Pipeline.hdPipelineView session (hdPipelineArgs p)
 
                                     InstanceGroupCard p ps ->
-                                        Html.div
-                                            ([ style "display" "flex"
-                                             , style "flex-direction" "column"
-                                             , style "width" "100%"
-                                             , style "min-width" "800px"
-                                             , style "margin-bottom" "3px"
-                                             ]
-                                                ++ (if cardIdentifier card /= "" then
-                                                        [ attribute
-                                                            "ondragstart"
-                                                            "event.dataTransfer.setData('text/plain', '');"
-                                                        , draggable "true"
-                                                        , on "dragstart"
-                                                            (Json.Decode.succeed (DragStart card))
-                                                        , on "dragend" (Json.Decode.succeed DragEnd)
-                                                        ]
-
-                                                    else
-                                                        []
-                                                   )
-                                                ++ (case dragState of
-                                                        Dragging currCard ->
-                                                            if cardIdentifier currCard == cardIdentifier card then
-                                                                [ style "width" "0"
-                                                                , style "margin" "0 12.5px"
-                                                                , style "overflow" "hidden"
-                                                                ]
-
-                                                            else
-                                                                []
-
-                                                        _ ->
-                                                            []
-                                                   )
-                                            )
-                                            [ InstanceGroup.hdCardView
-                                                { pipeline = p
-                                                , pipelines = ps
-                                                , resourceError =
-                                                    List.any
-                                                        (\pipeline ->
-                                                            Set.member pipeline.id pipelinesWithResourceErrors
-                                                        )
-                                                        (p :: ps)
-                                                , dashboardView = dashboardView
-                                                , query = query
-                                                }
-                                            ]
+                                        InstanceGroup.hdCardView
+                                            { pipeline = p
+                                            , pipelines = ps
+                                            , resourceError =
+                                                List.any
+                                                    (\pipeline ->
+                                                        Set.member pipeline.id pipelinesWithResourceErrors
+                                                    )
+                                                    (p :: ps)
+                                            , dashboardView = dashboardView
+                                            , query = query
+                                            }
                         in
                         [ hdDropZoneView dragState dropState teamName card
-                        , cardHtml
+                        , Html.div
+                            (Styles.hdCardWrapper isBeingDragged ++ dragAttributes)
+                            [ cardBody ]
                         ]
                 in
                 cards
@@ -544,48 +444,22 @@ sortPipelinesForListView cards =
     cards
         |> List.sortBy
             (\card ->
-                case card of
-                    PipelineCard p ->
-                        ( if p.paused then
-                            1
+                let
+                    p =
+                        cardPipeline card
+                in
+                ( if p.paused then
+                    1
 
-                          else
-                            0
-                        , if p.archived then
-                            1
+                  else
+                    0
+                , if p.archived then
+                    1
 
-                          else
-                            0
-                        , p.name
-                        )
-
-                    InstancedPipelineCard p ->
-                        ( if p.paused then
-                            1
-
-                          else
-                            0
-                        , if p.archived then
-                            1
-
-                          else
-                            0
-                        , p.name
-                        )
-
-                    InstanceGroupCard p _ ->
-                        ( if p.paused then
-                            1
-
-                          else
-                            0
-                        , if p.archived then
-                            1
-
-                          else
-                            0
-                        , p.name
-                        )
+                  else
+                    0
+                , p.name
+                )
             )
 
 
@@ -604,22 +478,14 @@ renderPipelineRow :
     -> Html Message
 renderPipelineRow params session hovered card =
     let
+        pipelineId =
+            (cardPipeline card).id
+
         pipelineJobs =
-            case card of
-                InstanceGroupCard pipeline _ ->
-                    params.jobs
-                        |> Dict.filter (\( dbId, _ ) _ -> dbId == pipeline.id)
-                        |> Dict.values
-
-                InstancedPipelineCard pipeline ->
-                    params.jobs
-                        |> Dict.filter (\( dbId, _ ) _ -> dbId == pipeline.id)
-                        |> Dict.values
-
-                PipelineCard pipeline ->
-                    params.jobs
-                        |> Dict.filter (\( dbId, _ ) _ -> dbId == pipeline.id)
-                        |> Dict.values
+            params.pipelineJobs
+                |> Dict.get pipelineId
+                |> Maybe.withDefault []
+                |> List.filterMap (\j -> Dict.get ( pipelineId, j ) params.jobs)
 
         isBeingDragged =
             case params.dragState of
@@ -1153,26 +1019,12 @@ hdDropZoneView dragState dropState teamName targetCard =
                     False
     in
     Html.div
-        [ style "height"
-            (if active then
-                "8px"
-
-             else
-                "3px"
-            )
-        , style "width" "100%"
-        , style "background-color"
-            (if active then
-                "#2196F3"
-
-             else
-                "transparent"
-            )
-        , style "transition" "height 0.1s ease, background-color 0.1s ease"
-        , on "dragenter" (Json.Decode.succeed (DragOver (Before targetCard)))
-        , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver (Before targetCard), True ))
-        , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
-        ]
+        (Styles.cardDropZone active
+            ++ [ on "dragenter" (Json.Decode.succeed (DragOver (Before targetCard)))
+               , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver (Before targetCard), True ))
+               , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
+               ]
+        )
         []
 
 
@@ -1196,26 +1048,12 @@ endDropZoneView dragState dropState teamName =
                     False
     in
     Html.div
-        [ style "height"
-            (if anyDragHappening then
-                "50px"
-
-             else
-                "3px"
-            )
-        , style "width" "100%"
-        , style "background-color"
-            (if active then
-                "#2196F3"
-
-             else
-                "transparent"
-            )
-        , style "transition" "background-color 0.1s ease"
-        , on "dragenter" (Json.Decode.succeed (DragOver End))
-        , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver End, True ))
-        , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
-        ]
+        (Styles.endDropZone { active = active, anyDragHappening = anyDragHappening }
+            ++ [ on "dragenter" (Json.Decode.succeed (DragOver End))
+               , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver End, True ))
+               , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
+               ]
+        )
         []
 
 

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -23,11 +23,11 @@ import Dashboard.Pipeline as Pipeline
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
 import Favorites
+import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, class, classList, draggable, href, id, style)
 import Html.Events exposing (on, preventDefaultOn, stopPropagationOn)
 import Html.Keyed
-import HoverState
 import Json.Decode
 import Maybe.Extra
 import Message.Effects as Effects
@@ -283,7 +283,7 @@ hdView :
     -> HoverState.HoverState
     -> Section Card
     -> List (Html Message)
-hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query, highDensity, now, dragState, dropState } session hovered { teamName, cards, header } =
+hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query, dragState, dropState } session _ { teamName, cards, header } =
     let
         headerElement =
             Html.div
@@ -299,153 +299,157 @@ hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query, 
                 let
                     createCardWithDropZone card =
                         let
-                            cardHtml = case card of
-                                PipelineCard p ->
-                                    Html.div
-                                        ([ style "display" "flex"
-                                         , style "flex-direction" "column"
-                                         , style "width" "100%"
-                                         , style "min-width" "800px"
-                                         , style "margin-bottom" "3px"
-                                         ] ++ (if cardIdentifier card /= "" then
-                                                [ attribute
-                                                    "ondragstart"
-                                                    "event.dataTransfer.setData('text/plain', '');"
-                                                , draggable "true"
-                                                , on "dragstart"
-                                                    (Json.Decode.succeed (DragStart card))
-                                                , on "dragend" (Json.Decode.succeed DragEnd)
-                                                ]
-
-                                            else
-                                                []
-                                           )
-                                        ++ (case dragState of
-                                                Dragging currCard ->
-                                                    if cardIdentifier currCard == cardIdentifier card then
-                                                        [ style "width" "0"
-                                                        , style "margin" "0 12.5px"
-                                                        , style "overflow" "hidden"
+                            cardHtml =
+                                case card of
+                                    PipelineCard p ->
+                                        Html.div
+                                            ([ style "display" "flex"
+                                             , style "flex-direction" "column"
+                                             , style "width" "100%"
+                                             , style "min-width" "800px"
+                                             , style "margin-bottom" "3px"
+                                             ]
+                                                ++ (if cardIdentifier card /= "" then
+                                                        [ attribute
+                                                            "ondragstart"
+                                                            "event.dataTransfer.setData('text/plain', '');"
+                                                        , draggable "true"
+                                                        , on "dragstart"
+                                                            (Json.Decode.succeed (DragStart card))
+                                                        , on "dragend" (Json.Decode.succeed DragEnd)
                                                         ]
 
                                                     else
                                                         []
+                                                   )
+                                                ++ (case dragState of
+                                                        Dragging currCard ->
+                                                            if cardIdentifier currCard == cardIdentifier card then
+                                                                [ style "width" "0"
+                                                                , style "margin" "0 12.5px"
+                                                                , style "overflow" "hidden"
+                                                                ]
 
-                                                _ ->
-                                                    []
-                                           )
-                                        )
-                                        [ Pipeline.hdPipelineView
-                                            session
-                                            { pipeline = p
-                                            , resourceError =
-                                                pipelinesWithResourceErrors
-                                                    |> Set.member p.id
-                                            , existingJobs =
-                                                pipelineJobs
-                                                |> Dict.get p.id
-                                                |> Maybe.withDefault []
-                                                |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
-                                            }
-                                        ]
+                                                            else
+                                                                []
 
-                                InstancedPipelineCard p ->
-                                    Html.div
-                                        ([ style "display" "flex"
-                                         , style "flex-direction" "column"
-                                         , style "width" "100%"
-                                         , style "min-width" "800px"
-                                         , style "margin-bottom" "3px"
-                                         ] ++ (if cardIdentifier card /= "" then
-                                                [ attribute
-                                                    "ondragstart"
-                                                    "event.dataTransfer.setData('text/plain', '');"
-                                                , draggable "true"
-                                                , on "dragstart"
-                                                    (Json.Decode.succeed (DragStart card))
-                                                , on "dragend" (Json.Decode.succeed DragEnd)
-                                                ]
+                                                        _ ->
+                                                            []
+                                                   )
+                                            )
+                                            [ Pipeline.hdPipelineView
+                                                session
+                                                { pipeline = p
+                                                , resourceError =
+                                                    pipelinesWithResourceErrors
+                                                        |> Set.member p.id
+                                                , existingJobs =
+                                                    pipelineJobs
+                                                        |> Dict.get p.id
+                                                        |> Maybe.withDefault []
+                                                        |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
+                                                }
+                                            ]
 
-                                            else
-                                                []
-                                           )
-                                        ++ (case dragState of
-                                                Dragging currCard ->
-                                                    if cardIdentifier currCard == cardIdentifier card then
-                                                        [ style "width" "0"
-                                                        , style "margin" "0 12.5px"
-                                                        , style "overflow" "hidden"
+                                    InstancedPipelineCard p ->
+                                        Html.div
+                                            ([ style "display" "flex"
+                                             , style "flex-direction" "column"
+                                             , style "width" "100%"
+                                             , style "min-width" "800px"
+                                             , style "margin-bottom" "3px"
+                                             ]
+                                                ++ (if cardIdentifier card /= "" then
+                                                        [ attribute
+                                                            "ondragstart"
+                                                            "event.dataTransfer.setData('text/plain', '');"
+                                                        , draggable "true"
+                                                        , on "dragstart"
+                                                            (Json.Decode.succeed (DragStart card))
+                                                        , on "dragend" (Json.Decode.succeed DragEnd)
                                                         ]
 
                                                     else
                                                         []
+                                                   )
+                                                ++ (case dragState of
+                                                        Dragging currCard ->
+                                                            if cardIdentifier currCard == cardIdentifier card then
+                                                                [ style "width" "0"
+                                                                , style "margin" "0 12.5px"
+                                                                , style "overflow" "hidden"
+                                                                ]
 
-                                                _ ->
-                                                    []
-                                           )
-                                        )
-                                        [ Pipeline.hdPipelineView
-                                            session
-                                            { pipeline = p
-                                            , resourceError =
-                                                pipelinesWithResourceErrors
-                                                    |> Set.member p.id
-                                            , existingJobs =
-                                                pipelineJobs
-                                                |> Dict.get p.id
-                                                |> Maybe.withDefault []
-                                                |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
-                                            }
-                                        ]
+                                                            else
+                                                                []
 
-                                InstanceGroupCard p ps ->
-                                    Html.div
-                                        ([ style "display" "flex"
-                                         , style "flex-direction" "column"
-                                         , style "width" "100%"
-                                         , style "min-width" "800px"
-                                         , style "margin-bottom" "3px"
-                                         ] ++ (if cardIdentifier card /= "" then
-                                                [ attribute
-                                                    "ondragstart"
-                                                    "event.dataTransfer.setData('text/plain', '');"
-                                                , draggable "true"
-                                                , on "dragstart"
-                                                    (Json.Decode.succeed (DragStart card))
-                                                , on "dragend" (Json.Decode.succeed DragEnd)
-                                                ]
+                                                        _ ->
+                                                            []
+                                                   )
+                                            )
+                                            [ Pipeline.hdPipelineView
+                                                session
+                                                { pipeline = p
+                                                , resourceError =
+                                                    pipelinesWithResourceErrors
+                                                        |> Set.member p.id
+                                                , existingJobs =
+                                                    pipelineJobs
+                                                        |> Dict.get p.id
+                                                        |> Maybe.withDefault []
+                                                        |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
+                                                }
+                                            ]
 
-                                            else
-                                                []
-                                           )
-                                        ++ (case dragState of
-                                                Dragging currCard ->
-                                                    if cardIdentifier currCard == cardIdentifier card then
-                                                        [ style "width" "0"
-                                                        , style "margin" "0 12.5px"
-                                                        , style "overflow" "hidden"
+                                    InstanceGroupCard p ps ->
+                                        Html.div
+                                            ([ style "display" "flex"
+                                             , style "flex-direction" "column"
+                                             , style "width" "100%"
+                                             , style "min-width" "800px"
+                                             , style "margin-bottom" "3px"
+                                             ]
+                                                ++ (if cardIdentifier card /= "" then
+                                                        [ attribute
+                                                            "ondragstart"
+                                                            "event.dataTransfer.setData('text/plain', '');"
+                                                        , draggable "true"
+                                                        , on "dragstart"
+                                                            (Json.Decode.succeed (DragStart card))
+                                                        , on "dragend" (Json.Decode.succeed DragEnd)
                                                         ]
 
                                                     else
                                                         []
+                                                   )
+                                                ++ (case dragState of
+                                                        Dragging currCard ->
+                                                            if cardIdentifier currCard == cardIdentifier card then
+                                                                [ style "width" "0"
+                                                                , style "margin" "0 12.5px"
+                                                                , style "overflow" "hidden"
+                                                                ]
 
-                                                _ ->
-                                                    []
-                                           )
-                                        )
-                                        [ InstanceGroup.hdCardView
-                                            { pipeline = p
-                                            , pipelines = ps
-                                            , resourceError =
-                                                List.any
-                                                    (\pipeline ->
-                                                        Set.member pipeline.id pipelinesWithResourceErrors
-                                                    )
-                                                    (p :: ps)
-                                            , dashboardView = dashboardView
-                                            , query = query
-                                            }
-                                        ]
+                                                            else
+                                                                []
+
+                                                        _ ->
+                                                            []
+                                                   )
+                                            )
+                                            [ InstanceGroup.hdCardView
+                                                { pipeline = p
+                                                , pipelines = ps
+                                                , resourceError =
+                                                    List.any
+                                                        (\pipeline ->
+                                                            Set.member pipeline.id pipelinesWithResourceErrors
+                                                        )
+                                                        (p :: ps)
+                                                , dashboardView = dashboardView
+                                                , query = query
+                                                }
+                                            ]
                         in
                         [ hdDropZoneView dragState dropState teamName card
                         , cardHtml
@@ -497,53 +501,92 @@ listView :
     -> List (Section Card)
     -> List (Html Message)
 listView params session hovered sections =
-    List.map (\section ->
-        Html.div Styles.listViewTeamGroup
-            [ Html.div Styles.listViewTeamHeader
-                [ Html.div Styles.listViewTeamName
-                    [ Html.text section.header ]
+    List.map
+        (\section ->
+            Html.div Styles.listViewTeamGroup
+                [ Html.div Styles.listViewTeamHeader
+                    [ Html.div Styles.listViewTeamName
+                        [ Html.text section.header ]
+                    ]
+                , Html.div Styles.listView
+                    (if List.isEmpty section.cards then
+                        [ pipelineNotSetView ]
+
+                     else
+                        section.cards
+                            |> sortPipelinesForListView
+                            |> List.concatMap
+                                (\card ->
+                                    [ hdDropZoneView params.dragState params.dropState section.teamName card
+                                    , renderPipelineRow
+                                        { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
+                                        , pipelineJobs = params.pipelineJobs
+                                        , jobs = params.jobs
+                                        , dashboardView = params.dashboardView
+                                        , query = params.query
+                                        , now = params.now
+                                        , dragState = params.dragState
+                                        }
+                                        session
+                                        hovered
+                                        card
+                                    ]
+                                )
+                            |> (\rows -> rows ++ [ endDropZoneView params.dragState params.dropState section.teamName ])
+                    )
                 ]
-            , Html.div Styles.listView
-                (if List.isEmpty section.cards then
-                    [ pipelineNotSetView ]
-                else
-                    section.cards
-                        |> sortPipelinesForListView
-                        |> List.concatMap (\card ->
-                            [ hdDropZoneView params.dragState params.dropState section.teamName card
-                            , renderPipelineRow 
-                                { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
-                                , pipelineJobs = params.pipelineJobs
-                                , jobs = params.jobs
-                                , dashboardView = params.dashboardView
-                                , query = params.query
-                                , now = params.now
-                                , dragState = params.dragState
-                                } 
-                                session 
-                                hovered
-                                card
-                            ])
-                        |> (\rows -> rows ++ [ endDropZoneView params.dragState params.dropState section.teamName ])
-                )
-            ]
-    ) sections
+        )
+        sections
 
 
 sortPipelinesForListView : List Card -> List Card
 sortPipelinesForListView cards =
     cards
-        |> List.sortBy (\card ->
-            case card of
-                PipelineCard p ->
-                    (if p.paused then 1 else 0, if p.archived then 1 else 0, p.name)
-                
-                InstancedPipelineCard p ->
-                    (if p.paused then 1 else 0, if p.archived then 1 else 0, p.name)
-                
-                InstanceGroupCard p ps ->
-                    (if p.paused then 1 else 0, if p.archived then 1 else 0, p.name)
-        )
+        |> List.sortBy
+            (\card ->
+                case card of
+                    PipelineCard p ->
+                        ( if p.paused then
+                            1
+
+                          else
+                            0
+                        , if p.archived then
+                            1
+
+                          else
+                            0
+                        , p.name
+                        )
+
+                    InstancedPipelineCard p ->
+                        ( if p.paused then
+                            1
+
+                          else
+                            0
+                        , if p.archived then
+                            1
+
+                          else
+                            0
+                        , p.name
+                        )
+
+                    InstanceGroupCard p _ ->
+                        ( if p.paused then
+                            1
+
+                          else
+                            0
+                        , if p.archived then
+                            1
+
+                          else
+                            0
+                        , p.name
+                        )
+            )
 
 
 renderPipelineRow :
@@ -561,21 +604,22 @@ renderPipelineRow :
     -> Html Message
 renderPipelineRow params session hovered card =
     let
-        pipelineJobs = case card of
-            InstanceGroupCard pipeline _ ->
-                params.jobs
-                    |> Dict.filter (\(dbId, _) _ -> dbId == pipeline.id)
-                    |> Dict.values
-            
-            InstancedPipelineCard pipeline ->
-                params.jobs
-                    |> Dict.filter (\(dbId, _) _ -> dbId == pipeline.id)
-                    |> Dict.values
-            
-            PipelineCard pipeline ->
-                params.jobs
-                    |> Dict.filter (\(dbId, _) _ -> dbId == pipeline.id)
-                    |> Dict.values
+        pipelineJobs =
+            case card of
+                InstanceGroupCard pipeline _ ->
+                    params.jobs
+                        |> Dict.filter (\( dbId, _ ) _ -> dbId == pipeline.id)
+                        |> Dict.values
+
+                InstancedPipelineCard pipeline ->
+                    params.jobs
+                        |> Dict.filter (\( dbId, _ ) _ -> dbId == pipeline.id)
+                        |> Dict.values
+
+                PipelineCard pipeline ->
+                    params.jobs
+                        |> Dict.filter (\( dbId, _ ) _ -> dbId == pipeline.id)
+                        |> Dict.values
 
         isBeingDragged =
             case params.dragState of
@@ -594,7 +638,7 @@ renderPipelineRow params session hovered card =
                     False
     in
     case card of
-        InstanceGroupCard pipeline pipelines ->
+        InstanceGroupCard pipeline _ ->
             Html.div
                 (Styles.listViewRowContainer isBeingDragged
                     ++ [ attribute
@@ -629,12 +673,12 @@ renderPipelineRow params session hovered card =
                     , Html.div (Styles.listViewPipelineRow ++ [ style "flex-grow" "1" ])
                         [ Html.div Styles.listViewRowContent
                             [ Html.div Styles.listViewPipelineInfo
-                                (getPipelineDisplayNameHtml pipeline) ]
+                                (getPipelineDisplayNameHtml pipeline)
+                            ]
                         ]
                     ]
                 ]
 
-        
         InstancedPipelineCard pipeline ->
             let
                 statusColor =
@@ -679,7 +723,6 @@ renderPipelineRow params session hovered card =
                     (renderPipelineButtons pipeline AllPipelinesSection session hovered)
                 ]
 
-        
         PipelineCard pipeline ->
             let
                 statusColor =
@@ -722,7 +765,6 @@ renderPipelineRow params session hovered card =
                         ]
                     ]
                 ]
-
 
 
 getPipelineStatusText : List Concourse.Job -> Pipeline -> Maybe Time.Posix -> String
@@ -834,7 +876,6 @@ renderPipelineButtons pipeline section session hovered =
 
     else
         [ pauseToggle, visibilityButton, favoritedIcon ]
-
 
 
 pipelineCardView :
@@ -1103,20 +1144,34 @@ hdDropZoneView dragState dropState teamName targetCard =
         active =
             case ( dragState, dropState ) of
                 ( Dragging draggingCard, Dropping (Before hoveredCard) ) ->
-                    cardTeamName draggingCard == teamName
-                        && cardIdentifier hoveredCard == cardIdentifier targetCard
+                    cardTeamName draggingCard
+                        == teamName
+                        && cardIdentifier hoveredCard
+                        == cardIdentifier targetCard
 
                 _ ->
                     False
     in
     Html.div
-        [ style "height" (if active then "8px" else "3px")
+        [ style "height"
+            (if active then
+                "8px"
+
+             else
+                "3px"
+            )
         , style "width" "100%"
-        , style "background-color" (if active then "#2196F3" else "transparent")
+        , style "background-color"
+            (if active then
+                "#2196F3"
+
+             else
+                "transparent"
+            )
         , style "transition" "height 0.1s ease, background-color 0.1s ease"
         , on "dragenter" (Json.Decode.succeed (DragOver (Before targetCard)))
-        , preventDefaultOn "dragover" (Json.Decode.succeed (DragOver (Before targetCard), True))
-        , stopPropagationOn "drop" (Json.Decode.succeed (DragEnd, True))
+        , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver (Before targetCard), True ))
+        , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
         ]
         []
 
@@ -1141,9 +1196,21 @@ endDropZoneView dragState dropState teamName =
                     False
     in
     Html.div
-        [ style "height" (if anyDragHappening then "50px" else "3px")
+        [ style "height"
+            (if anyDragHappening then
+                "50px"
+
+             else
+                "3px"
+            )
         , style "width" "100%"
-        , style "background-color" (if active then "#2196F3" else "transparent")
+        , style "background-color"
+            (if active then
+                "#2196F3"
+
+             else
+                "transparent"
+            )
         , style "transition" "background-color 0.1s ease"
         , on "dragenter" (Json.Decode.succeed (DragOver End))
         , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver End, True ))

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -2,6 +2,7 @@ module Dashboard.Group exposing
     ( PipelineIndex
     , Section
     , hdView
+    , listView
     , ordering
     , pipelineNotSetView
     , view
@@ -9,7 +10,9 @@ module Dashboard.Group exposing
     )
 
 import Application.Models exposing (Session)
-import Concourse
+import Colors
+import Concourse exposing (flattenJson)
+import Concourse.PipelineStatus
 import Dashboard.Grid as Grid
 import Dashboard.Grid.Constants as GridConstants
 import Dashboard.Group.Models exposing (Card(..), Pipeline, cardIdentifier, cardTeamName)
@@ -19,10 +22,12 @@ import Dashboard.Models exposing (DragState(..), DropState(..))
 import Dashboard.Pipeline as Pipeline
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
+import Favorites
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, class, classList, draggable, id, style)
+import Html.Attributes exposing (attribute, class, classList, draggable, href, id, style)
 import Html.Events exposing (on, preventDefaultOn, stopPropagationOn)
 import Html.Keyed
+import HoverState
 import Json.Decode
 import Maybe.Extra
 import Message.Effects as Effects
@@ -31,7 +36,10 @@ import Ordering exposing (Ordering)
 import Routes
 import Set exposing (Set)
 import Time
+import Tooltip
 import UserState exposing (UserState(..))
+import Views.FavoritedIcon
+import Views.PauseToggle as PauseToggle
 import Views.Spinner as Spinner
 import Views.Styles
 
@@ -266,11 +274,16 @@ hdView :
     , jobs : Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
     , dashboardView : Routes.DashboardView
     , query : String
+    , highDensity : Bool
+    , now : Maybe Time.Posix
+    , dragState : DragState
+    , dropState : DropState
     }
-    -> { a | userState : UserState, pipelineRunningKeyframes : String }
+    -> Session
+    -> HoverState.HoverState
     -> Section Card
     -> List (Html Message)
-hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query } session { teamName, cards, header } =
+hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query, highDensity, now, dragState, dropState } session hovered { teamName, cards, header } =
     let
         headerElement =
             Html.div
@@ -283,52 +296,165 @@ hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query }
                 [ pipelineNotSetView ]
 
             else
-                cards
-                    |> List.map
-                        (\card ->
-                            case card of
+                let
+                    createCardWithDropZone card =
+                        let
+                            cardHtml = case card of
                                 PipelineCard p ->
-                                    Pipeline.hdPipelineView
-                                        session
-                                        { pipeline = p
-                                        , resourceError =
-                                            pipelinesWithResourceErrors
-                                                |> Set.member p.id
-                                        , existingJobs =
-                                            pipelineJobs
+                                    Html.div
+                                        ([ style "display" "flex"
+                                         , style "flex-direction" "column"
+                                         , style "width" "100%"
+                                         , style "min-width" "800px"
+                                         , style "margin-bottom" "3px"
+                                         ] ++ (if cardIdentifier card /= "" then
+                                                [ attribute
+                                                    "ondragstart"
+                                                    "event.dataTransfer.setData('text/plain', '');"
+                                                , draggable "true"
+                                                , on "dragstart"
+                                                    (Json.Decode.succeed (DragStart card))
+                                                , on "dragend" (Json.Decode.succeed DragEnd)
+                                                ]
+
+                                            else
+                                                []
+                                           )
+                                        ++ (case dragState of
+                                                Dragging currCard ->
+                                                    if cardIdentifier currCard == cardIdentifier card then
+                                                        [ style "width" "0"
+                                                        , style "margin" "0 12.5px"
+                                                        , style "overflow" "hidden"
+                                                        ]
+
+                                                    else
+                                                        []
+
+                                                _ ->
+                                                    []
+                                           )
+                                        )
+                                        [ Pipeline.hdPipelineView
+                                            session
+                                            { pipeline = p
+                                            , resourceError =
+                                                pipelinesWithResourceErrors
+                                                    |> Set.member p.id
+                                            , existingJobs =
+                                                pipelineJobs
                                                 |> Dict.get p.id
                                                 |> Maybe.withDefault []
                                                 |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
-                                        }
+                                            }
+                                        ]
 
                                 InstancedPipelineCard p ->
-                                    Pipeline.hdPipelineView
-                                        session
-                                        { pipeline = p
-                                        , resourceError =
-                                            pipelinesWithResourceErrors
-                                                |> Set.member p.id
-                                        , existingJobs =
-                                            pipelineJobs
+                                    Html.div
+                                        ([ style "display" "flex"
+                                         , style "flex-direction" "column"
+                                         , style "width" "100%"
+                                         , style "min-width" "800px"
+                                         , style "margin-bottom" "3px"
+                                         ] ++ (if cardIdentifier card /= "" then
+                                                [ attribute
+                                                    "ondragstart"
+                                                    "event.dataTransfer.setData('text/plain', '');"
+                                                , draggable "true"
+                                                , on "dragstart"
+                                                    (Json.Decode.succeed (DragStart card))
+                                                , on "dragend" (Json.Decode.succeed DragEnd)
+                                                ]
+
+                                            else
+                                                []
+                                           )
+                                        ++ (case dragState of
+                                                Dragging currCard ->
+                                                    if cardIdentifier currCard == cardIdentifier card then
+                                                        [ style "width" "0"
+                                                        , style "margin" "0 12.5px"
+                                                        , style "overflow" "hidden"
+                                                        ]
+
+                                                    else
+                                                        []
+
+                                                _ ->
+                                                    []
+                                           )
+                                        )
+                                        [ Pipeline.hdPipelineView
+                                            session
+                                            { pipeline = p
+                                            , resourceError =
+                                                pipelinesWithResourceErrors
+                                                    |> Set.member p.id
+                                            , existingJobs =
+                                                pipelineJobs
                                                 |> Dict.get p.id
                                                 |> Maybe.withDefault []
                                                 |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
-                                        }
+                                            }
+                                        ]
 
                                 InstanceGroupCard p ps ->
-                                    InstanceGroup.hdCardView
-                                        { pipeline = p
-                                        , pipelines = ps
-                                        , resourceError =
-                                            List.any
-                                                (\pipeline ->
-                                                    Set.member pipeline.id pipelinesWithResourceErrors
-                                                )
-                                                (p :: ps)
-                                        , dashboardView = dashboardView
-                                        , query = query
-                                        }
-                        )
+                                    Html.div
+                                        ([ style "display" "flex"
+                                         , style "flex-direction" "column"
+                                         , style "width" "100%"
+                                         , style "min-width" "800px"
+                                         , style "margin-bottom" "3px"
+                                         ] ++ (if cardIdentifier card /= "" then
+                                                [ attribute
+                                                    "ondragstart"
+                                                    "event.dataTransfer.setData('text/plain', '');"
+                                                , draggable "true"
+                                                , on "dragstart"
+                                                    (Json.Decode.succeed (DragStart card))
+                                                , on "dragend" (Json.Decode.succeed DragEnd)
+                                                ]
+
+                                            else
+                                                []
+                                           )
+                                        ++ (case dragState of
+                                                Dragging currCard ->
+                                                    if cardIdentifier currCard == cardIdentifier card then
+                                                        [ style "width" "0"
+                                                        , style "margin" "0 12.5px"
+                                                        , style "overflow" "hidden"
+                                                        ]
+
+                                                    else
+                                                        []
+
+                                                _ ->
+                                                    []
+                                           )
+                                        )
+                                        [ InstanceGroup.hdCardView
+                                            { pipeline = p
+                                            , pipelines = ps
+                                            , resourceError =
+                                                List.any
+                                                    (\pipeline ->
+                                                        Set.member pipeline.id pipelinesWithResourceErrors
+                                                    )
+                                                    (p :: ps)
+                                            , dashboardView = dashboardView
+                                            , query = query
+                                            }
+                                        ]
+                        in
+                        [ hdDropZoneView dragState dropState teamName card
+                        , cardHtml
+                        ]
+                in
+                cards
+                    |> List.concatMap createCardWithDropZone
+                    |> List.tail
+                    |> Maybe.withDefault []
     in
     case teamPipelines of
         [] ->
@@ -354,6 +480,361 @@ pipelineNotSetView =
                 [ Html.text "no pipelines set" ]
             ]
         ]
+
+
+listView :
+    { pipelinesWithResourceErrors : Set Concourse.DatabaseID
+    , pipelineJobs : Dict Concourse.DatabaseID (List Concourse.JobName)
+    , jobs : Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
+    , dashboardView : Routes.DashboardView
+    , query : String
+    , now : Maybe Time.Posix
+    , dragState : DragState
+    , dropState : DropState
+    }
+    -> Session
+    -> HoverState.HoverState
+    -> List (Section Card)
+    -> List (Html Message)
+listView params session hovered sections =
+    List.map (\section ->
+        Html.div Styles.listViewTeamGroup
+            [ Html.div Styles.listViewTeamHeader
+                [ Html.div Styles.listViewTeamName
+                    [ Html.text section.header ]
+                ]
+            , Html.div Styles.listView
+                (if List.isEmpty section.cards then
+                    [ pipelineNotSetView ]
+                else
+                    section.cards
+                        |> sortPipelinesForListView
+                        |> List.concatMap (\card ->
+                            [ hdDropZoneView params.dragState params.dropState section.teamName card
+                            , renderPipelineRow 
+                                { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
+                                , pipelineJobs = params.pipelineJobs
+                                , jobs = params.jobs
+                                , dashboardView = params.dashboardView
+                                , query = params.query
+                                , now = params.now
+                                , dragState = params.dragState
+                                } 
+                                session 
+                                hovered
+                                card
+                            ])
+                        |> (\rows -> rows ++ [ endDropZoneView params.dragState params.dropState section.teamName ])
+                )
+            ]
+    ) sections
+
+
+sortPipelinesForListView : List Card -> List Card
+sortPipelinesForListView cards =
+    cards
+        |> List.sortBy (\card ->
+            case card of
+                PipelineCard p ->
+                    (if p.paused then 1 else 0, if p.archived then 1 else 0, p.name)
+                
+                InstancedPipelineCard p ->
+                    (if p.paused then 1 else 0, if p.archived then 1 else 0, p.name)
+                
+                InstanceGroupCard p ps ->
+                    (if p.paused then 1 else 0, if p.archived then 1 else 0, p.name)
+        )
+
+
+renderPipelineRow :
+    { pipelinesWithResourceErrors : Set Concourse.DatabaseID
+    , pipelineJobs : Dict Concourse.DatabaseID (List Concourse.JobName)
+    , jobs : Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
+    , dashboardView : Routes.DashboardView
+    , query : String
+    , now : Maybe Time.Posix
+    , dragState : DragState
+    }
+    -> Session
+    -> HoverState.HoverState
+    -> Card
+    -> Html Message
+renderPipelineRow params session hovered card =
+    let
+        pipelineJobs = case card of
+            InstanceGroupCard pipeline _ ->
+                params.jobs
+                    |> Dict.filter (\(dbId, _) _ -> dbId == pipeline.id)
+                    |> Dict.values
+            
+            InstancedPipelineCard pipeline ->
+                params.jobs
+                    |> Dict.filter (\(dbId, _) _ -> dbId == pipeline.id)
+                    |> Dict.values
+            
+            PipelineCard pipeline ->
+                params.jobs
+                    |> Dict.filter (\(dbId, _) _ -> dbId == pipeline.id)
+                    |> Dict.values
+
+        isBeingDragged =
+            case params.dragState of
+                Dragging draggedCard ->
+                    cardIdentifier draggedCard == cardIdentifier card
+
+                _ ->
+                    False
+
+        anyDragHappening =
+            case params.dragState of
+                Dragging _ ->
+                    True
+
+                NotDragging ->
+                    False
+    in
+    case card of
+        InstanceGroupCard pipeline pipelines ->
+            Html.div
+                (Styles.listViewRowContainer isBeingDragged
+                    ++ [ attribute
+                            "ondragstart"
+                            "event.dataTransfer.setData('text/plain', '');"
+                       , draggable "true"
+                       , on "dragstart"
+                            (Json.Decode.succeed (DragStart <| card))
+                       , on "dragend" (Json.Decode.succeed DragEnd)
+                       ]
+                )
+                [ Html.div
+                    (Styles.listViewRowOverlay anyDragHappening
+                        ++ [ preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver (Before card), True ))
+                           , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
+                           ]
+                    )
+                    []
+                , Html.a
+                    ([ draggable "false"
+                     , href <|
+                        Routes.toString <|
+                            InstanceGroup.instanceGroupRoute
+                                { pipeline = pipeline
+                                , dashboardView = params.dashboardView
+                                , query = params.query
+                                }
+                     ]
+                        ++ Styles.listViewRowLink
+                    )
+                    [ Html.div Styles.listViewInstanceGroupBar []
+                    , Html.div (Styles.listViewPipelineRow ++ [ style "flex-grow" "1" ])
+                        [ Html.div Styles.listViewRowContent
+                            [ Html.div Styles.listViewPipelineInfo
+                                (getPipelineDisplayNameHtml pipeline) ]
+                        ]
+                    ]
+                ]
+
+        
+        InstancedPipelineCard pipeline ->
+            let
+                statusColor =
+                    Colors.statusColor True (Pipeline.pipelineStatus pipelineJobs pipeline)
+            in
+            Html.div
+                (Styles.listViewRowContainer isBeingDragged
+                    ++ [ style "align-items" "stretch"
+                       , attribute
+                            "ondragstart"
+                            "event.dataTransfer.setData('text/plain', '');"
+                       , draggable "true"
+                       , on "dragstart"
+                            (Json.Decode.succeed (DragStart <| card))
+                       , on "dragend" (Json.Decode.succeed DragEnd)
+                       ]
+                )
+                [ Html.div
+                    (Styles.listViewRowOverlay anyDragHappening
+                        ++ [ preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver (Before card), True ))
+                           , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
+                           ]
+                    )
+                    []
+                , Html.a
+                    ([ draggable "false"
+                     , href <| Routes.toString <| Routes.pipelineRoute pipeline []
+                     ]
+                        ++ Styles.listViewInstancedRowLink
+                    )
+                    [ Html.div (Styles.listViewRowStatusBar statusColor) []
+                    , Html.div (Styles.listViewPipelineRow ++ [ style "flex-grow" "1" ])
+                        [ Html.div Styles.listViewRowContent
+                            [ Html.div Styles.listViewPipelineInfo
+                                (getPipelineDisplayNameHtml pipeline)
+                            , Html.div (Styles.listViewPipelineStatusColored statusColor)
+                                [ Html.text (getPipelineStatusText pipelineJobs pipeline params.now) ]
+                            ]
+                        ]
+                    ]
+                , Html.div Styles.listViewInstancedPipelineButtons
+                    (renderPipelineButtons pipeline AllPipelinesSection session hovered)
+                ]
+
+        
+        PipelineCard pipeline ->
+            let
+                statusColor =
+                    Colors.statusColor True (Pipeline.pipelineStatus pipelineJobs pipeline)
+            in
+            Html.div
+                (Styles.listViewRowContainer isBeingDragged
+                    ++ [ attribute
+                            "ondragstart"
+                            "event.dataTransfer.setData('text/plain', '');"
+                       , draggable "true"
+                       , on "dragstart"
+                            (Json.Decode.succeed (DragStart <| card))
+                       , on "dragend" (Json.Decode.succeed DragEnd)
+                       ]
+                )
+                [ Html.div
+                    (Styles.listViewRowOverlay anyDragHappening
+                        ++ [ preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver (Before card), True ))
+                           , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
+                           ]
+                    )
+                    []
+                , Html.a
+                    ([ draggable "false"
+                     , href <| Routes.toString <| Routes.pipelineRoute pipeline []
+                     ]
+                        ++ Styles.listViewRowLink
+                    )
+                    [ Html.div (Styles.listViewRowStatusBarTall statusColor) []
+                    , Html.div (Styles.listViewPipelineRow ++ [ style "flex-grow" "1" ])
+                        [ Html.div Styles.listViewRowContent
+                            [ Html.div Styles.listViewPipelineInfo
+                                (getPipelineDisplayNameHtml pipeline)
+                            , Html.div Styles.listViewPipelineStatus
+                                [ Html.text (getPipelineStatusText pipelineJobs pipeline params.now) ]
+                            , Html.div Styles.listViewPipelineButtonsContainer
+                                (renderStepStatusBlocks pipeline.id pipelineJobs ++ renderPipelineButtons pipeline AllPipelinesSection session hovered)
+                            ]
+                        ]
+                    ]
+                ]
+
+
+
+getPipelineStatusText : List Concourse.Job -> Pipeline -> Maybe Time.Posix -> String
+getPipelineStatusText jobs pipeline now =
+    let
+        status =
+            Pipeline.pipelineStatus jobs pipeline
+    in
+    case ( status, now ) of
+        ( Concourse.PipelineStatus.PipelineStatusSucceeded details, Just t ) ->
+            Concourse.PipelineStatus.show status ++ " " ++ Pipeline.sinceTransitionText details t
+
+        ( Concourse.PipelineStatus.PipelineStatusFailed details, Just t ) ->
+            Concourse.PipelineStatus.show status ++ " " ++ Pipeline.sinceTransitionText details t
+
+        ( Concourse.PipelineStatus.PipelineStatusErrored details, Just t ) ->
+            Concourse.PipelineStatus.show status ++ " " ++ Pipeline.sinceTransitionText details t
+
+        ( Concourse.PipelineStatus.PipelineStatusAborted details, Just t ) ->
+            Concourse.PipelineStatus.show status ++ " " ++ Pipeline.sinceTransitionText details t
+
+        _ ->
+            Concourse.PipelineStatus.show status
+
+
+getPipelineDisplayNameHtml : Pipeline -> List (Html Message)
+getPipelineDisplayNameHtml pipeline =
+    if Dict.isEmpty pipeline.instanceVars then
+        [ Html.text pipeline.name ]
+
+    else
+        pipeline.instanceVars
+            |> Dict.toList
+            |> List.concatMap (\( k, v ) -> flattenJson k v)
+            |> List.map
+                (\( k, v ) ->
+                    Html.span Styles.inlineInstanceVar
+                        [ Html.span [ style "color" Colors.pending ]
+                            [ Html.text <| k ++ ":" ]
+                        , Html.text v
+                        ]
+                )
+
+
+renderStepStatusBlocks : Concourse.DatabaseID -> List Concourse.Job -> List (Html Message)
+renderStepStatusBlocks pipelineId jobs =
+    if List.isEmpty jobs then
+        []
+
+    else
+        [ Html.div Styles.listViewStepStatusBlocks
+            (List.map
+                (\job ->
+                    Html.div
+                        (Styles.listViewStepStatusBlock (Colors.buildStatusColor True (Pipeline.jobStatus job))
+                            ++ Tooltip.hoverAttrs (JobPreview AllPipelinesSection pipelineId job.name)
+                        )
+                        []
+                )
+                jobs
+            )
+        ]
+
+
+renderPipelineButtons : Pipeline -> PipelinesSection -> Session -> HoverState.HoverState -> List (Html Message)
+renderPipelineButtons pipeline section session hovered =
+    let
+        pauseToggle =
+            PauseToggle.view
+                { isPaused = pipeline.paused
+                , pipeline = Concourse.toPipelineId pipeline
+                , isToggleHovered =
+                    HoverState.isHovered (PipelineCardPauseToggle section pipeline.id) hovered
+                , isToggleLoading = pipeline.isToggleLoading
+                , tooltipPosition = Views.Styles.Above
+                , margin = "0"
+                , userState = session.userState
+                , domID = PipelineCardPauseToggle section pipeline.id
+                }
+
+        visibilityButton =
+            Pipeline.visibilityView
+                { public = pipeline.public
+                , pipelineId = pipeline.id
+                , isClickable =
+                    UserState.isAnonymous session.userState
+                        || UserState.isMember
+                            { teamName = pipeline.teamName
+                            , userState = session.userState
+                            }
+                , isHovered =
+                    HoverState.isHovered (VisibilityButton section pipeline.id) hovered
+                , isVisibilityLoading = pipeline.isVisibilityLoading
+                , section = section
+                }
+
+        favoritedIcon =
+            Views.FavoritedIcon.view
+                { isFavorited = Favorites.isPipelineFavorited session pipeline
+                , isHovered =
+                    HoverState.isHovered (PipelineCardFavoritedIcon section pipeline.id) hovered
+                , isSideBar = False
+                , domID = PipelineCardFavoritedIcon section pipeline.id
+                }
+                []
+    in
+    if pipeline.archived then
+        [ visibilityButton, favoritedIcon ]
+
+    else
+        [ pauseToggle, visibilityButton, favoritedIcon ]
+
 
 
 pipelineCardView :
@@ -611,6 +1092,61 @@ pipelineDropAreaView dragState name { x, y, width, height } target =
         -- preventDefault is required so that the card will not appear to
         -- "float" or "snap" back to its original position when dropped.
         , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver target, True ))
+        , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
+        ]
+        []
+
+
+hdDropZoneView : DragState -> DropState -> String -> Card -> Html Message
+hdDropZoneView dragState dropState teamName targetCard =
+    let
+        active =
+            case ( dragState, dropState ) of
+                ( Dragging draggingCard, Dropping (Before hoveredCard) ) ->
+                    cardTeamName draggingCard == teamName
+                        && cardIdentifier hoveredCard == cardIdentifier targetCard
+
+                _ ->
+                    False
+    in
+    Html.div
+        [ style "height" (if active then "8px" else "3px")
+        , style "width" "100%"
+        , style "background-color" (if active then "#2196F3" else "transparent")
+        , style "transition" "height 0.1s ease, background-color 0.1s ease"
+        , on "dragenter" (Json.Decode.succeed (DragOver (Before targetCard)))
+        , preventDefaultOn "dragover" (Json.Decode.succeed (DragOver (Before targetCard), True))
+        , stopPropagationOn "drop" (Json.Decode.succeed (DragEnd, True))
+        ]
+        []
+
+
+endDropZoneView : DragState -> DropState -> String -> Html Message
+endDropZoneView dragState dropState teamName =
+    let
+        active =
+            case ( dragState, dropState ) of
+                ( Dragging draggingCard, Dropping End ) ->
+                    cardTeamName draggingCard == teamName
+
+                _ ->
+                    False
+
+        anyDragHappening =
+            case dragState of
+                Dragging _ ->
+                    True
+
+                NotDragging ->
+                    False
+    in
+    Html.div
+        [ style "height" (if anyDragHappening then "50px" else "3px")
+        , style "width" "100%"
+        , style "background-color" (if active then "#2196F3" else "transparent")
+        , style "transition" "background-color 0.1s ease"
+        , on "dragenter" (Json.Decode.succeed (DragOver End))
+        , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver End, True ))
         , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
         ]
         []

--- a/web/elm/src/Dashboard/Group/Models.elm
+++ b/web/elm/src/Dashboard/Group/Models.elm
@@ -3,6 +3,7 @@ module Dashboard.Group.Models exposing
     , Pipeline
     , cardIdentifier
     , cardName
+    , cardPipeline
     , cardTeamName
     , groupCardsWithinTeam
     , ungroupCards
@@ -71,6 +72,19 @@ cardName c =
 
         InstanceGroupCard p _ ->
             p.name
+
+
+cardPipeline : Card -> Pipeline
+cardPipeline c =
+    case c of
+        PipelineCard p ->
+            p
+
+        InstancedPipelineCard p ->
+            p
+
+        InstanceGroupCard p _ ->
+            p
 
 
 cardTeamName : Card -> String

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -76,7 +76,7 @@ hdCardView { pipeline, pipelines, resourceError, dashboardView, query } =
             ++ Styles.instanceGroupCardHd
         )
     <|
-        [ Html.div
+        Html.div
             Styles.instanceGroupCardBodyHd
             [ InstanceGroupBadge.view ColorValues.grey20 <| List.length (pipeline :: pipelines)
             , Html.div
@@ -86,8 +86,7 @@ hdCardView { pipeline, pipelines, resourceError, dashboardView, query } =
                 )
                 [ Html.text pipeline.name ]
             ]
-        ]
-            ++ (if resourceError then
+            :: (if resourceError then
                     [ Html.div Styles.resourceErrorTriangle [] ]
 
                 else

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -4,7 +4,7 @@ import Application.Models exposing (Session)
 import ColorValues
 import Concourse
 import Dashboard.FilterBuilder exposing (instanceGroupFilter)
-import Dashboard.Group.Models exposing (Pipeline)
+import Dashboard.Group.Models exposing (Card(..), Pipeline)
 import Dashboard.Pipeline exposing (pipelineStatus)
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
@@ -20,10 +20,8 @@ import Html.Attributes
         , href
         , style
         )
-
 import List.Extra
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
-import Dashboard.Group.Models exposing (Card(..))
 import Routes
 import Tooltip
 import Views.FavoritedIcon

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -1,9 +1,8 @@
-module Dashboard.InstanceGroup exposing (cardView, hdCardView)
+module Dashboard.InstanceGroup exposing (cardView, hdCardView, instanceGroupRoute)
 
 import Application.Models exposing (Session)
 import ColorValues
 import Concourse
-import Concourse.BuildStatus exposing (BuildStatus(..))
 import Dashboard.FilterBuilder exposing (instanceGroupFilter)
 import Dashboard.Group.Models exposing (Pipeline)
 import Dashboard.Pipeline exposing (pipelineStatus)
@@ -21,8 +20,10 @@ import Html.Attributes
         , href
         , style
         )
+
 import List.Extra
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
+import Dashboard.Group.Models exposing (Card(..))
 import Routes
 import Tooltip
 import Views.FavoritedIcon

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -24,6 +24,7 @@ type alias Model =
         (Login.Model
             { now : Maybe Time.Posix
             , highDensity : Bool
+            , groupListView : Bool
             , pipelinesWithResourceErrors : Set Concourse.DatabaseID
             , jobs : FetchResult (Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job)
             , pipelineLayers : Dict Concourse.DatabaseID (List (List Concourse.JobName))
@@ -71,6 +72,7 @@ type alias FooterModel r =
         , pipelines : Maybe (Dict String (List GroupModels.Pipeline))
         , dropdown : Dropdown
         , highDensity : Bool
+        , groupListView : Bool
         , dashboardView : Routes.DashboardView
         , query : String
     }

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -17,7 +17,7 @@ import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.PipelineStatus as PipelineStatus
 import Dashboard.DashboardPreview as DashboardPreview
 import Dashboard.Grid.Constants as GridConstants
-import Dashboard.Group.Models exposing (Pipeline)
+import Dashboard.Group.Models exposing (Card(..), Pipeline)
 import Dashboard.Styles as Styles
 import Dict
 import Duration
@@ -34,8 +34,7 @@ import Html.Attributes
         , id
         , style
         )
-import Html.Events exposing (onClick, onMouseEnter, onMouseLeave, on, preventDefaultOn, stopPropagationOn)
-import Dashboard.Group.Models exposing (Card(..))
+import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -1,9 +1,12 @@
 module Dashboard.Pipeline exposing
     ( hdPipelineView
     , headerRows
+    , jobStatus
     , pipelineNotSetView
     , pipelineStatus
     , pipelineView
+    , sinceTransitionText
+    , visibilityView
     )
 
 import Application.Models exposing (Session)
@@ -31,7 +34,8 @@ import Html.Attributes
         , id
         , style
         )
-import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
+import Html.Events exposing (onClick, onMouseEnter, onMouseLeave, on, preventDefaultOn, stopPropagationOn)
+import Dashboard.Group.Models exposing (Card(..))
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -4,32 +4,12 @@ module Dashboard.Styles exposing
     , cardTooltip
     , consoleIcon
     , content
-    , groupPageContent
     , docsIcon
     , dropdownContainer
     , dropdownItem
     , emptyCardBody
     , footerLink
-    , listViewInstanceGroupBar
-    , listViewRowOverlay
-    , listViewInstancedPipelineButtons
-    , listViewInstancedRowLink
-    , listViewPipelineButtonsContainer
-    , listViewPipelineInfo
-    , listViewPipelineRow
-    , listViewPipelineStatus
-    , listViewPipelineStatusColored
-    , listViewRowContainer
-    , listViewRowContent
-    , listViewRowLink
-    , listViewRowStatusBar
-    , listViewRowStatusBarTall
-    , listViewStepStatusBlock
-    , listViewStepStatusBlocks
-    , listViewTeamGroup
-    , listViewTeamHeader
-    , listViewTeamName
-    , listView
+    , groupPageContent
     , highDensityToggle
     , info
     , infoBar
@@ -53,6 +33,26 @@ module Dashboard.Styles exposing
     , legend
     , legendItem
     , legendSeparator
+    , listView
+    , listViewInstanceGroupBar
+    , listViewInstancedPipelineButtons
+    , listViewInstancedRowLink
+    , listViewPipelineButtonsContainer
+    , listViewPipelineInfo
+    , listViewPipelineRow
+    , listViewPipelineStatus
+    , listViewPipelineStatusColored
+    , listViewRowContainer
+    , listViewRowContent
+    , listViewRowLink
+    , listViewRowOverlay
+    , listViewRowStatusBar
+    , listViewRowStatusBarTall
+    , listViewStepStatusBlock
+    , listViewStepStatusBlocks
+    , listViewTeamGroup
+    , listViewTeamHeader
+    , listViewTeamName
     , loadingView
     , noInstanceVars
     , noPipelineCard
@@ -1063,7 +1063,10 @@ pipelineSectionHeader =
     ]
 
 
+
 -- HD List View Styles
+
+
 listViewTeamGroup : List (Html.Attribute msg)
 listViewTeamGroup =
     [ style "margin-bottom" "32px"
@@ -1139,9 +1142,27 @@ listViewRowContainer isBeingDragged =
     , style "min-width" "800px"
     , style "width" "100%"
     , style "position" "relative"
-    , style "height" (if isBeingDragged then "0" else "auto")
-    , style "overflow" (if isBeingDragged then "hidden" else "visible")
-    , style "cursor" (if isBeingDragged then "grabbing" else "grab")
+    , style "height"
+        (if isBeingDragged then
+            "0"
+
+         else
+            "auto"
+        )
+    , style "overflow"
+        (if isBeingDragged then
+            "hidden"
+
+         else
+            "visible"
+        )
+    , style "cursor"
+        (if isBeingDragged then
+            "grabbing"
+
+         else
+            "grab"
+        )
     ]
 
 
@@ -1153,7 +1174,13 @@ listViewRowOverlay isDragging =
     , style "bottom" "0"
     , style "left" "0"
     , style "z-index" "1"
-    , style "pointer-events" (if isDragging then "auto" else "none")
+    , style "pointer-events"
+        (if isDragging then
+            "auto"
+
+         else
+            "none"
+        )
     ]
 
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -1149,6 +1149,7 @@ listViewTeamHeader =
     , style "opacity" "0.9"
     , style "padding-left" "32px"
     , style "width" "100%"
+    , style "box-sizing" "border-box"
     , style "line-height" "25px"
     ]
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -1,5 +1,6 @@
 module Dashboard.Styles exposing
     ( asciiArt
+    , cardDropZone
     , cardFooter
     , cardTooltip
     , consoleIcon
@@ -8,8 +9,10 @@ module Dashboard.Styles exposing
     , dropdownContainer
     , dropdownItem
     , emptyCardBody
+    , endDropZone
     , footerLink
     , groupPageContent
+    , hdCardWrapper
     , highDensityToggle
     , info
     , infoBar
@@ -1067,6 +1070,67 @@ pipelineSectionHeader =
 -- HD List View Styles
 
 
+hdCardWrapper : Bool -> List (Html.Attribute msg)
+hdCardWrapper isBeingDragged =
+    [ style "display" "flex"
+    , style "flex-direction" "column"
+    , style "width" "100%"
+    , style "min-width" "800px"
+    , style "margin-bottom" "3px"
+    ]
+        ++ (if isBeingDragged then
+                [ style "width" "0"
+                , style "margin" "0 12.5px"
+                , style "overflow" "hidden"
+                ]
+
+            else
+                []
+           )
+
+
+cardDropZone : Bool -> List (Html.Attribute msg)
+cardDropZone active =
+    [ style "height"
+        (if active then
+            "8px"
+
+         else
+            "3px"
+        )
+    , style "width" "100%"
+    , style "background-color"
+        (if active then
+            Colors.dropTargetHighlight
+
+         else
+            "transparent"
+        )
+    , style "transition" "height 0.1s ease, background-color 0.1s ease"
+    ]
+
+
+endDropZone : { active : Bool, anyDragHappening : Bool } -> List (Html.Attribute msg)
+endDropZone { active, anyDragHappening } =
+    [ style "height"
+        (if anyDragHappening then
+            "50px"
+
+         else
+            "3px"
+        )
+    , style "width" "100%"
+    , style "background-color"
+        (if active then
+            Colors.dropTargetHighlight
+
+         else
+            "transparent"
+        )
+    , style "transition" "background-color 0.1s ease"
+    ]
+
+
 listViewTeamGroup : List (Html.Attribute msg)
 listViewTeamGroup =
     [ style "margin-bottom" "32px"
@@ -1078,7 +1142,7 @@ listViewTeamHeader =
     [ style "display" "flex"
     , style "align-items" "center"
     , style "margin-bottom" "32px"
-    , style "background" "#363636"
+    , style "background" ColorValues.grey80
     , style "z-index" "2"
     , style "opacity" "0.9"
     , style "padding-left" "32px"
@@ -1107,7 +1171,7 @@ listViewPipelineRow =
     [ style "display" "flex"
     , style "align-items" "center"
     , style "padding" "12px 16px"
-    , style "background-color" "#262626"
+    , style "background-color" ColorValues.grey90
     , style "width" "100%"
     , style "box-sizing" "border-box"
     ]
@@ -1205,7 +1269,7 @@ listViewInstancedRowLink =
 listViewInstanceGroupBar : List (Html.Attribute msg)
 listViewInstanceGroupBar =
     [ style "width" "12px"
-    , style "background-color" "#363636"
+    , style "background-color" ColorValues.grey80
     , style "flex-shrink" "0"
     ]
 
@@ -1243,7 +1307,7 @@ listViewInstancedPipelineButtons =
     [ style "display" "flex"
     , style "align-items" "center"
     , style "gap" "10px"
-    , style "background-color" "#262626"
+    , style "background-color" ColorValues.grey90
     , style "padding" "0 12px"
     , style "cursor" "default"
     ]

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -288,7 +288,9 @@ instanceVar =
 
 inlineInstanceVar : List (Html.Attribute msg)
 inlineInstanceVar =
-    [ style "padding-right" "8px" ]
+    [ style "padding-right" "8px"
+    , style "display" "inline-block"
+    ]
 
 
 noInstanceVars : List (Html.Attribute msg)

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -4,11 +4,32 @@ module Dashboard.Styles exposing
     , cardTooltip
     , consoleIcon
     , content
+    , groupPageContent
     , docsIcon
     , dropdownContainer
     , dropdownItem
     , emptyCardBody
     , footerLink
+    , listViewInstanceGroupBar
+    , listViewRowOverlay
+    , listViewInstancedPipelineButtons
+    , listViewInstancedRowLink
+    , listViewPipelineButtonsContainer
+    , listViewPipelineInfo
+    , listViewPipelineRow
+    , listViewPipelineStatus
+    , listViewPipelineStatusColored
+    , listViewRowContainer
+    , listViewRowContent
+    , listViewRowLink
+    , listViewRowStatusBar
+    , listViewRowStatusBarTall
+    , listViewStepStatusBlock
+    , listViewStepStatusBlocks
+    , listViewTeamGroup
+    , listViewTeamHeader
+    , listViewTeamName
+    , listView
     , highDensityToggle
     , info
     , infoBar
@@ -118,6 +139,27 @@ content highDensity =
 
         else
             "row"
+    ]
+
+
+groupPageContent : Bool -> List (Html.Attribute msg)
+groupPageContent isListView =
+    [ style "align-content" "flex-start"
+    , style "display" "initial"
+    , style "flex-flow" "column wrap"
+    , style "padding" <|
+        if isListView then
+            "30px"
+
+        else
+            "30px 0"
+    , style "flex-grow" "1"
+    , style "overflow-y" "auto"
+    , style "height" "100%"
+    , style "width" "100%"
+    , style "box-sizing" "border-box"
+    , style "-webkit-overflow-scrolling" "touch"
+    , style "flex-direction" "row"
     ]
 
 
@@ -1018,4 +1060,190 @@ pipelineSectionHeader =
     [ style "font-size" "22px"
     , style "font-weight" Views.Styles.fontWeightBold
     , style "padding" <| String.fromInt GridConstants.padding ++ "px"
+    ]
+
+
+-- HD List View Styles
+listViewTeamGroup : List (Html.Attribute msg)
+listViewTeamGroup =
+    [ style "margin-bottom" "32px"
+    ]
+
+
+listViewTeamHeader : List (Html.Attribute msg)
+listViewTeamHeader =
+    [ style "display" "flex"
+    , style "align-items" "center"
+    , style "margin-bottom" "32px"
+    , style "background" "#363636"
+    , style "z-index" "2"
+    , style "opacity" "0.9"
+    , style "padding-left" "32px"
+    , style "width" "100%"
+    , style "line-height" "25px"
+    ]
+
+
+listViewTeamName : List (Html.Attribute msg)
+listViewTeamName =
+    [ style "font-size" "18px"
+    , style "font-weight" "900"
+    , style "padding-right" "0.5rem"
+    ]
+
+
+listView : List (Html.Attribute msg)
+listView =
+    [ style "width" "100%"
+    , style "box-sizing" "border-box"
+    ]
+
+
+listViewPipelineRow : List (Html.Attribute msg)
+listViewPipelineRow =
+    [ style "display" "flex"
+    , style "align-items" "center"
+    , style "padding" "12px 16px"
+    , style "background-color" "#262626"
+    , style "width" "100%"
+    , style "box-sizing" "border-box"
+    ]
+
+
+listViewPipelineInfo : List (Html.Attribute msg)
+listViewPipelineInfo =
+    [ style "flex-grow" "1"
+    , style "font-size" "14px"
+    , style "font-weight" "700"
+    ]
+
+
+listViewPipelineStatus : List (Html.Attribute msg)
+listViewPipelineStatus =
+    [ style "font-size" "12px"
+    , style "color" "#a0a0a0"
+    , style "text-transform" "uppercase"
+    , style "letter-spacing" "0.05em"
+    , style "margin-right" "15px"
+    ]
+
+
+listViewPipelineStatusColored : String -> List (Html.Attribute msg)
+listViewPipelineStatusColored color =
+    listViewPipelineStatus ++ [ style "color" color ]
+
+
+listViewRowContainer : Bool -> List (Html.Attribute msg)
+listViewRowContainer isBeingDragged =
+    [ style "display" "flex"
+    , style "min-width" "800px"
+    , style "width" "100%"
+    , style "position" "relative"
+    , style "height" (if isBeingDragged then "0" else "auto")
+    , style "overflow" (if isBeingDragged then "hidden" else "visible")
+    , style "cursor" (if isBeingDragged then "grabbing" else "grab")
+    ]
+
+
+listViewRowOverlay : Bool -> List (Html.Attribute msg)
+listViewRowOverlay isDragging =
+    [ style "position" "absolute"
+    , style "top" "0"
+    , style "right" "0"
+    , style "bottom" "0"
+    , style "left" "0"
+    , style "z-index" "1"
+    , style "pointer-events" (if isDragging then "auto" else "none")
+    ]
+
+
+listViewRowLink : List (Html.Attribute msg)
+listViewRowLink =
+    [ style "text-decoration" "none"
+    , style "color" "inherit"
+    , style "display" "flex"
+    , style "width" "100%"
+    ]
+
+
+listViewInstancedRowLink : List (Html.Attribute msg)
+listViewInstancedRowLink =
+    [ style "text-decoration" "none"
+    , style "color" "inherit"
+    , style "display" "flex"
+    , style "flex-grow" "1"
+    ]
+
+
+listViewInstanceGroupBar : List (Html.Attribute msg)
+listViewInstanceGroupBar =
+    [ style "width" "12px"
+    , style "background-color" "#363636"
+    , style "flex-shrink" "0"
+    ]
+
+
+listViewRowStatusBar : String -> List (Html.Attribute msg)
+listViewRowStatusBar color =
+    [ style "width" "12px"
+    , style "background-color" color
+    , style "flex-shrink" "0"
+    ]
+
+
+listViewRowStatusBarTall : String -> List (Html.Attribute msg)
+listViewRowStatusBarTall color =
+    [ style "width" "12px"
+    , style "height" "100%"
+    , style "min-height" "64px"
+    , style "background-color" color
+    , style "flex-shrink" "0"
+    ]
+
+
+listViewRowContent : List (Html.Attribute msg)
+listViewRowContent =
+    [ style "flex-grow" "1"
+    , style "display" "flex"
+    , style "justify-content" "space-between"
+    , style "align-items" "center"
+    , style "width" "100%"
+    ]
+
+
+listViewInstancedPipelineButtons : List (Html.Attribute msg)
+listViewInstancedPipelineButtons =
+    [ style "display" "flex"
+    , style "align-items" "center"
+    , style "gap" "10px"
+    , style "background-color" "#262626"
+    , style "padding" "0 12px"
+    , style "cursor" "default"
+    ]
+
+
+listViewPipelineButtonsContainer : List (Html.Attribute msg)
+listViewPipelineButtonsContainer =
+    [ style "display" "flex"
+    , style "align-items" "center"
+    , style "gap" "34px"
+    ]
+
+
+listViewStepStatusBlocks : List (Html.Attribute msg)
+listViewStepStatusBlocks =
+    [ style "display" "flex"
+    , style "gap" "2px"
+    , style "height" "24px"
+    ]
+
+
+listViewStepStatusBlock : String -> List (Html.Attribute msg)
+listViewStepStatusBlock color =
+    [ style "width" "16px"
+    , style "min-width" "4px"
+    , style "height" "24px"
+    , style "background-color" color
+    , style "cursor" "pointer"
+    , style "position" "relative"
     ]

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -12,7 +12,7 @@ import Api
 import Api.Endpoints as Endpoints
 import Assets
 import Base64
-import Browser.Dom exposing (Viewport, getElement, getViewport, getViewportOf, setViewportOf)
+import Browser.Dom exposing (Viewport, getViewport, getViewportOf, setViewportOf)
 import Browser.Navigation as Navigation
 import Concourse exposing (DatabaseID, encodeJob, encodePipeline, encodeTeam)
 import Concourse.BuildStatus exposing (BuildStatus)
@@ -35,6 +35,8 @@ import Message.Storage
         ( deleteFromCache
         , favoritedInstanceGroupsKey
         , favoritedPipelinesKey
+        , groupListViewKey
+        , highDensityKey
         , jobsKey
         , loadFromCache
         , loadFromLocalStorage
@@ -212,6 +214,10 @@ type Effect
     | LoadFavoritedPipelines
     | SaveFavoritedInstanceGroups (Set ( Concourse.TeamName, Concourse.PipelineName ))
     | LoadFavoritedInstanceGroups
+    | SaveHighDensity Bool
+    | LoadHighDensity
+    | SaveGroupListView Bool
+    | LoadGroupListView
     | GetHostname
 
 
@@ -739,6 +745,18 @@ runEffect effect key csrfToken =
 
         LoadFavoritedInstanceGroups ->
             loadFromLocalStorage favoritedInstanceGroupsKey
+
+        SaveHighDensity highDensity ->
+            saveToLocalStorage ( highDensityKey, Json.Encode.bool highDensity )
+
+        LoadHighDensity ->
+            loadFromLocalStorage highDensityKey
+
+        SaveGroupListView groupListView ->
+            saveToLocalStorage ( groupListViewKey, Json.Encode.bool groupListView )
+
+        LoadGroupListView ->
+            loadFromLocalStorage groupListViewKey
 
         SaveCachedTeams teams ->
             saveToCache ( teamsKey, teams |> Json.Encode.list encodeTeam )

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -50,6 +50,8 @@ type Message
     | Click DomID
     | GoToRoute Routes.Route
     | Scrolled StrictEvents.ScrollState
+    | ToggleHighDensity
+    | ToggleGroupListView
     | NoOp
 
 

--- a/web/elm/src/Message/Storage.elm
+++ b/web/elm/src/Message/Storage.elm
@@ -5,6 +5,8 @@ port module Message.Storage exposing
     , deleteFromLocalStorage
     , favoritedInstanceGroupsKey
     , favoritedPipelinesKey
+    , groupListViewKey
+    , highDensityKey
     , jobsKey
     , loadFromCache
     , loadFromLocalStorage
@@ -86,6 +88,11 @@ teamsKey =
     "teams"
 
 
+highDensityKey : Key
+highDensityKey =
+    "high_density"
+
+
 favoritedPipelinesKey : Key
 favoritedPipelinesKey =
     "favorited_pipelines"
@@ -94,3 +101,8 @@ favoritedPipelinesKey =
 favoritedInstanceGroupsKey : Key
 favoritedInstanceGroupsKey =
     "favorited_instance_groups"
+
+
+groupListViewKey : Key
+groupListViewKey =
+    "group_list_view"

--- a/web/elm/src/Message/Subscription.elm
+++ b/web/elm/src/Message/Subscription.elm
@@ -114,6 +114,8 @@ type Delivery
     | CachedTeamsReceived (Result Json.Decode.Error (List Concourse.Team))
     | FavoritedPipelinesReceived (Result Json.Decode.Error (Set DatabaseID))
     | FavoritedInstanceGroupsReceived (Result Json.Decode.Error (Set ( Concourse.TeamName, Concourse.PipelineName )))
+    | HighDensityReceived (Result Json.Decode.Error Bool)
+    | GroupListViewReceived (Result Json.Decode.Error Bool)
     | ScrolledToId ( String, String )
     | GotHostname String
     | Noop
@@ -241,6 +243,12 @@ decodeStorageResponse ( key, value ) =
                             )
                     )
                     FavoritedInstanceGroupsReceived
+
+            else if key == Storage.highDensityKey then
+                decodeValue Json.Decode.bool HighDensityReceived
+
+            else if key == Storage.groupListViewKey then
+                decodeValue Json.Decode.bool GroupListViewReceived
 
             else
                 always Noop

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -63,8 +63,7 @@ type Route
 
 
 type SearchType
-    = HighDensity
-    | Normal String
+    = Normal String
 
 
 type DashboardView
@@ -277,7 +276,6 @@ dashboard =
                 <?> (stringWithSpaces "search" |> Query.map (Maybe.withDefault ""))
               )
                 |> map Normal
-            , s "hd" |> map HighDensity
             ]
             <?> dashboardViewQuery
 
@@ -523,14 +521,6 @@ toString route =
 
         Dashboard { searchType, dashboardView } ->
             ( [], [] )
-                |> appendPath
-                    (case searchType of
-                        Normal _ ->
-                            []
-
-                        HighDensity ->
-                            [ "hd" ]
-                    )
                 |> appendQuery
                     (case searchType of
                         Normal "" ->
@@ -538,9 +528,6 @@ toString route =
 
                         Normal query ->
                             searchQueryParams query
-
-                        _ ->
-                            []
                     )
                 |> appendQuery
                     (case dashboardView of
@@ -644,9 +631,6 @@ extractQuery route =
     case route of
         Normal q ->
             q
-
-        _ ->
-            ""
 
 
 searchQueryParams : String -> List Builder.QueryParameter

--- a/web/elm/src/Views/Toggle.elm
+++ b/web/elm/src/Views/Toggle.elm
@@ -2,7 +2,7 @@ module Views.Toggle exposing (TextDirection(..), toggleSwitch)
 
 import Assets
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, href, style)
+import Html.Attributes exposing (attribute, href, style, type_)
 import Html.Events exposing (onClick)
 import Message.Message exposing (DomID(..), Message(..))
 import Routes
@@ -66,9 +66,18 @@ toggleSwitch { ariaLabel, hrefRoute, onToggle, text, textDirection, styles, on }
                 [ iconElem, textElem ]
 
         Nothing ->
-            Html.div
-                ([ style "cursor" "pointer"
+            Html.button
+                ([ type_ "button"
                  , attribute "aria-label" ariaLabel
+                 , style "cursor" "pointer"
+                 , style "-webkit-appearance" "none"
+                 , style "appearance" "none"
+                 , style "background" "transparent"
+                 , style "border" "0"
+                 , style "padding" "0"
+                 , style "margin" "0"
+                 , style "font" "inherit"
+                 , style "color" "inherit"
                  , style "display" "flex"
                  , style "align-items" "center"
                  , style "flex-direction" <|

--- a/web/elm/src/Views/Toggle.elm
+++ b/web/elm/src/Views/Toggle.elm
@@ -3,6 +3,7 @@ module Views.Toggle exposing (TextDirection(..), toggleSwitch)
 import Assets
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, href, style)
+import Html.Events exposing (onClick)
 import Message.Message exposing (DomID(..), Message(..))
 import Routes
 
@@ -14,14 +15,15 @@ type TextDirection
 
 toggleSwitch :
     { on : Bool
-    , hrefRoute : Routes.Route
+    , hrefRoute : Maybe Routes.Route
+    , onToggle : Message
     , text : String
     , textDirection : TextDirection
     , ariaLabel : String
     , styles : List (Html.Attribute Message)
     }
     -> Html Message
-toggleSwitch { ariaLabel, hrefRoute, text, textDirection, styles, on } =
+toggleSwitch { ariaLabel, hrefRoute, onToggle, text, textDirection, styles, on } =
     let
         textElem =
             Html.text text
@@ -44,19 +46,40 @@ toggleSwitch { ariaLabel, hrefRoute, text, textDirection, styles, on } =
                 ]
                 []
     in
-    Html.a
-        ([ href <| Routes.toString hrefRoute
-         , attribute "aria-label" ariaLabel
-         , style "display" "flex"
-         , style "align-items" "center"
-         , style "flex-direction" <|
-            case textDirection of
-                Right ->
-                    "row"
+    case hrefRoute of
+        Just route ->
+            Html.a
+                ([ href <| Routes.toString route
+                 , attribute "aria-label" ariaLabel
+                 , style "display" "flex"
+                 , style "align-items" "center"
+                 , style "flex-direction" <|
+                    case textDirection of
+                        Right ->
+                            "row"
 
-                Left ->
-                    "row-reverse"
-         ]
-            ++ styles
-        )
-        [ iconElem, textElem ]
+                        Left ->
+                            "row-reverse"
+                 ]
+                    ++ styles
+                )
+                [ iconElem, textElem ]
+        
+        Nothing ->
+            Html.div
+                ([ style "cursor" "pointer"
+                 , attribute "aria-label" ariaLabel
+                 , style "display" "flex"
+                 , style "align-items" "center"
+                 , style "flex-direction" <|
+                    case textDirection of
+                        Right ->
+                            "row"
+
+                        Left ->
+                            "row-reverse"
+                 , onClick onToggle
+                 ]
+                    ++ styles
+                )
+                [ iconElem, textElem ]

--- a/web/elm/src/Views/Toggle.elm
+++ b/web/elm/src/Views/Toggle.elm
@@ -64,7 +64,7 @@ toggleSwitch { ariaLabel, hrefRoute, onToggle, text, textDirection, styles, on }
                     ++ styles
                 )
                 [ iconElem, textElem ]
-        
+
         Nothing ->
             Html.div
                 ([ style "cursor" "pointer"

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -2319,7 +2319,6 @@ all =
                         >> Tuple.first
                         >> expectTooltip TriggerBuildButton "manual triggering disabled in job config"
                 ]
-
             , describe "when history and details fetched with reruns disabled" <|
                 let
                     givenHistoryAndDetailsFetched =

--- a/web/elm/tests/DashboardArchiveTests.elm
+++ b/web/elm/tests/DashboardArchiveTests.elm
@@ -146,19 +146,6 @@ all =
                                         }
                                 ]
                 ]
-            , describe "on the HD view" <|
-                [ test "stays in the HD view" <|
-                    \_ ->
-                        setup "/hd"
-                            |> Query.find toggleSwitch
-                            |> Query.has
-                                [ Common.routeHref <|
-                                    Routes.Dashboard
-                                        { searchType = Routes.HighDensity
-                                        , dashboardView = Routes.ViewAllPipelines
-                                        }
-                                ]
-                ]
             ]
         , describe "when viewing only non-archived pipelines"
             [ test "archived pipelines are not rendered in all pipelines section" <|

--- a/web/elm/tests/DashboardInstanceGroupTests.elm
+++ b/web/elm/tests/DashboardInstanceGroupTests.elm
@@ -370,6 +370,53 @@ all =
                                     Msgs.PipelineCardInstanceVar Msgs.AllPipelinesSection 1 "a" "foo"
                             ]
             ]
+        , describe "list view" <|
+            [ test "list view toggle is shown" <|
+                \_ ->
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines [ pipelineInstance BuildStatusSucceeded False 1 ]
+                        |> Common.queryView
+                        |> Query.find [ id "legend" ]
+                        |> Query.has [ text "list view" ]
+            , test "list view toggle is off by default" <|
+                \_ ->
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines [ pipelineInstance BuildStatusSucceeded False 1 ]
+                        |> Common.queryView
+                        |> Query.find [ id "legend" ]
+                        |> Query.find [ attribute <| Attr.attribute "aria-label" "Toggle group list view" ]
+                        |> Query.children []
+                        |> Query.index 0
+                        |> Query.has
+                            [ style "background-image" <|
+                                Assets.backgroundImage <|
+                                    Just (Assets.ToggleSwitch False)
+                            ]
+            , test "list view renders when flag is set" <|
+                \_ ->
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines [ pipelineInstance BuildStatusSucceeded False 1 ]
+                        |> Application.handleDelivery (GroupListViewReceived (Ok True))
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.has [ style "margin-bottom" "32px" ]
+            , test "list view toggle is on when flag is set" <|
+                \_ ->
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines [ pipelineInstance BuildStatusSucceeded False 1 ]
+                        |> Application.handleDelivery (GroupListViewReceived (Ok True))
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ id "legend" ]
+                        |> Query.find [ attribute <| Attr.attribute "aria-label" "Toggle group list view" ]
+                        |> Query.children []
+                        |> Query.index 0
+                        |> Query.has
+                            [ style "background-image" <|
+                                Assets.backgroundImage <|
+                                    Just (Assets.ToggleSwitch True)
+                            ]
+            ]
         ]
 
 

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -1440,6 +1440,18 @@ all =
                         \_ ->
                             hdToggle
                                 |> Query.has [ style "cursor" "pointer" ]
+                    , test "is a native button element so it is keyboard accessible" <|
+                        \_ ->
+                            hdToggle
+                                |> Query.has
+                                    [ tag "button"
+                                    , attribute <| Attr.type_ "button"
+                                    ]
+                    , test "toggles high-density when activated" <|
+                        \_ ->
+                            hdToggle
+                                |> Event.simulate Event.click
+                                |> Event.expect (ApplicationMsgs.Update Msgs.ToggleHighDensity)
                     , test "displays the off state" <|
                         \_ ->
                             hdToggle

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -1436,10 +1436,10 @@ all =
                         \_ ->
                             hdToggle
                                 |> Query.has [ style "flex-direction" "row" ]
-                    , test "links to HD view" <|
+                    , test "is a clickable button" <|
                         \_ ->
                             hdToggle
-                                |> Query.has [ attribute <| Attr.href "/hd" ]
+                                |> Query.has [ style "cursor" "pointer" ]
                     , test "displays the off state" <|
                         \_ ->
                             hdToggle
@@ -1485,7 +1485,7 @@ all =
                                     , style "height" "20px"
                                     , style "width" "35px"
                                     ]
-                    , test "links to normal dashboard view" <|
+                    , test "is a clickable button" <|
                         \_ ->
                             whenOnDashboard { highDensity = True }
                                 |> givenDataUnauthenticated
@@ -1499,7 +1499,7 @@ all =
                                 |> Tuple.first
                                 |> Common.queryView
                                 |> findHDToggle
-                                |> Query.has [ attribute <| Attr.href "/" ]
+                                |> Query.has [ style "cursor" "pointer" ]
                     , test "will not shrink on resizing" <|
                         \_ ->
                             whenOnDashboard { highDensity = True }
@@ -1888,13 +1888,15 @@ all =
                         (Callback.LoggedOut <| Ok ())
                     |> Tuple.second
                     |> Common.contains (Effects.NavigateTo "/")
-        , test "navigate to hd view on logged out when in hd view" <|
+        , test "navigate to root on logged out when in hd view" <|
             \_ ->
-                Common.init "/hd"
+                Common.init "/"
+                    |> Application.handleDelivery (HighDensityReceived (Ok True))
+                    |> Tuple.first
                     |> Application.handleCallback
                         (Callback.LoggedOut <| Ok ())
                     |> Tuple.second
-                    |> Common.contains (Effects.NavigateTo "/hd")
+                    |> Common.contains (Effects.NavigateTo "/")
         , test "fetch all teams on logged out" <|
             \_ ->
                 Common.init "/"
@@ -1951,13 +1953,13 @@ iconSelector { size, image } =
 
 whenOnDashboard : { highDensity : Bool } -> Application.Model
 whenOnDashboard { highDensity } =
-    Common.init
-        (if highDensity then
-            "/hd"
+    Common.init "/"
+        |> (if highDensity then
+                Application.handleDelivery (HighDensityReceived (Ok True)) >> Tuple.first
 
-         else
-            "/"
-        )
+            else
+                identity
+           )
         |> Common.withAllPipelinesVisible
 
 
@@ -1967,12 +1969,7 @@ whenOnDashboardViewingAllPipelines { highDensity } =
         |> Application.handleDelivery
             (RouteChanged <|
                 Routes.Dashboard
-                    { searchType =
-                        if highDensity then
-                            Routes.HighDensity
-
-                        else
-                            Routes.Normal ""
+                    { searchType = Routes.Normal ""
                     , dashboardView = Routes.ViewAllPipelines
                     }
             )
@@ -2133,7 +2130,7 @@ circularJobs =
       , pausedBy = Nothing
       , pausedAt = Nothing
       , disableManualTrigger = False
-    , disableReruns = False
+      , disableReruns = False
       , inputs =
             [ { name = "inA"
               , resource = "res0"
@@ -2184,7 +2181,7 @@ circularJobs =
       , pausedBy = Nothing
       , pausedAt = Nothing
       , disableManualTrigger = False
-    , disableReruns = False
+      , disableReruns = False
       , inputs =
             [ { name = "inB"
               , resource = "res0"

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -540,6 +540,36 @@ all =
                         [ style "display" "initial"
                         , style "padding" "0"
                         ]
+        , test "high density view uses normal density layout when there are no pipelines" <|
+            \_ ->
+                whenOnDashboard { highDensity = True }
+                    |> givenDataAndUser
+                        (apiData [ ( "team", [] ) ])
+                        (userWithRoles [])
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <| Ok [])
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ id "page-below-top-bar" ]
+                    |> Query.find [ class "dashboard" ]
+                    |> Query.has
+                        [ style "display" "initial"
+                        , style "padding" "0"
+                        ]
+        , test "high density cards view renders normal density header when there are no pipelines" <|
+            \_ ->
+                whenOnDashboard { highDensity = True }
+                    |> givenDataAndUser
+                        (apiData [ ( "team", [] ) ])
+                        (userWithRoles [])
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <| Ok [])
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ id "page-below-top-bar" ]
+                    |> Query.has [ text "all pipelines" ]
         , test "high density view left-aligns contents" <|
             \_ ->
                 whenOnDashboard { highDensity = True }

--- a/web/elm/tests/RoutesTests.elm
+++ b/web/elm/tests/RoutesTests.elm
@@ -83,7 +83,7 @@ all =
                                 }
                             )
                         )
-        , test "parses dashboard in hd view" <|
+        , test "/hd is no longer a valid route" <|
             \_ ->
                 Routes.parsePath
                     { protocol = Url.Http
@@ -93,15 +93,8 @@ all =
                     , query = Nothing
                     , fragment = Nothing
                     }
-                    |> Expect.equal
-                        (Just
-                            (Routes.Dashboard
-                                { searchType = Routes.HighDensity
-                                , dashboardView = Routes.ViewNonArchivedPipelines
-                                }
-                            )
-                        )
-        , test "dashboard hd view ignores search and instance group query params" <|
+                    |> Expect.equal Nothing
+        , test "/hd with query params is no longer a valid route" <|
             \_ ->
                 Routes.parsePath
                     { protocol = Url.Http
@@ -111,14 +104,7 @@ all =
                     , query = Just "search=abc&team=def&group=ghi"
                     , fragment = Nothing
                     }
-                    |> Expect.equal
-                        (Just
-                            (Routes.Dashboard
-                                { searchType = Routes.HighDensity
-                                , dashboardView = Routes.ViewNonArchivedPipelines
-                                }
-                            )
-                        )
+                    |> Expect.equal Nothing
         , test "fly success has noop parameter" <|
             \_ ->
                 Routes.parsePath

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -1554,14 +1554,7 @@ iSeeALinkToThePipelineInstance =
 
 iToggledToHighDensity =
     Tuple.first
-        >> Application.update
-            (TopLevelMessage.DeliveryReceived <|
-                Subscription.RouteChanged <|
-                    Routes.Dashboard
-                        { searchType = Routes.HighDensity
-                        , dashboardView = Routes.ViewNonArchivedPipelines
-                        }
-            )
+        >> Application.handleDelivery (Subscription.HighDensityReceived (Ok True))
 
 
 iNavigateToTheInstanceGroup =


### PR DESCRIPTION
This commit adds a list view capability to the web frontend. It's available only for instance groups with a toggle similar to the HD one. Related to that, the former HD route was replaced with a session-stored one, so its setting along with the new list view one are restored on reload and independent of the route flow.

## Changes proposed by this PR

closes https://github.com/orgs/concourse/discussions/9608 (#9608)

_Make sure to follow all [PR requirements](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements)._

* new list view capability for instance groups
  * can be toggled
  * still allows for dragging, etc
  * fully responsive
* the HD route was removed and warped into a session-stored value along with the new list view toggle status
  * main pro: is being restored now even after switching to details view and back

[Screenshot (same as in the ticket)](https://private-user-images.githubusercontent.com/1199637/614436710-ada55129-7d07-4b2c-bad2-faa5e3e546ef.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODMwNzQxNDEsIm5iZiI6MTc4MzA3Mzg0MSwicGF0aCI6Ii8xMTk5NjM3LzYxNDQzNjcxMC1hZGE1NTEyOS03ZDA3LTRiMmMtYmFkMi1mYWE1ZTNlNTQ2ZWYucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI2MDcwMyUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNjA3MDNUMTAxNzIxWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NDJiNDBhMzE4MzViZDRkOGNmYjM0MjJlN2VhNGQ2YWIwN2VjMzVmNzdlYjQ0ZDhiOWM5MDZlZTc3Y2MzZjE2NCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmcmVzcG9uc2UtY29udGVudC10eXBlPWltYWdlJTJGcG5nIn0.rrto9Nq2CDKWQHNQc4y-yGQD69Ald-TR4JuxJwsXOTU)

## Notes to reviewer

Not sure, if the comments in `Dashboard.elm` regarding loading from `localStorage` are required, but as I removed loading them from the route, it made sense to me.

Tried to follow the existing formatting, hope it's alright. And got a bit bigger due to the list view and especially its drag-drop handling; had to do it manually, as going the card view way and calculating every card's location felt wrong when a plain HTML way can achieve the same.
