### PR TITLE
add: Health endpoint go-client methods and fly command

### DIFF
--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -21,6 +21,7 @@ type FlyCommand struct {
 	Login  LoginCommand  `command:"login" alias:"l" description:"Authenticate with the target"`
 	Logout LogoutCommand `command:"logout" alias:"o" description:"Release authentication with the target"`
 	Status StatusCommand `command:"status" description:"Login status"`
+	Health HealthCommand `command:"health" alias:"h" description:"Check cluster health"`
 	Sync   SyncCommand   `command:"sync"  alias:"s" description:"Download and replace the current fly from the target"`
 
 	ActiveUsers ActiveUsersCommand `command:"active-users" alias:"au" description:"List the active users since a date or for the past 2 months"`

--- a/fly/commands/health.go
+++ b/fly/commands/health.go
@@ -18,7 +18,7 @@ type HealthCommand struct {
 }
 
 func (command *HealthCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := rc.LoadTargetWithoutAuth(Fly.Target, Fly.Verbose)
 	if err != nil {
 		return err
 	}

--- a/fly/commands/health.go
+++ b/fly/commands/health.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/fly/ui"
+	"github.com/fatih/color"
+)
+
+type HealthCommand struct {
+	Json bool `long:"json" description:"Print command result as JSON"`
+}
+
+func (command *HealthCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	health, err := target.Client().GetHealth()
+	if err != nil {
+		return err
+	}
+
+	if command.Json {
+		return displayhelpers.JsonPrint(health)
+	}
+
+	return command.renderTable(health)
+}
+
+func (command *HealthCommand) renderTable(health atc.Health) error {
+	headers := ui.TableRow{
+		{Contents: "subsystem", Color: color.New(color.Bold)},
+		{Contents: "status", Color: color.New(color.Bold)},
+		{Contents: "detail", Color: color.New(color.Bold)},
+	}
+
+	table := ui.Table{Headers: headers}
+
+	table.Data = append(table.Data, ui.TableRow{
+		{Contents: "overall"},
+		statusCell(string(health.Status)),
+		{Contents: health.Timestamp.UTC().Format(time.RFC3339)},
+	})
+
+	dbDetail := ""
+	if health.Database.Error != "" {
+		dbDetail = health.Database.Error
+	}
+	table.Data = append(table.Data, ui.TableRow{
+		{Contents: "database"},
+		statusCell(string(health.Database.Status)),
+		{Contents: dbDetail},
+	})
+
+	workerDetail := fmt.Sprintf("%d/%d running", health.Workers.Running, health.Workers.Total)
+	if len(health.Workers.UnhealthyWorkers) > 0 {
+		workerDetail += fmt.Sprintf(" (unhealthy: %s)", strings.Join(health.Workers.UnhealthyWorkers, ", "))
+	}
+	table.Data = append(table.Data, ui.TableRow{
+		{Contents: "workers"},
+		statusCell(health.Workers.Status),
+		{Contents: workerDetail},
+	})
+
+	for _, c := range health.Components {
+		detail := ""
+		if !c.LastRan.IsZero() {
+			detail = "last ran: " + c.LastRan.UTC().Format(time.RFC3339)
+		}
+		if c.Paused {
+			detail = "paused"
+		}
+		table.Data = append(table.Data, ui.TableRow{
+			{Contents: c.Name},
+			statusCell(string(c.Status)),
+			{Contents: detail},
+		})
+	}
+
+	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+}
+
+func statusCell(status string) ui.TableCell {
+	switch status {
+	case string(atc.HealthStatusOK), string(atc.HealthStatusHealthy):
+		return ui.TableCell{Contents: status, Color: ui.SucceededColor}
+	case string(atc.HealthStatusDegraded):
+		return ui.TableCell{Contents: status, Color: ui.StartedColor}
+	case string(atc.HealthStatusFailing), string(atc.HealthStatusUnhealthy):
+		return ui.TableCell{Contents: status, Color: ui.FailedColor}
+	default:
+		return ui.TableCell{Contents: status, Color: ui.OffColor}
+	}
+}

--- a/fly/integration/health_test.go
+++ b/fly/integration/health_test.go
@@ -1,0 +1,151 @@
+package integration_test
+
+import (
+	"os/exec"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/fly/ui"
+	"github.com/fatih/color"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("fly health", func() {
+	var (
+		flyCmd        *exec.Cmd
+		healthPayload atc.Health
+	)
+
+	BeforeEach(func() {
+		// Write a pre-authenticated target and reset the server so the login
+		// handlers queued by the suite BeforeEach are discarded.
+		createFlyRc(rc.Targets{
+			targetName: {
+				API:      atcServer.URL(),
+				TeamName: teamName,
+				Token:    &rc.TargetToken{Type: "Bearer", Value: validAccessToken(time.Now().Add(time.Hour))},
+			},
+		})
+		atcServer.Reset()
+
+		flyCmd = exec.Command(flyPath, "-t", targetName, "health")
+		healthPayload = atc.Health{
+			Status:    atc.HealthStatusOK,
+			Timestamp: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
+			Workers: atc.WorkerHealth{
+				Status:  string(atc.HealthStatusHealthy),
+				Total:   2,
+				Running: 2,
+			},
+			Components: []atc.ComponentHealth{
+				{
+					Name:    atc.ComponentScheduler,
+					Status:  atc.HealthStatusHealthy,
+					Paused:  false,
+					LastRan: time.Date(2024, 1, 1, 11, 59, 0, 0, time.UTC),
+				},
+			},
+		}
+	})
+
+	Context("when the cluster is healthy", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/health"),
+					ghttp.RespondWithJSONEncoded(200, healthPayload),
+				),
+			)
+		})
+
+		It("prints a table with the cluster health and exits 0", func() {
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gexec.Exit(0))
+			Expect(sess.Out).To(PrintTable(ui.Table{
+				Headers: ui.TableRow{
+					{Contents: "subsystem", Color: color.New(color.Bold)},
+					{Contents: "status", Color: color.New(color.Bold)},
+					{Contents: "detail", Color: color.New(color.Bold)},
+				},
+				Data: []ui.TableRow{
+					{{Contents: "overall"}, {Contents: "ok", Color: ui.SucceededColor}, {Contents: "2024-01-01T12:00:00Z"}},
+					{{Contents: "database"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: ""}},
+					{{Contents: "workers"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "2/2 running"}},
+					{{Contents: "scheduler"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "last ran: 2024-01-01T11:59:00Z"}},
+				},
+			}))
+		})
+
+		Context("when --json is given", func() {
+			BeforeEach(func() {
+				flyCmd.Args = append(flyCmd.Args, "--json")
+			})
+
+			It("prints the response as JSON and exits 0", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(0))
+				Expect(sess.Out.Contents()).To(MatchJSON(`{
+					"status": "ok",
+					"timestamp": "2024-01-01T12:00:00Z",
+					"database": {"status": "healthy"},
+					"workers": {"status": "healthy", "total": 2, "running": 2},
+					"components": [{"name": "scheduler", "status": "healthy", "paused": false, "last_ran": "2024-01-01T11:59:00Z"}]
+				}`))
+			})
+		})
+	})
+
+	Context("when the cluster is failing (503)", func() {
+		BeforeEach(func() {
+			healthPayload.Status = atc.HealthStatusFailing
+			healthPayload.Database = atc.DatabaseHealth{
+				Status: atc.HealthStatusUnhealthy,
+				Error:  "database unreachable",
+			}
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/health"),
+					ghttp.RespondWithJSONEncoded(503, healthPayload),
+				),
+			)
+		})
+
+		It("prints the table showing failing status and exits 0", func() {
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gexec.Exit(0))
+			Expect(sess.Out).To(gbytes.Say("failing"))
+			Expect(sess.Out).To(gbytes.Say("database unreachable"))
+		})
+	})
+
+	Context("when the server returns an unexpected error", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/health"),
+					ghttp.RespondWith(500, ""),
+				),
+			)
+		})
+
+		It("writes an error message to stderr and exits 1", func() {
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gexec.Exit(1))
+			Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
+		})
+	})
+})

--- a/fly/integration/health_test.go
+++ b/fly/integration/health_test.go
@@ -22,8 +22,6 @@ var _ = Describe("fly health", func() {
 	)
 
 	BeforeEach(func() {
-		// Write a pre-authenticated target and reset the server so the login
-		// handlers queued by the suite BeforeEach are discarded.
 		createFlyRc(rc.Targets{
 			targetName: {
 				API:      atcServer.URL(),
@@ -82,6 +80,26 @@ var _ = Describe("fly health", func() {
 					{{Contents: "scheduler"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "last ran: 2024-01-01T11:59:00Z"}},
 				},
 			}))
+		})
+
+		Context("when the token is expired or missing", func() {
+			BeforeEach(func() {
+				createFlyRc(rc.Targets{
+					targetName: {
+						API:      atcServer.URL(),
+						TeamName: teamName,
+						Token:    &rc.TargetToken{Type: "Bearer", Value: validAccessToken(time.Now().Add(-time.Hour))},
+					},
+				})
+			})
+
+			It("succeeds without requiring a valid token", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(0))
+				Expect(sess.Out).To(gbytes.Say("ok"))
+			})
 		})
 
 		Context("when --json is given", func() {

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -170,6 +170,43 @@ func LoadTarget(selectedTarget TargetName, tracing bool) (Target, error) {
 	), nil
 }
 
+// Use for unauthenticated endpoints of targets, like (health, info, etc.).
+func LoadTargetWithoutAuth(selectedTarget TargetName, tracing bool) (Target, error) {
+	var clientCertificate []tls.Certificate
+
+	targetProps, err := selectTarget(selectedTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	caCertPool, err := loadCACertPool(targetProps.CACert)
+	if err != nil {
+		return nil, err
+	}
+
+	clientCertificate, err = loadClientCertificate(targetProps.ClientCertPath, targetProps.ClientKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := defaultHttpClient(nil, targetProps.Insecure, caCertPool, clientCertificate)
+	client := concourse.NewClient(targetProps.API, httpClient, tracing)
+
+	return NewTarget(
+		selectedTarget,
+		targetProps.TeamName,
+		targetProps.API,
+		targetProps.Token,
+		targetProps.CACert,
+		caCertPool,
+		targetProps.ClientCertPath,
+		targetProps.ClientKeyPath,
+		clientCertificate,
+		targetProps.Insecure,
+		client,
+	), nil
+}
+
 func LoadUnauthenticatedTarget(
 	selectedTarget TargetName,
 	teamName string,

--- a/go-concourse/concourse/client.go
+++ b/go-concourse/concourse/client.go
@@ -27,6 +27,7 @@ type Client interface {
 	PruneWorker(workerName string) error
 	LandWorker(workerName string) error
 	GetInfo() (atc.Info, error)
+	GetHealth() (atc.Health, error)
 	GetCLIReader(arch, platform string) (io.ReadCloser, http.Header, error)
 	ListPipelines() ([]atc.Pipeline, error)
 	ListAllJobs() ([]atc.Job, error)

--- a/go-concourse/concourse/concoursefakes/fake_client.go
+++ b/go-concourse/concourse/concoursefakes/fake_client.go
@@ -136,6 +136,18 @@ type FakeClient struct {
 		result2 http.Header
 		result3 error
 	}
+	GetHealthStub        func() (atc.Health, error)
+	getHealthMutex       sync.RWMutex
+	getHealthArgsForCall []struct {
+	}
+	getHealthReturns struct {
+		result1 atc.Health
+		result2 error
+	}
+	getHealthReturnsOnCall map[int]struct {
+		result1 atc.Health
+		result2 error
+	}
 	GetInfoStub        func() (atc.Info, error)
 	getInfoMutex       sync.RWMutex
 	getInfoArgsForCall []struct {
@@ -959,6 +971,62 @@ func (fake *FakeClient) GetCLIReaderReturnsOnCall(i int, result1 io.ReadCloser, 
 		result2 http.Header
 		result3 error
 	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) GetHealth() (atc.Health, error) {
+	fake.getHealthMutex.Lock()
+	ret, specificReturn := fake.getHealthReturnsOnCall[len(fake.getHealthArgsForCall)]
+	fake.getHealthArgsForCall = append(fake.getHealthArgsForCall, struct {
+	}{})
+	stub := fake.GetHealthStub
+	fakeReturns := fake.getHealthReturns
+	fake.recordInvocation("GetHealth", []interface{}{})
+	fake.getHealthMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetHealthCallCount() int {
+	fake.getHealthMutex.RLock()
+	defer fake.getHealthMutex.RUnlock()
+	return len(fake.getHealthArgsForCall)
+}
+
+func (fake *FakeClient) GetHealthCalls(stub func() (atc.Health, error)) {
+	fake.getHealthMutex.Lock()
+	defer fake.getHealthMutex.Unlock()
+	fake.GetHealthStub = stub
+}
+
+func (fake *FakeClient) GetHealthReturns(result1 atc.Health, result2 error) {
+	fake.getHealthMutex.Lock()
+	defer fake.getHealthMutex.Unlock()
+	fake.GetHealthStub = nil
+	fake.getHealthReturns = struct {
+		result1 atc.Health
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetHealthReturnsOnCall(i int, result1 atc.Health, result2 error) {
+	fake.getHealthMutex.Lock()
+	defer fake.getHealthMutex.Unlock()
+	fake.GetHealthStub = nil
+	if fake.getHealthReturnsOnCall == nil {
+		fake.getHealthReturnsOnCall = make(map[int]struct {
+			result1 atc.Health
+			result2 error
+		})
+	}
+	fake.getHealthReturnsOnCall[i] = struct {
+		result1 atc.Health
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeClient) GetInfo() (atc.Info, error) {

--- a/go-concourse/concourse/health.go
+++ b/go-concourse/concourse/health.go
@@ -1,0 +1,36 @@
+package concourse
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/go-concourse/concourse/internal"
+)
+
+func (client *client) GetHealth() (atc.Health, error) {
+	resp, err := client.httpAgent.Send(internal.Request{
+		RequestName: atc.GetHealth,
+	})
+	if err != nil {
+		return atc.Health{}, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusServiceUnavailable:
+		var health atc.Health
+		if err = json.NewDecoder(resp.Body).Decode(&health); err != nil {
+			return atc.Health{}, err
+		}
+		return health, nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return atc.Health{}, internal.UnexpectedResponseError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       string(body),
+		}
+	}
+}

--- a/go-concourse/concourse/health_test.go
+++ b/go-concourse/concourse/health_test.go
@@ -1,0 +1,97 @@
+package concourse_test
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/go-concourse/concourse/internal"
+)
+
+var _ = Describe("GetHealth", func() {
+	var healthResponse atc.Health
+
+	BeforeEach(func() {
+		healthResponse = atc.Health{
+			Status:    atc.HealthStatusOK,
+			Timestamp: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+			Database:  atc.DatabaseHealth{Status: atc.HealthStatusHealthy},
+			Workers: atc.WorkerHealth{
+				Status:  string(atc.HealthStatusHealthy),
+				Total:   3,
+				Running: 3,
+			},
+			Components: []atc.ComponentHealth{
+				{Name: atc.ComponentScheduler, Status: atc.HealthStatusHealthy, Paused: false},
+			},
+		}
+	})
+
+	Context("when the cluster is healthy (200)", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/health"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, healthResponse),
+				),
+			)
+		})
+
+		It("returns the health response", func() {
+			health, err := client.GetHealth()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(health.Status).To(Equal(atc.HealthStatusOK))
+			Expect(health.Database.Status).To(Equal(atc.HealthStatusHealthy))
+			Expect(health.Workers.Total).To(Equal(3))
+			Expect(health.Workers.Running).To(Equal(3))
+			Expect(health.Components).To(HaveLen(1))
+		})
+	})
+
+	Context("when the cluster is failing (503)", func() {
+		BeforeEach(func() {
+			healthResponse.Status = atc.HealthStatusFailing
+			healthResponse.Database = atc.DatabaseHealth{
+				Status: atc.HealthStatusUnhealthy,
+				Error:  "database unreachable",
+			}
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/health"),
+					ghttp.RespondWithJSONEncoded(http.StatusServiceUnavailable, healthResponse),
+				),
+			)
+		})
+
+		It("still decodes the response body without returning an error", func() {
+			health, err := client.GetHealth()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(health.Status).To(Equal(atc.HealthStatusFailing))
+			Expect(health.Database.Status).To(Equal(atc.HealthStatusUnhealthy))
+			Expect(health.Database.Error).To(Equal("database unreachable"))
+		})
+	})
+
+	Context("when the server returns an unexpected status code", func() {
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/health"),
+					ghttp.RespondWith(http.StatusInternalServerError, "internal error"),
+				),
+			)
+		})
+
+		It("returns an UnexpectedResponseError", func() {
+			_, err := client.GetHealth()
+			Expect(err).To(HaveOccurred())
+			ure, ok := err.(internal.UnexpectedResponseError)
+			Expect(ok).To(BeTrue())
+			Expect(ure.StatusCode).To(Equal(http.StatusInternalServerError))
+		})
+	})
+})


### PR DESCRIPTION
## Changes proposed by this PR

Follow-up to #9588 — adds client library support and a CLI command for the health endpoint.

- Added `GetHealth() (atc.Health, error)` to the `go-concourse` client interface
- Implemented `GET /api/v1/health` client method using `httpAgent` so the response body is decoded on both 200 and 503 (a 503 from this endpoint means the cluster is failing, not that the request itself failed)
- Regenerated `concoursefakes/fake_client.go` with the new method
- Added `fly health` command with table output and `--json` flag, ~~registered as alias `h`~~
- Table shows overall status, database, workers (total/running + unhealthy worker names), and all components with their last run time

## Notes to reviewer

- **`httpAgent` over `connection.Send`**: the health endpoint deliberately returns 503 with a JSON body when the cluster is failing. `connection.Send` treats non-2xx as an error and skips decoding — `httpAgent.Send` lets us decode 503 responses the same as 200, so callers always get a populated `atc.Health` struct regardless of cluster state.

- **No `target.Validate()` in the fly command**: the health endpoint is unauthenticated. Calling `Validate()` would hit `/api/v1/info` and do a version check before the actual health call, which is unnecessary overhead. Follows the same pattern as `fly status`.

- **Exit code is always 0**: a failing cluster is informational, not a fly error. The cluster state is conveyed through the JSON body and table output. Consistent with how `fly status` works.

- **Integration tests use `createFlyRc` + `atcServer.Reset()`**: the suite `BeforeEach` runs a full login sequence and queues 4 handlers. Since `fly health` skips login, we write the target directly to `~/.flyrc` and reset the server to discard those unused handlers. Same pattern as `fly status` integration tests.


