### PR TITLE
Have pipeline collector destroy archived pipelines after some duration (opt-in)

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -168,6 +168,7 @@ type RunCommand struct {
 	ResourceTypeCheckingInterval        time.Duration `long:"resource-type-checking-interval" default:"1m" description:"Interval on which to check for new versions of resource types."`
 	ResourceWithWebhookCheckingInterval time.Duration `long:"resource-with-webhook-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources that has webhook defined."`
 	MaxChecksPerSecond                  int           `long:"max-checks-per-second" description:"Maximum number of checks that can be started per second. If not specified, this will be calculated as (# of resources)/(resource checking interval). -1 value will remove this maximum limit of checks per second."`
+	DestroyArchivedPipelinesAfter       time.Duration `long:"destroy-archived-pipelines-after" default:"0s" description:"The duration in Go's time.Duration format, after which an archived pipeline will be automatically destroyed. A value of zero means archived pipelines are never destroyed."`
 	PausePipelinesAfter                 int           `long:"pause-pipelines-after" default:"0" description:"The number of days after which a pipeline will be automatically paused if none of its jobs have run in more than the given number of days. A value of zero disables this component."`
 	PipelinePauserInterval              time.Duration `long:"pipeline-pauser-interval" default:"24h" hidden:"true" description:"The frequency on which the Pipeline Pauser component will be run to check if any pipelines need to be paused."`
 
@@ -1402,7 +1403,7 @@ func (cmd *RunCommand) gcComponents(
 		atc.ComponentCollectorVolumes:           gc.NewVolumeCollector(dbVolumeRepository, cmd.GC.MissingGracePeriod),
 		atc.ComponentCollectorContainers:        gc.NewContainerCollector(dbContainerRepository, cmd.GC.MissingGracePeriod, cmd.GC.HijackGracePeriod),
 		atc.ComponentCollectorCheckSessions:     gc.NewResourceConfigCheckSessionCollector(resourceConfigCheckSessionLifecycle),
-		atc.ComponentCollectorPipelines:         gc.NewPipelineCollector(dbPipelineLifecycle),
+		atc.ComponentCollectorPipelines:         gc.NewPipelineCollector(dbPipelineLifecycle, cmd.DestroyArchivedPipelinesAfter),
 		atc.ComponentCollectorAccessTokens:      gc.NewAccessTokensCollector(dbAccessTokenLifecycle, jwt.DefaultLeeway),
 		atc.ComponentCollectorChecks:            gc.NewChecksCollector(dbCheckLifecycle),
 	}

--- a/atc/db/dbfakes/fake_pipeline_lifecycle.go
+++ b/atc/db/dbfakes/fake_pipeline_lifecycle.go
@@ -3,6 +3,7 @@ package dbfakes
 
 import (
 	"sync"
+	"time"
 
 	"github.com/concourse/concourse/atc/db"
 )
@@ -16,6 +17,17 @@ type FakePipelineLifecycle struct {
 		result1 error
 	}
 	archiveAbandonedPipelinesReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DestroyArchivedPipelinesStub        func(time.Duration) error
+	destroyArchivedPipelinesMutex       sync.RWMutex
+	destroyArchivedPipelinesArgsForCall []struct {
+		arg1 time.Duration
+	}
+	destroyArchivedPipelinesReturns struct {
+		result1 error
+	}
+	destroyArchivedPipelinesReturnsOnCall map[int]struct {
 		result1 error
 	}
 	RemoveBuildEventsForDeletedPipelinesStub        func() error
@@ -81,6 +93,67 @@ func (fake *FakePipelineLifecycle) ArchiveAbandonedPipelinesReturnsOnCall(i int,
 		})
 	}
 	fake.archiveAbandonedPipelinesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipelineLifecycle) DestroyArchivedPipelines(arg1 time.Duration) error {
+	fake.destroyArchivedPipelinesMutex.Lock()
+	ret, specificReturn := fake.destroyArchivedPipelinesReturnsOnCall[len(fake.destroyArchivedPipelinesArgsForCall)]
+	fake.destroyArchivedPipelinesArgsForCall = append(fake.destroyArchivedPipelinesArgsForCall, struct {
+		arg1 time.Duration
+	}{arg1})
+	stub := fake.DestroyArchivedPipelinesStub
+	fakeReturns := fake.destroyArchivedPipelinesReturns
+	fake.recordInvocation("DestroyArchivedPipelines", []interface{}{arg1})
+	fake.destroyArchivedPipelinesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePipelineLifecycle) DestroyArchivedPipelinesCallCount() int {
+	fake.destroyArchivedPipelinesMutex.RLock()
+	defer fake.destroyArchivedPipelinesMutex.RUnlock()
+	return len(fake.destroyArchivedPipelinesArgsForCall)
+}
+
+func (fake *FakePipelineLifecycle) DestroyArchivedPipelinesCalls(stub func(time.Duration) error) {
+	fake.destroyArchivedPipelinesMutex.Lock()
+	defer fake.destroyArchivedPipelinesMutex.Unlock()
+	fake.DestroyArchivedPipelinesStub = stub
+}
+
+func (fake *FakePipelineLifecycle) DestroyArchivedPipelinesArgsForCall(i int) time.Duration {
+	fake.destroyArchivedPipelinesMutex.RLock()
+	defer fake.destroyArchivedPipelinesMutex.RUnlock()
+	argsForCall := fake.destroyArchivedPipelinesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakePipelineLifecycle) DestroyArchivedPipelinesReturns(result1 error) {
+	fake.destroyArchivedPipelinesMutex.Lock()
+	defer fake.destroyArchivedPipelinesMutex.Unlock()
+	fake.DestroyArchivedPipelinesStub = nil
+	fake.destroyArchivedPipelinesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipelineLifecycle) DestroyArchivedPipelinesReturnsOnCall(i int, result1 error) {
+	fake.destroyArchivedPipelinesMutex.Lock()
+	defer fake.destroyArchivedPipelinesMutex.Unlock()
+	fake.DestroyArchivedPipelinesStub = nil
+	if fake.destroyArchivedPipelinesReturnsOnCall == nil {
+		fake.destroyArchivedPipelinesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.destroyArchivedPipelinesReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -128,6 +128,8 @@ type Pipeline interface {
 	SetParentIDs(jobID, buildID int) error
 }
 
+var _ Pipeline = (*pipeline)(nil)
+
 type pipeline struct {
 	id            int
 	name          string
@@ -772,11 +774,26 @@ func (p *pipeline) Expose() error {
 }
 
 func (p *pipeline) Destroy() error {
+	tx, err := p.conn.Begin()
+	if err != nil {
+		return err
+	}
+
+	defer Rollback(tx)
+	err = p.destroy(tx)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (p *pipeline) destroy(tx Tx) error {
 	_, err := psql.Delete("pipelines").
 		Where(sq.Eq{
 			"id": p.id,
 		}).
-		RunWith(p.conn).
+		RunWith(tx).
 		Exec()
 
 	return err

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc/db/lock"
@@ -10,8 +11,13 @@ import (
 
 //counterfeiter:generate . PipelineLifecycle
 type PipelineLifecycle interface {
+	// Finds any pipelines no longer being set by their parent pipeline via the
+	// set_pipeline step and archives them
 	ArchiveAbandonedPipelines() error
 	RemoveBuildEventsForDeletedPipelines() error
+	// Destroys any pipelines that have been archived for longer than the given
+	// duration. The duration must be > 0. A duration of zero is a no-op.
+	DestroyArchivedPipelines(time.Duration) error
 }
 
 func NewPipelineLifecycle(conn DbConn, lockFactory lock.LockFactory) PipelineLifecycle {
@@ -20,6 +26,8 @@ func NewPipelineLifecycle(conn DbConn, lockFactory lock.LockFactory) PipelineLif
 		lockFactory: lockFactory,
 	}
 }
+
+var _ PipelineLifecycle = (*pipelineLifecycle)(nil)
 
 type pipelineLifecycle struct {
 	conn        DbConn
@@ -145,6 +153,64 @@ func (p *pipelineLifecycle) RemoveBuildEventsForDeletedPipelines() error {
 		Exec()
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (pl *pipelineLifecycle) DestroyArchivedPipelines(olderThan time.Duration) error {
+	if olderThan <= 0 {
+		return nil
+	}
+
+	tx, err := pl.conn.Begin()
+	if err != nil {
+		return err
+	}
+	defer Rollback(tx)
+
+	archivedPipelinesToDestroy, err := pipelinesQuery.
+		Where(sq.And{
+			sq.Eq{"p.archived": true},
+			sq.Expr(fmt.Sprintf("paused_at < NOW() - '%d seconds'::INTERVAL", int(olderThan.Seconds()))),
+		}).
+		RunWith(tx).
+		Query()
+
+	if err != nil {
+		return err
+	}
+	defer archivedPipelinesToDestroy.Close()
+
+	err = destroyArchivedPipelines(tx, pl.conn, pl.lockFactory, archivedPipelinesToDestroy)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func destroyArchivedPipelines(tx Tx, conn DbConn, lockFactory lock.LockFactory, rows *sql.Rows) error {
+	var toDestroy []pipeline
+	for rows.Next() {
+		p := newPipeline(conn, lockFactory)
+		if err := scanPipeline(p, rows); err != nil {
+			return err
+		}
+
+		toDestroy = append(toDestroy, *p)
+	}
+
+	for _, pipeline := range toDestroy {
+		err := pipeline.destroy(tx)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/atc/db/pipeline_lifecycle_test.go
+++ b/atc/db/pipeline_lifecycle_test.go
@@ -160,6 +160,97 @@ var _ = Describe("PipelineLifecycle", func() {
 		})
 	})
 
+	Describe("DestroyArchivedPipelines", func() {
+		var (
+			olderThan  time.Duration
+			p1, p2, p3 db.Pipeline
+		)
+
+		BeforeEach(func() {
+			olderThan = 48 * time.Hour
+
+			p1, _, err = defaultTeam.SavePipeline(atc.PipelineRef{Name: "p1"}, defaultPipelineConfig, db.ConfigVersion(0), false)
+			Expect(err).ToNot(HaveOccurred())
+			p2, _, err = defaultTeam.SavePipeline(atc.PipelineRef{Name: "p2"}, defaultPipelineConfig, db.ConfigVersion(0), false)
+			Expect(err).ToNot(HaveOccurred())
+			p3, _, err = defaultTeam.SavePipeline(atc.PipelineRef{Name: "p3"}, defaultPipelineConfig, db.ConfigVersion(0), false)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			err = pl.DestroyArchivedPipelines(olderThan)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("no pipelines are archived", func() {
+			It("destroys no pipelines", func() {
+				found, err := p1.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				found, err = p2.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				found, err = p3.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+		})
+
+		Context("there are some archived pipelines", func() {
+			BeforeEach(func() {
+				By("archiving 2/3 pipelines")
+				err = p1.Archive()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = dbConn.Exec(`UPDATE pipelines SET paused_at = NOW() - INTERVAL '3' DAY WHERE id = $1`, p1.ID())
+				Expect(err).ToNot(HaveOccurred())
+
+				err = p3.Archive()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = dbConn.Exec(`UPDATE pipelines SET paused_at = NOW() - INTERVAL '1' DAY WHERE id = $1`, p3.ID())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("destroys archived pipelines older than duration specified", func() {
+				found, err := p1.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeFalse(), "should be destroyed")
+
+				found, err = p2.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				found, err = p3.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+
+			Context("told to destroy archived pipelines with an age of zero", func() {
+				BeforeEach(func() {
+					olderThan = 0
+				})
+
+				It("destroys no pipelines", func() {
+					found, err := p1.Reload()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(p1.Archived()).To(BeTrue())
+
+					found, err = p2.Reload()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(p2.Archived()).To(BeFalse())
+
+					found, err = p3.Reload()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(p3.Archived()).To(BeTrue())
+				})
+			})
+		})
+
+	})
 	Describe("RemoveBuildEventsForDeletedPipelines", func() {
 		var (
 			pipeline1 db.Pipeline

--- a/atc/gc/pipeline_collector.go
+++ b/atc/gc/pipeline_collector.go
@@ -2,6 +2,7 @@ package gc
 
 import (
 	"context"
+	"time"
 
 	"code.cloudfoundry.org/lager/v3/lagerctx"
 	"github.com/concourse/concourse/atc/db"
@@ -9,11 +10,13 @@ import (
 
 type pipelineCollector struct {
 	pipelineLifecycle db.PipelineLifecycle
+	archivedExpiry    time.Duration
 }
 
-func NewPipelineCollector(pipelineLifecyle db.PipelineLifecycle) *pipelineCollector {
+func NewPipelineCollector(pipelineLifecyle db.PipelineLifecycle, archivedExpiry time.Duration) *pipelineCollector {
 	return &pipelineCollector{
 		pipelineLifecycle: pipelineLifecyle,
+		archivedExpiry:    archivedExpiry,
 	}
 }
 
@@ -26,6 +29,12 @@ func (pc *pipelineCollector) Run(ctx context.Context) error {
 	err := pc.pipelineLifecycle.ArchiveAbandonedPipelines()
 	if err != nil {
 		logger.Error("failed-to-automatically-archive-pipelines", err)
+		return err
+	}
+
+	err = pc.pipelineLifecycle.DestroyArchivedPipelines(pc.archivedExpiry)
+	if err != nil {
+		logger.Error("failed-to-destroy-archived-pipelines", err)
 		return err
 	}
 

--- a/atc/gc/pipeline_collector_test.go
+++ b/atc/gc/pipeline_collector_test.go
@@ -2,6 +2,7 @@ package gc_test
 
 import (
 	"context"
+	"time"
 
 	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/gc"
@@ -16,7 +17,7 @@ var _ = Describe("PipelineCollector", func() {
 	BeforeEach(func() {
 		fakePipelineLifecycle = new(dbfakes.FakePipelineLifecycle)
 
-		collector = gc.NewPipelineCollector(fakePipelineLifecycle)
+		collector = gc.NewPipelineCollector(fakePipelineLifecycle, time.Hour)
 	})
 
 	Describe("Run", func() {
@@ -25,6 +26,14 @@ var _ = Describe("PipelineCollector", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakePipelineLifecycle.ArchiveAbandonedPipelinesCallCount()).To(Equal(1))
+		})
+
+		It("tells the pipeline lifecycle to remove archived pipelines", func() {
+			err := collector.Run(context.TODO())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakePipelineLifecycle.DestroyArchivedPipelinesCallCount()).To(Equal(1))
+			Expect(fakePipelineLifecycle.DestroyArchivedPipelinesArgsForCall(0)).To(Equal(time.Hour))
 		})
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

Adds a `CONCOURSE_DESTROY_ARCHIVED_PIPELINES_AFTER` flag to the `web` command with a default value of zero. When set to a value > 0 in Go's `time.Duration` format, the pipeline collector component will also destroy previously archived pipelines. Archived pipelines are only destroyed when a duration > zero is specified.

The lifecycle of a pipeline set by another pipeline via the `set_pipeline` step now looks like:

1. Child pipeline created via `set_pipeline`
2. Child pipeline stops being set by parent pipeline
3. Pipeline collector immediately archives the child pipeline
4. If `CONCOURSE_DESTROY_ARCHIVED_PIPELINES_AFTER` is > 0, when the child pipeline has been archived for longer than the given duration, it will be permanently destroyed.

This should be documented on these pages:
- https://concourse-ci.org/docs/how-to/pipeline-guides/managing-pipeline-configs/#2a-parent-child-pipeline-relationships
- https://concourse-ci.org/docs/steps/set-pipeline/