### PR TITLE
Workaround for root.MkdirAll bug

### DIFF
--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -79,7 +79,7 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 	fileInfo := header.FileInfo()
 	fileMode := fileInfo.Mode()
 
-	err := root.MkdirAll(filepath.Dir(filePath), 0755)
+	err := RootMkdirAll(root, filepath.Dir(filePath), 0755)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 		}
 
 	case tar.TypeDir:
-		err := root.MkdirAll(filePath, fileMode.Perm())
+		err := RootMkdirAll(root, filePath, fileMode.Perm())
 		if err != nil {
 			return err
 		}
@@ -231,4 +231,9 @@ func stripRoot(p string) string {
 	// Removes all leading forward and backwards slashes
 	p = strings.TrimLeft(p, `/\`)
 	return p
+}
+
+// Workaround for https://github.com/golang/go/issues/80308
+func RootMkdirAll(r *os.Root, path string, perm os.FileMode) error {
+	return r.MkdirAll(strings.TrimSuffix(path, "/"), perm)
 }

--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -185,7 +185,7 @@ var _ = Describe("ExtractEntry", func() {
 			By("creating the target of the hard link", func() {
 				root, err := os.OpenRoot(dest)
 				Expect(err).ToNot(HaveOccurred())
-				err = root.MkdirAll("absolute/path/", 0755)
+				err = tarfs.RootMkdirAll(root, "absolute/path/", 0755)
 				Expect(err).ToNot(HaveOccurred())
 				f, err := root.Create("absolute/path/file")
 				Expect(err).ToNot(HaveOccurred())

--- a/go-archive/zipfs/extract.go
+++ b/go-archive/zipfs/extract.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/klauspost/compress/zip"
 )
@@ -59,12 +60,12 @@ func extractZipArchiveFile(root *os.Root, file *zip.File, input io.Reader) error
 	fileInfo := file.FileInfo()
 
 	if fileInfo.IsDir() {
-		err := root.MkdirAll(filePath, fileInfo.Mode().Perm())
+		err := RootMkdirAll(root, filePath, fileInfo.Mode().Perm())
 		if err != nil {
 			return err
 		}
 	} else {
-		err := root.MkdirAll(filepath.Dir(filePath), 0755)
+		err := RootMkdirAll(root, filepath.Dir(filePath), 0755)
 		if err != nil {
 			return err
 		}
@@ -90,4 +91,9 @@ func extractZipArchiveFile(root *os.Root, file *zip.File, input io.Reader) error
 	}
 
 	return nil
+}
+
+// Workaround for https://github.com/golang/go/issues/80308
+func RootMkdirAll(r *os.Root, path string, perm os.FileMode) error {
+	return r.MkdirAll(strings.TrimSuffix(path, "/"), perm)
 }


### PR DESCRIPTION
## Changes proposed by this PR

closes #9635

See https://github.com/golang/go/issues/80308

Can verify tests pass now with:
```
GOTOOLCHAIN=go1.26.5 ginkgo -r -p --keep-going ./go-archive/
```