### PR TITLE
atc: Have EOF errors from checks treated as no versions found

### DIFF
--- a/atc/resource/resource.go
+++ b/atc/resource/resource.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -36,7 +37,7 @@ func (resource Resource) Check(ctx context.Context, container runtime.Container,
 		Path: "/opt/resource/check",
 	}
 
-	var versions []atc.Version
+	versions := []atc.Version{}
 	processResult, err := resource.run(ctx, container, spec, stderr, false, &versions)
 	if err != nil {
 		return nil, runtime.ProcessResult{}, err
@@ -68,6 +69,14 @@ func (resource Resource) Get(ctx context.Context, container runtime.Container, s
 	processResult, err := resource.run(ctx, container, spec, stderr, true, &versionResult)
 	if err != nil {
 		return VersionResult{}, runtime.ProcessResult{}, err
+	}
+
+	if processResult.ExitStatus != 0 {
+		return VersionResult{}, processResult, nil
+	}
+
+	if versionResult.Version == nil {
+		return VersionResult{}, runtime.ProcessResult{}, fmt.Errorf("resource script (%s %s) output a null version", spec.Path, strings.Join(spec.Args, " "))
 	}
 
 	if err := resource.cacheResult(container, versionResult); err != nil {
@@ -102,7 +111,12 @@ func (resource Resource) Put(ctx context.Context, container runtime.Container, s
 	if err != nil {
 		return VersionResult{}, runtime.ProcessResult{}, err
 	}
-	if processResult.ExitStatus == 0 && versionResult.Version == nil {
+
+	if processResult.ExitStatus != 0 {
+		return VersionResult{}, processResult, nil
+	}
+
+	if versionResult.Version == nil {
 		return VersionResult{}, runtime.ProcessResult{}, fmt.Errorf("resource script (%s %s) output a null version", spec.Path, strings.Join(spec.Args, " "))
 	}
 
@@ -129,7 +143,7 @@ func (resource Resource) run(ctx context.Context, container runtime.Container, s
 	}
 
 	buf := new(bytes.Buffer)
-	io := runtime.ProcessIO{
+	runtimeIO := runtime.ProcessIO{
 		Stdin:  bytes.NewBuffer(input),
 		Stdout: buf,
 		Stderr: stderr,
@@ -137,9 +151,9 @@ func (resource Resource) run(ctx context.Context, container runtime.Container, s
 
 	var process runtime.Process
 	if attach {
-		process, err = attachOrRun(ctx, container, spec, io)
+		process, err = attachOrRun(ctx, container, spec, runtimeIO)
 	} else {
-		process, err = container.Run(ctx, spec, io)
+		process, err = container.Run(ctx, spec, runtimeIO)
 	}
 	if err != nil {
 		return runtime.ProcessResult{}, err
@@ -154,6 +168,11 @@ func (resource Resource) run(ctx context.Context, container runtime.Container, s
 	}
 
 	if err := json.NewDecoder(buf).Decode(output); err != nil {
+		if errors.Is(err, io.EOF) {
+			// Getting EOF means there was no data from stdout to parse. Let
+			// callers determine if this result is valid or not.
+			return result, nil
+		}
 		return runtime.ProcessResult{}, err
 	}
 	return result, nil

--- a/atc/resource/resource_test.go
+++ b/atc/resource/resource_test.go
@@ -44,6 +44,25 @@ func TestResourceCheck(t *testing.T) {
 		require.Equal(t, "some stderr log", stderr.String())
 	})
 
+	t.Run("successful run with no output on stdout", func(t *testing.T) {
+		expectedVersions := []atc.Version{}
+		container := runtimetest.NewContainer().
+			WithProcess(
+				expectedSpec,
+				runtimetest.ProcessStub{
+					SkipOutput: true,
+					Stderr:     "some stderr log",
+				},
+			)
+		stderr := new(bytes.Buffer)
+		versions, processResult, err := resource.Check(ctx, container, stderr)
+		require.NoError(t, err)
+		require.Equal(t, expectedVersions, versions)
+		require.Equal(t, 0, processResult.ExitStatus)
+
+		require.Equal(t, "some stderr log", stderr.String())
+	})
+
 	t.Run("error", func(t *testing.T) {
 		container := runtimetest.NewContainer().
 			WithProcess(
@@ -196,6 +215,20 @@ func TestResourceGet(t *testing.T) {
 			require.Equal(t, 123, processResult.ExitStatus)
 		})
 	})
+
+	t.Run("doesn't emit a version", func(t *testing.T) {
+		container := runtimetest.NewContainer().
+			WithProcess(
+				expectedSpec,
+				runtimetest.ProcessStub{
+					SkipOutput: true,
+					Stderr:     "some stderr log",
+				},
+			)
+		stderr := new(bytes.Buffer)
+		_, _, err := resource.Get(ctx, container, stderr)
+		require.ErrorContains(t, err, "output a null version")
+	})
 }
 
 func TestResourcePut(t *testing.T) {
@@ -292,7 +325,7 @@ func TestResourcePut(t *testing.T) {
 				},
 			)
 		_, _, err := resource.Put(ctx, container, new(bytes.Buffer))
-		require.Error(t, err)
+		require.ErrorContains(t, err, "output a null version")
 	})
 
 	t.Run("error", func(t *testing.T) {

--- a/atc/runtime/runtimetest/process.go
+++ b/atc/runtime/runtimetest/process.go
@@ -16,6 +16,7 @@ type ProcessStub struct {
 	Do         func(context.Context, *Process) error
 	Call       func(context.Context, *Process) (runtime.ProcessResult, error)
 	Output     any
+	SkipOutput bool
 	Stderr     string
 	ExitStatus int
 	Err        string
@@ -51,7 +52,9 @@ func (p *Process) Wait(ctx context.Context) (runtime.ProcessResult, error) {
 	if p.ExitStatus != 0 {
 		return runtime.ProcessResult{ExitStatus: p.ExitStatus}, nil
 	}
-	json.NewEncoder(p.Stdout()).Encode(p.Output)
+	if !p.SkipOutput {
+		json.NewEncoder(p.Stdout()).Encode(p.Output)
+	}
 	return runtime.ProcessResult{ExitStatus: 0}, nil
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

I got the intermittent and randomly occurring `run check: EOF` error in our CI, which marks the resource as "errored" with an orange outline on the resource and an orange triangle on the pipeline's card. I decided to look at where the error came from again. It starts here: https://github.com/concourse/concourse/blob/2bddebe3e32a4b8ac57f493ba994081bb32bf4e7/atc/exec/check_step.go#L216

and leads us into this function: https://github.com/concourse/concourse/blob/2bddebe3e32a4b8ac57f493ba994081bb32bf4e7/atc/resource/resource.go#L125-L160

This also got me looking at the `io.EOF` code in Go stdlib and noticed that it says:

```
// Functions should return EOF only to signal a graceful end of input.
```

That got me looking at the `Decode()` function here: https://github.com/concourse/concourse/blob/2bddebe3e32a4b8ac57f493ba994081bb32bf4e7/atc/resource/resource.go#L156

I wondered if it's meant to return `io.EOF` in the way described in the previous comment, and it does! The godocs have an example showing how the decoder parses one JSON object at a time and returns `EOF` when it's done parsing: https://pkg.go.dev/encoding/json#Decoder

Us immediately getting EOF just means there was no data on Stdout to parse. Given that we only hit this when the check already exited with an exit code of zero, I think we can infer that the check had nothing to return. If we only got a partial data read, we'd get a more detailed error from the decoder. In my tests of the decoder I can see that partial reads of JSON objects results in errors like `invalid character...`.

Still don't know why this error happens at all. Resources are supposed to emit empty json arrays `[]` if they found nothing. I wonder if such a short string ends up not getting flushed by the container runtime before we try decoding it, assuming there is a buffer to flush. We never see this error on put or get steps, so this seems like a likely cause.

I added some extra checks in the `Get()` and `Put()` functions that also call this private `run()`. In these cases we want to detect if we get back a null version and then error since it's always invalid for either of these scripts to not return a version. The `put` already had a check like this, but only when the exit status was zero. Now both functions will return early if the exit status is zero, and return an error if no version was emitted.