### PR TITLE
add shared path support to kubernetes, CONCOURSE_KUBERNETES_SHARED_PATH

### DIFF
--- a/atc/creds/kubernetes/kubernetes_factory.go
+++ b/atc/creds/kubernetes/kubernetes_factory.go
@@ -10,17 +10,17 @@ import (
 type kubernetesFactory struct {
 	logger lager.Logger
 
-	client          kubernetes.Interface
-	namespacePrefix string
-	sharedPath      string
+	client                kubernetes.Interface
+	namespacePrefix       string
+	namespaceSharedSuffix string
 }
 
-func NewKubernetesFactory(logger lager.Logger, client kubernetes.Interface, namespacePrefix, sharedPath string) *kubernetesFactory {
+func NewKubernetesFactory(logger lager.Logger, client kubernetes.Interface, namespacePrefix, namespaceSharedSuffix string) *kubernetesFactory {
 	factory := &kubernetesFactory{
-		logger:          logger,
-		client:          client,
-		namespacePrefix: namespacePrefix,
-		sharedPath:      sharedPath,
+		logger:                logger,
+		client:                client,
+		namespacePrefix:       namespacePrefix,
+		namespaceSharedSuffix: namespaceSharedSuffix,
 	}
 
 	return factory
@@ -28,9 +28,9 @@ func NewKubernetesFactory(logger lager.Logger, client kubernetes.Interface, name
 
 func (factory *kubernetesFactory) NewSecrets() creds.Secrets {
 	return &Secrets{
-		logger:          factory.logger,
-		client:          factory.client,
-		namespacePrefix: factory.namespacePrefix,
-		sharedPath:      factory.sharedPath,
+		logger:                factory.logger,
+		client:                factory.client,
+		namespacePrefix:       factory.namespacePrefix,
+		NamespaceSharedSuffix: factory.namespaceSharedSuffix,
 	}
 }

--- a/atc/creds/kubernetes/kubernetes_factory.go
+++ b/atc/creds/kubernetes/kubernetes_factory.go
@@ -31,6 +31,6 @@ func (factory *kubernetesFactory) NewSecrets() creds.Secrets {
 		logger:                factory.logger,
 		client:                factory.client,
 		namespacePrefix:       factory.namespacePrefix,
-		NamespaceSharedSuffix: factory.namespaceSharedSuffix,
+		namespaceSharedSuffix: factory.namespaceSharedSuffix,
 	}
 }

--- a/atc/creds/kubernetes/kubernetes_factory.go
+++ b/atc/creds/kubernetes/kubernetes_factory.go
@@ -12,13 +12,15 @@ type kubernetesFactory struct {
 
 	client          kubernetes.Interface
 	namespacePrefix string
+	sharedPath      string
 }
 
-func NewKubernetesFactory(logger lager.Logger, client kubernetes.Interface, namespacePrefix string) *kubernetesFactory {
+func NewKubernetesFactory(logger lager.Logger, client kubernetes.Interface, namespacePrefix, sharedPath string) *kubernetesFactory {
 	factory := &kubernetesFactory{
 		logger:          logger,
 		client:          client,
 		namespacePrefix: namespacePrefix,
+		sharedPath:      sharedPath,
 	}
 
 	return factory
@@ -29,5 +31,6 @@ func (factory *kubernetesFactory) NewSecrets() creds.Secrets {
 		logger:          factory.logger,
 		client:          factory.client,
 		namespacePrefix: factory.namespacePrefix,
+		sharedPath:      factory.sharedPath,
 	}
 }

--- a/atc/creds/kubernetes/kubernetes_test.go
+++ b/atc/creds/kubernetes/kubernetes_test.go
@@ -166,9 +166,9 @@ var _ = Describe("Kubernetes", func() {
 		},
 			Entry("shared-path scoped vars with a value field", Example{
 				Setup: func() {
-					fakeClientset.CoreV1().Secrets("prefix-").Create(context.TODO(), &v1.Secret{
+					fakeClientset.CoreV1().Secrets("prefix-shared").Create(context.TODO(), &v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "shared." + secretName,
+							Name: secretName,
 						},
 						Data: map[string][]byte{
 							"value": []byte("some-shared-value"),
@@ -182,7 +182,7 @@ var _ = Describe("Kubernetes", func() {
 		)
 	})
 
-	Context("with a nested shared path", func() {
+	Context("with a custom shared path suffix", func() {
 		BeforeEach(func() {
 			fakeClientset = fake.NewSimpleClientset()
 
@@ -190,7 +190,7 @@ var _ = Describe("Kubernetes", func() {
 				lagertest.NewTestLogger("test"),
 				fakeClientset,
 				"prefix-",
-				"shared/nested",
+				"shared-nested",
 			)
 
 			vs = creds.NewVariables(factory.NewSecrets(), creds.SecretLookupParams{Team: "some-team", Pipeline: "some-pipeline"}, false)
@@ -201,9 +201,9 @@ var _ = Describe("Kubernetes", func() {
 		},
 			Entry("nested shared-path scoped vars with a value field", Example{
 				Setup: func() {
-					fakeClientset.CoreV1().Secrets("prefix-").Create(context.TODO(), &v1.Secret{
+					fakeClientset.CoreV1().Secrets("prefix-shared-nested").Create(context.TODO(), &v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "shared.nested." + secretName,
+							Name: secretName,
 						},
 						Data: map[string][]byte{
 							"value": []byte("some-nested-shared-value"),

--- a/atc/creds/kubernetes/kubernetes_test.go
+++ b/atc/creds/kubernetes/kubernetes_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Kubernetes", func() {
 		}),
 	)
 
-	Context("with a shared path", func() {
+	Context("with a shared namespace suffix", func() {
 		BeforeEach(func() {
 			fakeClientset = fake.NewSimpleClientset()
 
@@ -164,7 +164,7 @@ var _ = Describe("Kubernetes", func() {
 		DescribeTable("var lookup", func(ex Example) {
 			ex.Assert(vs)
 		},
-			Entry("shared-path scoped vars with a value field", Example{
+			Entry("shared-namespace-suffix scoped vars with a value field", Example{
 				Setup: func() {
 					fakeClientset.CoreV1().Secrets("prefix-shared").Create(context.TODO(), &v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
@@ -178,41 +178,6 @@ var _ = Describe("Kubernetes", func() {
 
 				Template: "((" + secretName + "))",
 				Result:   "some-shared-value",
-			}),
-		)
-	})
-
-	Context("with a custom shared path suffix", func() {
-		BeforeEach(func() {
-			fakeClientset = fake.NewSimpleClientset()
-
-			factory := kubernetes.NewKubernetesFactory(
-				lagertest.NewTestLogger("test"),
-				fakeClientset,
-				"prefix-",
-				"shared-nested",
-			)
-
-			vs = creds.NewVariables(factory.NewSecrets(), creds.SecretLookupParams{Team: "some-team", Pipeline: "some-pipeline"}, false)
-		})
-
-		DescribeTable("var lookup", func(ex Example) {
-			ex.Assert(vs)
-		},
-			Entry("nested shared-path scoped vars with a value field", Example{
-				Setup: func() {
-					fakeClientset.CoreV1().Secrets("prefix-shared-nested").Create(context.TODO(), &v1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: secretName,
-						},
-						Data: map[string][]byte{
-							"value": []byte("some-nested-shared-value"),
-						},
-					}, metav1.CreateOptions{})
-				},
-
-				Template: "((" + secretName + "))",
-				Result:   "some-nested-shared-value",
 			}),
 		)
 	})

--- a/atc/creds/kubernetes/kubernetes_test.go
+++ b/atc/creds/kubernetes/kubernetes_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Kubernetes", func() {
 			lagertest.NewTestLogger("test"),
 			fakeClientset,
 			"prefix-",
+			"",
 		)
 
 		vs = creds.NewVariables(factory.NewSecrets(), creds.SecretLookupParams{Team: "some-team", Pipeline: "some-pipeline"}, false)

--- a/atc/creds/kubernetes/kubernetes_test.go
+++ b/atc/creds/kubernetes/kubernetes_test.go
@@ -146,4 +146,74 @@ var _ = Describe("Kubernetes", func() {
 			Result:   "some-field-value",
 		}),
 	)
+
+	Context("with a shared path", func() {
+		BeforeEach(func() {
+			fakeClientset = fake.NewSimpleClientset()
+
+			factory := kubernetes.NewKubernetesFactory(
+				lagertest.NewTestLogger("test"),
+				fakeClientset,
+				"prefix-",
+				"shared",
+			)
+
+			vs = creds.NewVariables(factory.NewSecrets(), creds.SecretLookupParams{Team: "some-team", Pipeline: "some-pipeline"}, false)
+		})
+
+		DescribeTable("var lookup", func(ex Example) {
+			ex.Assert(vs)
+		},
+			Entry("shared-path scoped vars with a value field", Example{
+				Setup: func() {
+					fakeClientset.CoreV1().Secrets("prefix-").Create(context.TODO(), &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "shared." + secretName,
+						},
+						Data: map[string][]byte{
+							"value": []byte("some-shared-value"),
+						},
+					}, metav1.CreateOptions{})
+				},
+
+				Template: "((" + secretName + "))",
+				Result:   "some-shared-value",
+			}),
+		)
+	})
+
+	Context("with a nested shared path", func() {
+		BeforeEach(func() {
+			fakeClientset = fake.NewSimpleClientset()
+
+			factory := kubernetes.NewKubernetesFactory(
+				lagertest.NewTestLogger("test"),
+				fakeClientset,
+				"prefix-",
+				"shared/nested",
+			)
+
+			vs = creds.NewVariables(factory.NewSecrets(), creds.SecretLookupParams{Team: "some-team", Pipeline: "some-pipeline"}, false)
+		})
+
+		DescribeTable("var lookup", func(ex Example) {
+			ex.Assert(vs)
+		},
+			Entry("nested shared-path scoped vars with a value field", Example{
+				Setup: func() {
+					fakeClientset.CoreV1().Secrets("prefix-").Create(context.TODO(), &v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "shared.nested." + secretName,
+						},
+						Data: map[string][]byte{
+							"value": []byte("some-nested-shared-value"),
+						},
+					}, metav1.CreateOptions{})
+				},
+
+				Template: "((" + secretName + "))",
+				Result:   "some-nested-shared-value",
+			}),
+		)
+	})
 })

--- a/atc/creds/kubernetes/manager.go
+++ b/atc/creds/kubernetes/manager.go
@@ -13,19 +13,19 @@ import (
 )
 
 type KubernetesManager struct {
-	InClusterConfig bool   `long:"in-cluster" description:"Enables the in-cluster client."`
-	ConfigPath      string `long:"config-path" description:"Path to Kubernetes config when running ATC outside Kubernetes."`
-	NamespacePrefix string `long:"namespace-prefix" default:"concourse-" description:"Prefix to use for Kubernetes namespaces under which secrets will be looked up."`
-	SharedPath      string `long:"shared-path" description:"Path under which to look up shared credentials. This value is appended to the configured namespacePrefix to determine the shared namespace."`
+	InClusterConfig       bool   `long:"in-cluster" description:"Enables the in-cluster client."`
+	ConfigPath            string `long:"config-path" description:"Path to Kubernetes config when running ATC outside Kubernetes."`
+	NamespacePrefix       string `long:"namespace-prefix" default:"concourse-" description:"Prefix to use for Kubernetes namespaces under which secrets will be looked up."`
+	NamespaceSharedSuffix string `long:"shared-namespace-suffix" description:"Appended to the namespace-prefix, which combined should match an existing Kubernetes namespace used to lookup shared secrets in."`
 }
 
 func (manager *KubernetesManager) MarshalJSON() ([]byte, error) {
 	// XXX: Get Health
 	return json.Marshal(&map[string]any{
-		"in_cluster_config": manager.InClusterConfig,
-		"config_path":       manager.ConfigPath,
-		"namespace_config":  manager.NamespacePrefix,
-		"shared_path":       manager.SharedPath,
+		"in_cluster_config":       manager.InClusterConfig,
+		"config_path":             manager.ConfigPath,
+		"namespace_config":        manager.NamespacePrefix,
+		"namespace_shared_config": manager.NamespaceSharedSuffix,
 	})
 }
 
@@ -71,7 +71,7 @@ func (manager KubernetesManager) NewSecretsFactory(logger lager.Logger) (creds.S
 		return nil, err
 	}
 
-	return NewKubernetesFactory(logger, clientset, manager.NamespacePrefix, manager.SharedPath), nil
+	return NewKubernetesFactory(logger, clientset, manager.NamespacePrefix, manager.NamespaceSharedSuffix), nil
 }
 
 func (manager KubernetesManager) Close(logger lager.Logger) {

--- a/atc/creds/kubernetes/manager.go
+++ b/atc/creds/kubernetes/manager.go
@@ -16,7 +16,7 @@ type KubernetesManager struct {
 	InClusterConfig bool   `long:"in-cluster" description:"Enables the in-cluster client."`
 	ConfigPath      string `long:"config-path" description:"Path to Kubernetes config when running ATC outside Kubernetes."`
 	NamespacePrefix string `long:"namespace-prefix" default:"concourse-" description:"Prefix to use for Kubernetes namespaces under which secrets will be looked up."`
-	SharedPath      string `long:"shared-path" description:"Path under which to lookup shared credentials."`
+	SharedPath      string `long:"shared-path" description:"Path under which to look up shared credentials. This value is appended to the configured namespacePrefix to determine the shared namespace."`
 }
 
 func (manager *KubernetesManager) MarshalJSON() ([]byte, error) {

--- a/atc/creds/kubernetes/manager.go
+++ b/atc/creds/kubernetes/manager.go
@@ -16,6 +16,7 @@ type KubernetesManager struct {
 	InClusterConfig bool   `long:"in-cluster" description:"Enables the in-cluster client."`
 	ConfigPath      string `long:"config-path" description:"Path to Kubernetes config when running ATC outside Kubernetes."`
 	NamespacePrefix string `long:"namespace-prefix" default:"concourse-" description:"Prefix to use for Kubernetes namespaces under which secrets will be looked up."`
+	SharedPath      string `long:"shared-path" default:"path under which to lookup for shared credentials"`
 }
 
 func (manager *KubernetesManager) MarshalJSON() ([]byte, error) {
@@ -24,6 +25,7 @@ func (manager *KubernetesManager) MarshalJSON() ([]byte, error) {
 		"in_cluster_config": manager.InClusterConfig,
 		"config_path":       manager.ConfigPath,
 		"namespace_config":  manager.NamespacePrefix,
+		"shared_path":       manager.SharedPath,
 	})
 }
 
@@ -69,7 +71,7 @@ func (manager KubernetesManager) NewSecretsFactory(logger lager.Logger) (creds.S
 		return nil, err
 	}
 
-	return NewKubernetesFactory(logger, clientset, manager.NamespacePrefix), nil
+	return NewKubernetesFactory(logger, clientset, manager.NamespacePrefix, manager.SharedPath), nil
 }
 
 func (manager KubernetesManager) Close(logger lager.Logger) {

--- a/atc/creds/kubernetes/manager.go
+++ b/atc/creds/kubernetes/manager.go
@@ -16,7 +16,7 @@ type KubernetesManager struct {
 	InClusterConfig bool   `long:"in-cluster" description:"Enables the in-cluster client."`
 	ConfigPath      string `long:"config-path" description:"Path to Kubernetes config when running ATC outside Kubernetes."`
 	NamespacePrefix string `long:"namespace-prefix" default:"concourse-" description:"Prefix to use for Kubernetes namespaces under which secrets will be looked up."`
-	SharedPath      string `long:"shared-path" default:"Path under which to lookup shared credentials."`
+	SharedPath      string `long:"shared-path" description:"Path under which to lookup shared credentials."`
 }
 
 func (manager *KubernetesManager) MarshalJSON() ([]byte, error) {

--- a/atc/creds/kubernetes/manager.go
+++ b/atc/creds/kubernetes/manager.go
@@ -16,7 +16,7 @@ type KubernetesManager struct {
 	InClusterConfig bool   `long:"in-cluster" description:"Enables the in-cluster client."`
 	ConfigPath      string `long:"config-path" description:"Path to Kubernetes config when running ATC outside Kubernetes."`
 	NamespacePrefix string `long:"namespace-prefix" default:"concourse-" description:"Prefix to use for Kubernetes namespaces under which secrets will be looked up."`
-	SharedPath      string `long:"shared-path" default:"path under which to lookup for shared credentials"`
+	SharedPath      string `long:"shared-path" default:"Path under which to lookup shared credentials."`
 }
 
 func (manager *KubernetesManager) MarshalJSON() ([]byte, error) {

--- a/atc/creds/kubernetes/secrets.go
+++ b/atc/creds/kubernetes/secrets.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ type Secrets struct {
 
 	client          kubernetes.Interface
 	namespacePrefix string
+	sharedPath      string
 }
 
 // NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
@@ -31,6 +33,9 @@ func (secrets Secrets) NewSecretLookupPaths(teamName string, pipelineName string
 	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"))
 	if allowRootPath {
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+"/"))
+	}
+	if secrets.sharedPath != "" {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(secrets.namespacePrefix, secrets.sharedPath)+"/"))
 	}
 	return lookupPaths
 }

--- a/atc/creds/kubernetes/secrets.go
+++ b/atc/creds/kubernetes/secrets.go
@@ -20,7 +20,7 @@ type Secrets struct {
 
 	client                kubernetes.Interface
 	namespacePrefix       string
-	NamespaceSharedSuffix string
+	namespaceSharedSuffix string
 }
 
 // NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
@@ -30,8 +30,8 @@ func (secrets Secrets) NewSecretLookupPaths(teamName string, pipelineName string
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"+pipelineName+"."))
 	}
 	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"))
-	if secrets.NamespaceSharedSuffix != "" {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+secrets.NamespaceSharedSuffix+"/"))
+	if secrets.namespaceSharedSuffix != "" {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+secrets.namespaceSharedSuffix+"/"))
 	}
 	if allowRootPath {
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+"/"))

--- a/atc/creds/kubernetes/secrets.go
+++ b/atc/creds/kubernetes/secrets.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 	"time"
 
@@ -35,7 +34,8 @@ func (secrets Secrets) NewSecretLookupPaths(teamName string, pipelineName string
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+"/"))
 	}
 	if secrets.sharedPath != "" {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(secrets.namespacePrefix, secrets.sharedPath)+"/"))
+		sharedPath := strings.ReplaceAll(secrets.sharedPath, "/", ".")
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+"/"+sharedPath+"."))
 	}
 	return lookupPaths
 }

--- a/atc/creds/kubernetes/secrets.go
+++ b/atc/creds/kubernetes/secrets.go
@@ -18,9 +18,9 @@ import (
 type Secrets struct {
 	logger lager.Logger
 
-	client          kubernetes.Interface
-	namespacePrefix string
-	sharedPath      string
+	client                kubernetes.Interface
+	namespacePrefix       string
+	NamespaceSharedSuffix string
 }
 
 // NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
@@ -30,8 +30,8 @@ func (secrets Secrets) NewSecretLookupPaths(teamName string, pipelineName string
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"+pipelineName+"."))
 	}
 	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"))
-	if secrets.sharedPath != "" {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+secrets.sharedPath+"/"))
+	if secrets.NamespaceSharedSuffix != "" {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+secrets.NamespaceSharedSuffix+"/"))
 	}
 	if allowRootPath {
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+"/"))

--- a/atc/creds/kubernetes/secrets.go
+++ b/atc/creds/kubernetes/secrets.go
@@ -30,12 +30,11 @@ func (secrets Secrets) NewSecretLookupPaths(teamName string, pipelineName string
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"+pipelineName+"."))
 	}
 	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"))
+	if secrets.sharedPath != "" {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+secrets.sharedPath+"/"))
+	}
 	if allowRootPath {
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+"/"))
-	}
-	if secrets.sharedPath != "" {
-		sharedPath := strings.ReplaceAll(secrets.sharedPath, "/", ".")
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+"/"+sharedPath+"."))
 	}
 	return lookupPaths
 }


### PR DESCRIPTION
Changes proposed by this PR

As of now, it is not possible to configure shared paths for Kubernetes secret manager as opposed to other cred managers such as Vault,AWS. So I propose to add a new parameter --kubernetes-shared-path similar to the Vault cred manager. This parameter can be optional (as with Vault). This PR provides all the changes needed for this functionality.
Notes to reviewer

Release Note

Added `--kubernetes-shared-path` to configure shared secret paths for Kubernetes cred manager similarly to the one for Vault, SSM.

PR is for the issue: https://github.com/concourse/concourse/issues/9062