### PR TITLE
skymarshal: behaviour: handle RFC 8693 token-exchange responses

### DIFF
--- a/skymarshal/token/access_token.go
+++ b/skymarshal/token/access_token.go
@@ -70,11 +70,12 @@ func StoreAccessToken(
 			return
 		}
 		var resp struct {
-			AccessToken  string `json:"access_token"`
-			TokenType    string `json:"token_type"`
-			ExpiresIn    int    `json:"expires_in"`
-			RefreshToken string `json:"refresh_token,omitempty"`
-			IDToken      string `json:"id_token"`
+			AccessToken     string `json:"access_token"`
+			TokenType       string `json:"token_type"`
+			ExpiresIn       int    `json:"expires_in"`
+			RefreshToken    string `json:"refresh_token,omitempty"`
+			IDToken         string `json:"id_token,omitempty"`
+			IssuedTokenType string `json:"issued_token_type,omitempty"`
 		}
 		err := json.Unmarshal(rec.Body.Bytes(), &resp)
 		if err != nil {
@@ -82,7 +83,11 @@ func StoreAccessToken(
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		claims, err := claimsParser.ParseClaims(resp.IDToken)
+		rawIDToken := resp.IDToken
+		if rawIDToken == "" {
+			rawIDToken = resp.AccessToken
+		}
+		claims, err := claimsParser.ParseClaims(rawIDToken)
 		if err != nil {
 			logger.Error("parse-id-token", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/skymarshal/token/access_token_test.go
+++ b/skymarshal/token/access_token_test.go
@@ -79,6 +79,16 @@ var _ = Describe("Access Tokens", func() {
 				expectBody:       `{"access_token":"123abc","token_type":"bearer","expires_in":1234,"id_token":"a.b.c"}`,
 			},
 			{
+				it: "converts RFC 8693 token-exchange responses, which have no id_token",
+
+				path:       "/sky/issuer/token",
+				statusCode: 200,
+				body:       `{"access_token":"a.b.c","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"bearer","expires_in":1234}`,
+
+				expectStatusCode: 200,
+				expectBody:       `{"access_token":"123abc","token_type":"bearer","expires_in":1234,"issued_token_type":"urn:ietf:params:oauth:token-type:access_token"}`,
+			},
+			{
 				it: "forwards failure response",
 
 				path:       "/sky/issuer/token",
@@ -168,6 +178,33 @@ var _ = Describe("Access Tokens", func() {
 				Expect(rec.Body.String()).To(Equal(t.expectBody))
 			})
 		}
+
+		Describe("choosing the token to parse claims from", func() {
+			var serveTokenResponse = func(body string) {
+				baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(200)
+					w.Write([]byte(body))
+				})
+				handler := token.StoreAccessToken(dummyLogger, baseHandler, generator, claimsParser, accessTokenFactory, userFactory, displayUserIdGenerator)
+				r, _ := http.NewRequest("GET", "/sky/issuer/token", nil)
+				generator.GenerateAccessTokenReturns("123abc", nil)
+				handler.ServeHTTP(httptest.NewRecorder(), r)
+			}
+
+			It("parses claims from the id_token when present", func() {
+				serveTokenResponse(`{"access_token":"123","token_type":"bearer","expires_in":1234,"id_token":"a.b.c"}`)
+
+				Expect(claimsParser.ParseClaimsCallCount()).To(Equal(1))
+				Expect(claimsParser.ParseClaimsArgsForCall(0)).To(Equal("a.b.c"))
+			})
+
+			It("parses claims from the access_token when id_token is absent (RFC 8693 token exchange)", func() {
+				serveTokenResponse(`{"access_token":"x.y.z","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"bearer","expires_in":1234}`)
+
+				Expect(claimsParser.ParseClaimsCallCount()).To(Equal(1))
+				Expect(claimsParser.ParseClaimsArgsForCall(0)).To(Equal("x.y.z"))
+			})
+		})
 	})
 
 	Describe("Token Generation", func() {


### PR DESCRIPTION
## Changes proposed by this PR

closes #9636

_Make sure to follow all [PR requirements](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements)._

* Dex's token-exchange grant returns the issued token in access_token and, per RFC 8693 section 2.2.1, has no id_token member. StoreAccessToken assumed every 2xx from /sky/issuer/token carried an id_token, so it parsed an empty string, failed, and converted Dex's successful response into an empty 500 - making token exchange against the embedded Dex unusable. Fall back to parsing claims from access_token so exchanged tokens are converted to stored Concourse access tokens like every other grant.


## Notes to reviewer

- **Why rewrite rather than pass through?** Simply skipping the middleware for
  the exchange grant would hand the client a raw Dex JWT, which the ATC no
  longer accepts (Concourse >= 7 validates opaque DB-backed tokens). Rewriting
  keeps exchange clients on the same token model as `fly` login, including the
  user row creation (`CreateOrUpdateUser`) and the short-header benefit that
  motivated opaque tokens in the first place.
- **Why not gate on `grant_type` from the request?** The response-side check
  (`id_token` empty) is more robust — the request body has already been
  consumed by the Dex handler, and any 2xx response lacking `id_token`
  previously produced a guaranteed 500, so the fallback is strictly an
  improvement.
- The two struct additions are cosmetic but keep the rewritten response
  honest: `omitempty` stops an empty `"id_token": ""` appearing in exchange
  responses, and `issued_token_type` is preserved instead of silently dropped
  on re-marshal.
- A test belongs in `skymarshal/token/access_token_test.go`: feed the
  middleware a fake Dex 200 with `access_token` = signed JWT and no
  `id_token`, assert a 200 with an opaque token and stored claims.
