### PR TITLE
fix: Hermetic doesn't configure hosts on the containers

### DIFF
--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -309,12 +309,14 @@ func (b *GardenBackend) Ping() (err error) {
 func (b *GardenBackend) Create(gdnSpec garden.ContainerSpec) (garden.Container, error) {
 	ctx := context.Background()
 
-	cont, err := b.createContainer(ctx, gdnSpec)
+	hermetic := b.isHermetic(gdnSpec)
+
+	cont, err := b.createContainer(ctx, gdnSpec, hermetic)
 	if err != nil {
 		return nil, fmt.Errorf("new container: %w", err)
 	}
 
-	err = b.startTask(ctx, cont, b.isHermetic(gdnSpec))
+	err = b.startTask(ctx, cont, hermetic)
 	if err != nil {
 		return nil, fmt.Errorf("starting task: %w", err)
 	}
@@ -335,7 +337,7 @@ func (b *GardenBackend) isHermetic(gdnSpec garden.ContainerSpec) bool {
 	return true
 }
 
-func (b *GardenBackend) createContainer(ctx context.Context, gdnSpec garden.ContainerSpec) (containerd.Container, error) {
+func (b *GardenBackend) createContainer(ctx context.Context, gdnSpec garden.ContainerSpec, hermetic bool) (containerd.Container, error) {
 	err := b.createLock.Acquire(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("acquiring create container lock: %w", err)
@@ -358,7 +360,7 @@ func (b *GardenBackend) createContainer(ctx context.Context, gdnSpec garden.Cont
 		return nil, fmt.Errorf("garden spec to oci spec: %w", err)
 	}
 
-	netMounts, err := b.network.SetupMounts(gdnSpec.Handle)
+	netMounts, err := b.network.SetupMounts(gdnSpec.Handle, hermetic)
 	if err != nil {
 		return nil, fmt.Errorf("network setup mounts: %w", err)
 	}

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -401,7 +401,7 @@ func (n cniNetwork) SetupHostNetwork() error {
 	return nil
 }
 
-func (n cniNetwork) SetupMounts(handle string) ([]specs.Mount, error) {
+func (n cniNetwork) SetupMounts(handle string, hermetic bool) ([]specs.Mount, error) {
 	if handle == "" {
 		return nil, ErrInvalidInput("empty handle")
 	}
@@ -428,7 +428,7 @@ func (n cniNetwork) SetupMounts(handle string) ([]specs.Mount, error) {
 		return nil, fmt.Errorf("creating /etc/hostname: %w", err)
 	}
 
-	resolvContents, err := n.generateResolvConfContents()
+	resolvContents, err := n.generateResolvConfContents(hermetic)
 	if err != nil {
 		return nil, fmt.Errorf("generating resolv.conf: %w", err)
 	}
@@ -485,7 +485,11 @@ func (n cniNetwork) setupRestrictedNetworks() error {
 	return nil
 }
 
-func (n cniNetwork) generateResolvConfContents() ([]byte, error) {
+func (n cniNetwork) generateResolvConfContents(hermetic bool) ([]byte, error) {
+	if hermetic {
+		return []byte{}, nil
+	}
+
 	contents := ""
 	resolvConfEntries := n.nameServers
 	var err error

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -69,14 +69,14 @@ func (s *CNINetworkSuite) TestNewCNINetworkWithInvalidIPv6ConfigDoesntFail() {
 }
 
 func (s *CNINetworkSuite) TestSetupMountsEmptyHandle() {
-	_, err := s.network.SetupMounts("")
+	_, err := s.network.SetupMounts("", false)
 	s.EqualError(err, "empty handle")
 }
 
 func (s *CNINetworkSuite) TestSetupMountsFailToCreateHosts() {
 	s.store.CreateReturnsOnCall(0, "", errors.New("create-hosts-err"))
 
-	_, err := s.network.SetupMounts("handle")
+	_, err := s.network.SetupMounts("handle", false)
 	s.EqualError(errors.Unwrap(err), "create-hosts-err")
 
 	s.Equal(1, s.store.CreateCallCount())
@@ -88,7 +88,7 @@ func (s *CNINetworkSuite) TestSetupMountsFailToCreateHosts() {
 func (s *CNINetworkSuite) TestSetupMountsFailToCreateHostname() {
 	s.store.CreateReturnsOnCall(1, "", errors.New("create-hostname-err"))
 
-	_, err := s.network.SetupMounts("handle")
+	_, err := s.network.SetupMounts("handle", false)
 	s.EqualError(errors.Unwrap(err), "create-hostname-err")
 
 	s.Equal(2, s.store.CreateCallCount())
@@ -100,7 +100,7 @@ func (s *CNINetworkSuite) TestSetupMountsFailToCreateHostname() {
 func (s *CNINetworkSuite) TestSetupMountsFailToCreateResolvConf() {
 	s.store.CreateReturnsOnCall(2, "", errors.New("create-resolvconf-err"))
 
-	_, err := s.network.SetupMounts("handle")
+	_, err := s.network.SetupMounts("handle", false)
 	s.EqualError(errors.Unwrap(err), "create-resolvconf-err")
 
 	s.Equal(3, s.store.CreateCallCount())
@@ -114,7 +114,7 @@ func (s *CNINetworkSuite) TestSetupMountsReturnsMountpoints() {
 	s.store.CreateReturnsOnCall(1, "/worker-state/handle/etc/hostname", nil)
 	s.store.CreateReturnsOnCall(2, "/worker-state/handle/etc/resolv.conf", nil)
 
-	mounts, err := s.network.SetupMounts("some-handle")
+	mounts, err := s.network.SetupMounts("some-handle", false)
 	s.NoError(err)
 
 	s.Len(mounts, 3)
@@ -149,7 +149,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithNameServers() {
 	)
 	s.NoError(err)
 
-	_, err = network.SetupMounts("some-handle")
+	_, err = network.SetupMounts("some-handle", false)
 	s.NoError(err)
 
 	_, resolvConfContents := s.store.CreateArgsForCall(2)
@@ -164,7 +164,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutNameServers() {
 	)
 	s.NoError(err)
 
-	_, err = network.SetupMounts("some-handle")
+	_, err = network.SetupMounts("some-handle", false)
 	s.NoError(err)
 
 	actualResolvContents, err := runtime.ParseHostResolveConf("/etc/resolv.conf")
@@ -176,6 +176,22 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutNameServers() {
 	s.Equal(resolvConfContents, []byte(contents))
 }
 
+func (s *CNINetworkSuite) TestSetupMountsHermeticWritesEmptyResolvConf() {
+	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
+		runtime.WithCNIFileStore(s.store),
+		runtime.WithNameServers([]string{"1.2.3.4"}),
+		runtime.WithIptables(s.iptables),
+	)
+	s.NoError(err)
+
+	_, err = network.SetupMounts("some-handle", true)
+	s.NoError(err)
+
+	_, resolvConfContents := s.store.CreateArgsForCall(2)
+	s.Equal([]byte{}, resolvConfContents)
+}
+
 func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithAdditionalHosts() {
 	network, err := runtime.NewCNINetwork(
 		runtime.WithDefaultsForTesting(),
@@ -185,7 +201,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithAdditionalHosts() {
 	)
 	s.NoError(err)
 
-	_, err = network.SetupMounts("some-handle")
+	_, err = network.SetupMounts("some-handle", false)
 	s.NoError(err)
 
 	_, firstHost := s.store.AppendArgsForCall(0)
@@ -203,7 +219,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutAdditionalHosts() {
 	)
 	s.NoError(err)
 
-	_, err = network.SetupMounts("some-handle")
+	_, err = network.SetupMounts("some-handle", false)
 	s.NoError(err)
 
 	s.Equal(0, s.store.AppendCallCount())
@@ -222,7 +238,7 @@ func (s *CNINetworkSuite) TestSetupMountsFailsToAppendAdditionalHost() {
 	s.store.AppendReturns(errors.New("append-error"))
 
 	// Act
-	_, err = network.SetupMounts("some-handle")
+	_, err = network.SetupMounts("some-handle", false)
 
 	// Assert
 	s.Error(err)
@@ -239,7 +255,7 @@ func (s *CNINetworkSuite) TestSetupMountsFailsWithInvalidIP() {
 	s.NoError(err)
 
 	// Act
-	_, err = network.SetupMounts("some-handle")
+	_, err = network.SetupMounts("some-handle", false)
 
 	// Assert
 	s.Error(err)

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -282,7 +282,7 @@ func (s *IntegrationSuite) TestHermeticContainerNetworkEgress() {
 	s.NoError(err)
 
 	s.Equal(exitCode, 1, "Process in container should not be able to connect to external network")
-	s.Contains(buf.String(), "failed performing http getGet \"http://example.com\": context deadline exceeded")
+	s.Contains(buf.String(), "failed performing http getGet \"http://example.com\": dial tcp: lookup example.com")
 }
 
 // TestContainerNetworkEgressWithRestrictedNetworks verifies that a process that we run in a

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -909,6 +909,7 @@ func (s *IntegrationSuite) TestCustomDNS() {
 		Handle:     handle,
 		RootFSPath: "raw://" + s.rootfs,
 		Privileged: true,
+		NetOut:     []garden.NetOutRule{{}},
 	})
 	s.NoError(err)
 

--- a/worker/runtime/network.go
+++ b/worker/runtime/network.go
@@ -17,9 +17,10 @@ type Network interface {
 	SetupHostNetwork() (err error)
 
 	// SetupMounts prepares mounts that might be necessary for proper
-	// networking functionality.
+	// networking functionality. When hermetic is true, an empty resolv.conf
+	// is written so DNS lookups fail immediately rather than timing out.
 	//
-	SetupMounts(handle string) (mounts []specs.Mount, err error)
+	SetupMounts(handle string, hermetic bool) (mounts []specs.Mount, err error)
 
 	// Add adds a task to the network.
 	//

--- a/worker/runtime/runtimefakes/fake_network.go
+++ b/worker/runtime/runtimefakes/fake_network.go
@@ -69,10 +69,11 @@ type FakeNetwork struct {
 	setupHostNetworkReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetupMountsStub        func(string) ([]specs.Mount, error)
+	SetupMountsStub        func(string, bool) ([]specs.Mount, error)
 	setupMountsMutex       sync.RWMutex
 	setupMountsArgsForCall []struct {
 		arg1 string
+		arg2 bool
 	}
 	setupMountsReturns struct {
 		result1 []specs.Mount
@@ -387,18 +388,19 @@ func (fake *FakeNetwork) SetupHostNetworkReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeNetwork) SetupMounts(arg1 string) ([]specs.Mount, error) {
+func (fake *FakeNetwork) SetupMounts(arg1 string, arg2 bool) ([]specs.Mount, error) {
 	fake.setupMountsMutex.Lock()
 	ret, specificReturn := fake.setupMountsReturnsOnCall[len(fake.setupMountsArgsForCall)]
 	fake.setupMountsArgsForCall = append(fake.setupMountsArgsForCall, struct {
 		arg1 string
-	}{arg1})
+		arg2 bool
+	}{arg1, arg2})
 	stub := fake.SetupMountsStub
 	fakeReturns := fake.setupMountsReturns
-	fake.recordInvocation("SetupMounts", []interface{}{arg1})
+	fake.recordInvocation("SetupMounts", []interface{}{arg1, arg2})
 	fake.setupMountsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -412,17 +414,17 @@ func (fake *FakeNetwork) SetupMountsCallCount() int {
 	return len(fake.setupMountsArgsForCall)
 }
 
-func (fake *FakeNetwork) SetupMountsCalls(stub func(string) ([]specs.Mount, error)) {
+func (fake *FakeNetwork) SetupMountsCalls(stub func(string, bool) ([]specs.Mount, error)) {
 	fake.setupMountsMutex.Lock()
 	defer fake.setupMountsMutex.Unlock()
 	fake.SetupMountsStub = stub
 }
 
-func (fake *FakeNetwork) SetupMountsArgsForCall(i int) string {
+func (fake *FakeNetwork) SetupMountsArgsForCall(i int) (string, bool) {
 	fake.setupMountsMutex.RLock()
 	defer fake.setupMountsMutex.RUnlock()
 	argsForCall := fake.setupMountsArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeNetwork) SetupMountsReturns(result1 []specs.Mount, result2 error) {


### PR DESCRIPTION
## Changes proposed by this PR

closes #9633 


* `network.go`- added `hermetic` bool parameter to the `SetupMounts` interface method
* `cni_network.go` - when `hermetic` is true, write an empty `/etc/resolv.conf` instead of copying nameservers from the host
* `backend.go` - compute hermetic once and pass it through to `SetupMounts`
* `runtimefakes/fake_network.go` - updated generated fake to match the new signature
* `cni_network_test.go` - updated all existing calls to pass `hermetic: false`; added new test asserting that a hermetic container gets an empty `resolv.conf` even when nameservers are configured on the worker

## Notes to reviewer

### Without fix:
<img width="575" height="359" alt="Screenshot 2026-07-08 at 13 29 19" src="https://github.com/user-attachments/assets/782b3d28-1826-4c36-a5cb-d1e0db3f9a13" />

### With fix:
<img width="589" height="279" alt="Screenshot 2026-07-08 at 13 34 27" src="https://github.com/user-attachments/assets/19c26662-683a-43e1-b61e-7697b5fb2616" />


