### PR TITLE
Allow workers to configure their own max active tasks `CONCOURSE_MAX_ACTIVE_TASKS`

### DIFF
--- a/atc/api/workers_test.go
+++ b/atc/api/workers_test.go
@@ -842,6 +842,7 @@ var _ = Describe("Workers API", func() {
 				"active_containers": 2,
 				"active_volumes": 10,
 				"active_tasks": 42,
+				"max_active_tasks": 0,
 				"resource_types": null,
 				"platform": "penguin",
 				"ephemeral": true,

--- a/atc/db/dbfakes/fake_worker.go
+++ b/atc/db/dbfakes/fake_worker.go
@@ -186,6 +186,16 @@ type FakeWorker struct {
 	landReturnsOnCall map[int]struct {
 		result1 error
 	}
+	MaxActiveTasksStub        func() int
+	maxActiveTasksMutex       sync.RWMutex
+	maxActiveTasksArgsForCall []struct {
+	}
+	maxActiveTasksReturns struct {
+		result1 int
+	}
+	maxActiveTasksReturnsOnCall map[int]struct {
+		result1 int
+	}
 	NameStub        func() string
 	nameMutex       sync.RWMutex
 	nameArgsForCall []struct {
@@ -1224,6 +1234,59 @@ func (fake *FakeWorker) LandReturnsOnCall(i int, result1 error) {
 	}
 	fake.landReturnsOnCall[i] = struct {
 		result1 error
+	}{result1}
+}
+
+func (fake *FakeWorker) MaxActiveTasks() int {
+	fake.maxActiveTasksMutex.Lock()
+	ret, specificReturn := fake.maxActiveTasksReturnsOnCall[len(fake.maxActiveTasksArgsForCall)]
+	fake.maxActiveTasksArgsForCall = append(fake.maxActiveTasksArgsForCall, struct {
+	}{})
+	stub := fake.MaxActiveTasksStub
+	fakeReturns := fake.maxActiveTasksReturns
+	fake.recordInvocation("MaxActiveTasks", []interface{}{})
+	fake.maxActiveTasksMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeWorker) MaxActiveTasksCallCount() int {
+	fake.maxActiveTasksMutex.RLock()
+	defer fake.maxActiveTasksMutex.RUnlock()
+	return len(fake.maxActiveTasksArgsForCall)
+}
+
+func (fake *FakeWorker) MaxActiveTasksCalls(stub func() int) {
+	fake.maxActiveTasksMutex.Lock()
+	defer fake.maxActiveTasksMutex.Unlock()
+	fake.MaxActiveTasksStub = stub
+}
+
+func (fake *FakeWorker) MaxActiveTasksReturns(result1 int) {
+	fake.maxActiveTasksMutex.Lock()
+	defer fake.maxActiveTasksMutex.Unlock()
+	fake.MaxActiveTasksStub = nil
+	fake.maxActiveTasksReturns = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeWorker) MaxActiveTasksReturnsOnCall(i int, result1 int) {
+	fake.maxActiveTasksMutex.Lock()
+	defer fake.maxActiveTasksMutex.Unlock()
+	fake.MaxActiveTasksStub = nil
+	if fake.maxActiveTasksReturnsOnCall == nil {
+		fake.maxActiveTasksReturnsOnCall = make(map[int]struct {
+			result1 int
+		})
+	}
+	fake.maxActiveTasksReturnsOnCall[i] = struct {
+		result1 int
 	}{result1}
 }
 

--- a/atc/db/migration/migrations/1783024587_workers_max_active_tasks.down.sql
+++ b/atc/db/migration/migrations/1783024587_workers_max_active_tasks.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workers DROP COLUMN max_active_tasks;

--- a/atc/db/migration/migrations/1783024587_workers_max_active_tasks.up.sql
+++ b/atc/db/migration/migrations/1783024587_workers_max_active_tasks.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workers ADD COLUMN max_active_tasks int default 0;

--- a/atc/db/worker.go
+++ b/atc/db/worker.go
@@ -82,10 +82,13 @@ type Worker interface {
 	ActiveTasks() (int, error)
 	IncreaseActiveTasks(int) (int, error)
 	DecreaseActiveTasks() (int, error)
+	MaxActiveTasks() int
 
 	FindContainer(owner ContainerOwner) (CreatingContainer, CreatedContainer, error)
 	CreateContainer(owner ContainerOwner, meta ContainerMetadata) (CreatingContainer, error)
 }
+
+var _ Worker = (*worker)(nil)
 
 type worker struct {
 	conn DbConn
@@ -101,6 +104,7 @@ type worker struct {
 	activeContainers int
 	activeVolumes    int
 	activeTasks      int
+	maxActiveTasks   int
 	resourceTypes    []atc.WorkerResourceType
 	platform         string
 	tags             []string
@@ -130,6 +134,7 @@ func (worker *worker) Tags() []string                          { return worker.t
 func (worker *worker) TeamID() int                             { return worker.teamID }
 func (worker *worker) TeamName() string                        { return worker.teamName }
 func (worker *worker) Ephemeral() bool                         { return worker.ephemeral }
+func (worker *worker) MaxActiveTasks() int                     { return worker.maxActiveTasks }
 
 func (worker *worker) StartTime() time.Time { return worker.startTime }
 func (worker *worker) ExpiresAt() time.Time { return worker.expiresAt }

--- a/atc/db/worker_factory.go
+++ b/atc/db/worker_factory.go
@@ -55,7 +55,8 @@ var workersQuery = psql.Select(`
 		w.team_id,
 		w.start_time,
 		w.expires,
-		w.ephemeral
+		w.ephemeral,
+		w.max_active_tasks
 	`).
 	From("workers w").
 	LeftJoin("teams t ON w.team_id = t.id")
@@ -183,6 +184,7 @@ func scanWorker(worker *worker, row scannable) error {
 		&startTime,
 		&expiresAt,
 		&ephemeral,
+		&worker.maxActiveTasks,
 	)
 	if err != nil {
 		return err
@@ -410,6 +412,7 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 		string(workerState),
 		teamID,
 		atcWorker.Ephemeral,
+		atcWorker.MaxActiveTasks,
 	}
 
 	conflictValues := values
@@ -441,6 +444,7 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 			"state",
 			"team_id",
 			"ephemeral",
+			"max_active_tasks",
 		).
 		Values(append([]any{
 			sq.Expr(expires),
@@ -465,7 +469,8 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 				version = ?,
 				state = ?,
 				team_id = ?,
-				ephemeral = ?
+				ephemeral = ?,
+				max_active_tasks = ?
 			WHERE `+matchTeamUpsert,
 			conflictValues...,
 		).
@@ -508,6 +513,7 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 		teamID:           workerTeamID,
 		startTime:        time.Unix(atcWorker.StartTime, 0),
 		ephemeral:        atcWorker.Ephemeral,
+		maxActiveTasks:   atcWorker.MaxActiveTasks,
 		conn:             conn,
 	}
 

--- a/atc/db/worker_factory_test.go
+++ b/atc/db/worker_factory_test.go
@@ -29,6 +29,7 @@ var _ = Describe("WorkerFactory", func() {
 			Ephemeral:        true,
 			ActiveContainers: 140,
 			ActiveVolumes:    550,
+			MaxActiveTasks:   6,
 			ResourceTypes: []atc.WorkerResourceType{
 				{
 					Type:       "some-resource-type",
@@ -228,6 +229,7 @@ var _ = Describe("WorkerFactory", func() {
 				Expect(foundWorker.Ephemeral()).To(Equal(true))
 				Expect(foundWorker.ActiveContainers()).To(Equal(140))
 				Expect(foundWorker.ActiveVolumes()).To(Equal(550))
+				Expect(foundWorker.MaxActiveTasks()).To(Equal(6))
 				Expect(foundWorker.ResourceTypes()).To(Equal([]atc.WorkerResourceType{
 					{
 						Type:       "some-resource-type",

--- a/atc/db/worker_test.go
+++ b/atc/db/worker_test.go
@@ -441,7 +441,7 @@ var _ = Describe("Worker", func() {
 				It("errors when increasing the active tasks counter", func() {
 					at, err := worker.IncreaseActiveTasks(1)
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("worker has too many active tasks"))
+					Expect(err).To(MatchError(ErrTooManyActiveTasks))
 					Expect(at).To(Equal(0))
 
 					By("it does not increase worker active tasks count")

--- a/atc/worker.go
+++ b/atc/worker.go
@@ -21,6 +21,8 @@ type Worker struct {
 	ActiveVolumes    int `json:"active_volumes"`
 	ActiveTasks      int `json:"active_tasks"`
 
+	MaxActiveTasks int `json:"max_active_tasks"`
+
 	ResourceTypes []WorkerResourceType `json:"resource_types"`
 
 	Platform  string `json:"platform"`

--- a/atc/worker/gardenruntime/gardenruntimetest/worker.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/worker.go
@@ -189,6 +189,12 @@ func (w Worker) WithActiveTasks(activeTasks int) *Worker {
 	})
 }
 
+func (w Worker) WithMaxActiveTasks(activeTasks int) *Worker {
+	return w.WithWorkerSetup(func(w *atc.Worker) {
+		w.MaxActiveTasks = activeTasks
+	})
+}
+
 func (w Worker) WithTeam(team string) *Worker {
 	return w.WithWorkerSetup(func(w *atc.Worker) {
 		w.Team = team

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -339,7 +339,12 @@ func (strategy limitActiveTasksStrategy) Approve(logger lager.Logger, worker db.
 		return nil
 	}
 
-	_, err := worker.IncreaseActiveTasks(strategy.MaxTasks)
+	maxTasks := strategy.MaxTasks
+	if workersMax := worker.MaxActiveTasks(); workersMax > 0 {
+		maxTasks = workersMax
+	}
+
+	_, err := worker.IncreaseActiveTasks(maxTasks)
 
 	return err
 }

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -611,6 +611,40 @@ var _ = Describe("Container Placement Strategies", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
+
+		Test("allows workers to define their own max active tasks", func() {
+			var scenario *workertest.Scenario
+
+			By("specifying the worker has a max active tasks of 10", func() {
+				scenario = Setup(
+					workertest.WithBasicJob(),
+					workertest.WithWorkers(
+						grt.NewWorker("worker1").
+							WithMaxActiveTasks(10).
+							WithActiveTasks(10),
+					),
+				)
+			})
+
+			var strategy worker.PlacementStrategy
+			By("specifying the system default max-tasks-per-worker as higher than 10", func() {
+				strategy = limitActiveTasksStrategy(20)
+			})
+
+			spec := runtime.ContainerSpec{
+				TeamID:   scenario.TeamID,
+				JobID:    scenario.JobID,
+				StepName: scenario.StepName,
+
+				Type: db.ContainerTypeTask,
+			}
+
+			workers, err := strategy.Order(logger, scenario.Pool, scenario.DB.Workers, spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = strategy.Approve(logger, workers[0], spec)
+			Expect(err).To(MatchError(db.ErrTooManyActiveTasks))
+		})
 	})
 
 	Describe("Limit Active Containers", func() {

--- a/fly/integration/workers_test.go
+++ b/fly/integration/workers_test.go
@@ -199,6 +199,7 @@ var _ = Describe("workers", func() {
                 "active_containers": 0,
 				"active_volumes": 0,
 				"active_tasks": 1,
+				"max_active_tasks": 0,
                 "resource_types": [
                   {
                     "type": "resource-1",
@@ -226,6 +227,7 @@ var _ = Describe("workers", func() {
                 "active_containers": 0,
 				"active_volumes": 0,
 				"active_tasks": 1,
+				"max_active_tasks": 0,
                 "resource_types": null,
                 "platform": "platform2",
                 "tags": [
@@ -244,6 +246,7 @@ var _ = Describe("workers", func() {
                 "active_containers": 0,
 				"active_volumes": 0,
 				"active_tasks": 0,
+				"max_active_tasks": 0,
                 "resource_types": null,
                 "platform": "platform2",
                 "tags": [
@@ -262,6 +265,7 @@ var _ = Describe("workers", func() {
                 "active_containers": 1,
 				"active_volumes": 0,
 				"active_tasks": 1,
+				"max_active_tasks": 0,
                 "resource_types": [
                   {
                     "type": "resource-1",
@@ -295,6 +299,7 @@ var _ = Describe("workers", func() {
                 "active_containers": 10,
 				"active_volumes": 0,
 				"active_tasks": 1,
+				"max_active_tasks": 0,
                 "resource_types": null,
                 "platform": "platform3",
                 "tags": [],
@@ -311,6 +316,7 @@ var _ = Describe("workers", func() {
                 "active_containers": 7,
 				"active_volumes": 0,
 				"active_tasks": 1,
+				"max_active_tasks": 0,
                 "resource_types": null,
                 "platform": "platform4",
                 "tags": [
@@ -329,6 +335,7 @@ var _ = Describe("workers", func() {
                 "active_containers": 5,
 				"active_volumes": 0,
 				"active_tasks": 1,
+				"max_active_tasks": 0,
                 "resource_types": null,
                 "platform": "platform5",
                 "tags": [],

--- a/tsa/client.go
+++ b/tsa/client.go
@@ -159,7 +159,7 @@ func (client *Client) Register(ctx context.Context, opts RegisterOptions) error 
 	err = client.run(
 		ctx,
 		sshClient,
-		"forward-worker --garden "+gardenForwardAddr+" --baggageclaim "+baggageclaimForwardAddr,
+		ForwardWorker+" --garden "+gardenForwardAddr+" --baggageclaim "+baggageclaimForwardAddr,
 		eventsW,
 	)
 	if err != nil {
@@ -190,7 +190,7 @@ func (client *Client) Land(ctx context.Context) error {
 
 	defer sshClient.Close()
 
-	return client.run(ctx, sshClient, "land-worker", os.Stdout)
+	return client.run(ctx, sshClient, LandWorker, os.Stdout)
 }
 
 // Retire invokes the 'retire-worker' command, which will initiate the retiring
@@ -208,7 +208,7 @@ func (client *Client) Retire(ctx context.Context) error {
 
 	defer sshClient.Close()
 
-	return client.run(ctx, sshClient, "retire-worker", os.Stdout)
+	return client.run(ctx, sshClient, RetireWorker, os.Stdout)
 }
 
 // Delete invokes the 'delete-worker' command, which will immediately
@@ -225,7 +225,7 @@ func (client *Client) Delete(ctx context.Context) error {
 
 	defer sshClient.Close()
 
-	return client.run(ctx, sshClient, "delete-worker", os.Stdout)
+	return client.run(ctx, sshClient, DeleteWorker, os.Stdout)
 }
 
 // ContainersToDestroy invokes the 'sweep-containers' command, returning a list
@@ -242,7 +242,7 @@ func (client *Client) ContainersToDestroy(ctx context.Context) ([]string, error)
 	defer sshClient.Close()
 
 	out := new(bytes.Buffer)
-	err = client.run(ctx, sshClient, "sweep-containers", out)
+	err = client.run(ctx, sshClient, SweepContainers, out)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func (client *Client) ReportContainers(ctx context.Context, handles []string) er
 
 	defer sshClient.Close()
 
-	command := append([]string{"report-containers"}, handles...)
+	command := append([]string{ReportContainers}, handles...)
 
 	return client.run(ctx, sshClient, strings.Join(command, " "), os.Stdout)
 }
@@ -289,7 +289,7 @@ func (client *Client) VolumesToDestroy(ctx context.Context) ([]string, error) {
 	defer sshClient.Close()
 
 	out := new(bytes.Buffer)
-	err = client.run(ctx, sshClient, "sweep-volumes", out)
+	err = client.run(ctx, sshClient, SweepVolumes, out)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func (client *Client) ReportVolumes(ctx context.Context, handles []string) error
 
 	defer sshClient.Close()
 
-	command := append([]string{"report-volumes"}, handles...)
+	command := append([]string{ReportVolumes}, handles...)
 
 	return client.run(ctx, sshClient, strings.Join(command, " "), os.Stdout)
 }

--- a/worker/workercmd/worker_config.go
+++ b/worker/workercmd/worker_config.go
@@ -17,19 +17,22 @@ type WorkerConfig struct {
 
 	Ephemeral bool `long:"ephemeral" description:"If set, the worker will be immediately removed upon stalling."`
 
+	MaxActiveTasks int `long:"max-active-tasks" description:"If set, when the worker registers with the web node(s) it will specify this value as the max number of active tasks that can be assigned to it, overriding the web's --max-active-tasks-per-worker for THIS worker. Web nodes must be using the limit-active-tasks placement strategy for this to have any effect."`
+
 	Version string `long:"version" hidden:"true" description:"Version of the worker. This is normally baked in to the binary, so this flag is hidden."`
 }
 
 func (c WorkerConfig) Worker() atc.Worker {
 	return atc.Worker{
-		Tags:          c.Tags,
-		Team:          c.TeamName,
-		Name:          c.Name,
-		StartTime:     time.Now().Unix(),
-		Version:       c.Version,
-		HTTPProxyURL:  c.HTTPProxy,
-		HTTPSProxyURL: c.HTTPSProxy,
-		NoProxy:       c.NoProxy,
-		Ephemeral:     c.Ephemeral,
+		Tags:           c.Tags,
+		Team:           c.TeamName,
+		Name:           c.Name,
+		StartTime:      time.Now().Unix(),
+		Version:        c.Version,
+		HTTPProxyURL:   c.HTTPProxy,
+		HTTPSProxyURL:  c.HTTPSProxy,
+		NoProxy:        c.NoProxy,
+		Ephemeral:      c.Ephemeral,
+		MaxActiveTasks: c.MaxActiveTasks,
 	}
 }


### PR DESCRIPTION
## Changes proposed by this PR

Adds a new worker flag `--max-active-tasks`/`CONCOURSE_MAX_ACTIVE_TASKS` that allows operators to specify the max active tasks for a worker, overriding the `--max-active-tasks-per-worker` defined on the web nodes.

Web nodes must be using the `limit-active-tasks` placement strategy and defined a `--max-active-tasks-per-worker`/`CONCOURSE_MAX_ACTIVE_TASKS_PER_WORKER` for this setting to have any effect on container placement.
