### PR TITLE
Enhance fly health output and auth handling

### DIFF
--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -21,7 +21,7 @@ type FlyCommand struct {
 	Login  LoginCommand  `command:"login" alias:"l" description:"Authenticate with the target"`
 	Logout LogoutCommand `command:"logout" alias:"o" description:"Release authentication with the target"`
 	Status StatusCommand `command:"status" description:"Login status"`
-	Health HealthCommand `command:"health" alias:"h" description:"Check cluster health"`
+	Health HealthCommand `command:"health" description:"Check cluster health"`
 	Sync   SyncCommand   `command:"sync"  alias:"s" description:"Download and replace the current fly from the target"`
 
 	ActiveUsers ActiveUsersCommand `command:"active-users" alias:"au" description:"List the active users since a date or for the past 2 months"`

--- a/fly/commands/health.go
+++ b/fly/commands/health.go
@@ -71,17 +71,20 @@ func (command *HealthCommand) renderTable(health atc.Health) error {
 	})
 
 	for _, c := range health.Components {
-		detail := ""
-		if !c.LastRan.IsZero() {
-			detail = "last ran: " + c.LastRan.UTC().Format(time.RFC3339)
-		}
+		var details []string
+
 		if c.Paused {
-			detail = "paused"
+			details = append(details, "paused")
 		}
+
+		if !c.LastRan.IsZero() {
+			details = append(details, "last ran: "+c.LastRan.UTC().Format(time.RFC3339))
+		}
+
 		table.Data = append(table.Data, ui.TableRow{
 			{Contents: c.Name},
 			statusCell(string(c.Status)),
-			{Contents: detail},
+			{Contents: strings.Join(details, ", ")},
 		})
 	}
 

--- a/fly/commands/health.go
+++ b/fly/commands/health.go
@@ -50,14 +50,10 @@ func (command *HealthCommand) renderTable(health atc.Health) error {
 		{Contents: health.Timestamp.UTC().Format(time.RFC3339)},
 	})
 
-	dbDetail := ""
-	if health.Database.Error != "" {
-		dbDetail = health.Database.Error
-	}
 	table.Data = append(table.Data, ui.TableRow{
 		{Contents: "database"},
 		statusCell(string(health.Database.Status)),
-		{Contents: dbDetail},
+		{Contents: health.Database.Error},
 	})
 
 	workerDetail := fmt.Sprintf("%d/%d running", health.Workers.Running, health.Workers.Total)

--- a/fly/integration/health_test.go
+++ b/fly/integration/health_test.go
@@ -131,6 +131,45 @@ var _ = Describe("fly health", func() {
 		})
 	})
 
+	Context("when a component is paused and has previously run", func() {
+		BeforeEach(func() {
+			healthPayload.Components = []atc.ComponentHealth{
+				{
+					Name:    atc.ComponentScheduler,
+					Status:  atc.HealthStatusHealthy,
+					Paused:  true,
+					LastRan: time.Date(2024, 1, 1, 11, 59, 0, 0, time.UTC),
+				},
+			}
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/health"),
+					ghttp.RespondWithJSONEncoded(200, healthPayload),
+				),
+			)
+		})
+
+		It("shows both paused and last ran in the detail column", func() {
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess).Should(gexec.Exit(0))
+			Expect(sess.Out).To(PrintTable(ui.Table{
+				Headers: ui.TableRow{
+					{Contents: "subsystem", Color: color.New(color.Bold)},
+					{Contents: "status", Color: color.New(color.Bold)},
+					{Contents: "detail", Color: color.New(color.Bold)},
+				},
+				Data: []ui.TableRow{
+					{{Contents: "overall"}, {Contents: "ok", Color: ui.SucceededColor}, {Contents: "2024-01-01T12:00:00Z"}},
+					{{Contents: "database"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: ""}},
+					{{Contents: "workers"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "2/2 running"}},
+					{{Contents: "scheduler"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "paused, last ran: 2024-01-01T11:59:00Z"}},
+				},
+			}))
+		})
+	})
+
 	Context("when the server returns an unexpected error", func() {
 		BeforeEach(func() {
 			atcServer.AppendHandlers(

--- a/fly/integration/health_test.go
+++ b/fly/integration/health_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 	. "github.com/onsi/ginkgo/v2"
@@ -45,7 +46,7 @@ var _ = Describe("fly health", func() {
 	})
 
 	Context("when the cluster is healthy", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			atcServer.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/api/v1/health"),
@@ -75,6 +76,15 @@ var _ = Describe("fly health", func() {
 		})
 
 		Context("when the token is expired or missing", func() {
+			BeforeEach(func() {
+				createFlyRc(rc.Targets{
+					targetName: {
+						API:      atcServer.URL(),
+						TeamName: teamName,
+						Token:    &rc.TargetToken{Type: "Bearer", Value: validAccessToken(time.Now().Add(-time.Hour))},
+					},
+				})
+			})
 
 			It("succeeds without requiring a valid token", func() {
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
@@ -82,6 +92,9 @@ var _ = Describe("fly health", func() {
 
 				Eventually(sess).Should(gexec.Exit(0))
 				Expect(sess.Out).To(gbytes.Say("ok"))
+
+				Expect(atcServer.ReceivedRequests()).To(HaveLen(1))
+				Expect(atcServer.ReceivedRequests()[0].Header.Get("Authorization")).To(BeEmpty())
 			})
 		})
 
@@ -102,6 +115,102 @@ var _ = Describe("fly health", func() {
 					"workers": {"status": "healthy", "total": 2, "running": 2},
 					"components": [{"name": "scheduler", "status": "healthy", "paused": false, "last_ran": "2024-01-01T11:59:00Z"}]
 				}`))
+			})
+		})
+
+		Context("when a component is paused and has previously run", func() {
+			BeforeEach(func() {
+				healthPayload.Components = []atc.ComponentHealth{
+					{
+						Name:    atc.ComponentScheduler,
+						Status:  atc.HealthStatusHealthy,
+						Paused:  true,
+						LastRan: time.Date(2024, 1, 1, 11, 59, 0, 0, time.UTC),
+					},
+				}
+			})
+
+			It("shows both paused and last ran in the detail column", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(0))
+				Expect(sess.Out).To(PrintTable(ui.Table{
+					Headers: ui.TableRow{
+						{Contents: "subsystem", Color: color.New(color.Bold)},
+						{Contents: "status", Color: color.New(color.Bold)},
+						{Contents: "detail", Color: color.New(color.Bold)},
+					},
+					Data: []ui.TableRow{
+						{{Contents: "overall"}, {Contents: "ok", Color: ui.SucceededColor}, {Contents: "2024-01-01T12:00:00Z"}},
+						{{Contents: "database"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: ""}},
+						{{Contents: "workers"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "2/2 running"}},
+						{{Contents: "scheduler"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "paused, last ran: 2024-01-01T11:59:00Z"}},
+					},
+				}))
+			})
+		})
+
+		Context("when a component is paused and has never run", func() {
+			BeforeEach(func() {
+				healthPayload.Components = []atc.ComponentHealth{
+					{
+						Name:   atc.ComponentScheduler,
+						Status: atc.HealthStatusHealthy,
+						Paused: true,
+					},
+				}
+			})
+
+			It("shows only paused in the detail column", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(0))
+				Expect(sess.Out).To(PrintTable(ui.Table{
+					Headers: ui.TableRow{
+						{Contents: "subsystem", Color: color.New(color.Bold)},
+						{Contents: "status", Color: color.New(color.Bold)},
+						{Contents: "detail", Color: color.New(color.Bold)},
+					},
+					Data: []ui.TableRow{
+						{{Contents: "overall"}, {Contents: "ok", Color: ui.SucceededColor}, {Contents: "2024-01-01T12:00:00Z"}},
+						{{Contents: "database"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: ""}},
+						{{Contents: "workers"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "2/2 running"}},
+						{{Contents: "scheduler"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "paused"}},
+					},
+				}))
+			})
+		})
+
+		Context("when a component has never run", func() {
+			BeforeEach(func() {
+				healthPayload.Components = []atc.ComponentHealth{
+					{
+						Name:   atc.ComponentScheduler,
+						Status: atc.HealthStatusHealthy,
+					},
+				}
+			})
+
+			It("shows an empty detail column", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(0))
+				Expect(sess.Out).To(PrintTable(ui.Table{
+					Headers: ui.TableRow{
+						{Contents: "subsystem", Color: color.New(color.Bold)},
+						{Contents: "status", Color: color.New(color.Bold)},
+						{Contents: "detail", Color: color.New(color.Bold)},
+					},
+					Data: []ui.TableRow{
+						{{Contents: "overall"}, {Contents: "ok", Color: ui.SucceededColor}, {Contents: "2024-01-01T12:00:00Z"}},
+						{{Contents: "database"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: ""}},
+						{{Contents: "workers"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "2/2 running"}},
+						{{Contents: "scheduler"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: ""}},
+					},
+				}))
 			})
 		})
 	})
@@ -128,45 +237,6 @@ var _ = Describe("fly health", func() {
 			Eventually(sess).Should(gexec.Exit(0))
 			Expect(sess.Out).To(gbytes.Say("failing"))
 			Expect(sess.Out).To(gbytes.Say("database unreachable"))
-		})
-	})
-
-	Context("when a component is paused and has previously run", func() {
-		BeforeEach(func() {
-			healthPayload.Components = []atc.ComponentHealth{
-				{
-					Name:    atc.ComponentScheduler,
-					Status:  atc.HealthStatusHealthy,
-					Paused:  true,
-					LastRan: time.Date(2024, 1, 1, 11, 59, 0, 0, time.UTC),
-				},
-			}
-			atcServer.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/api/v1/health"),
-					ghttp.RespondWithJSONEncoded(200, healthPayload),
-				),
-			)
-		})
-
-		It("shows both paused and last ran in the detail column", func() {
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(sess).Should(gexec.Exit(0))
-			Expect(sess.Out).To(PrintTable(ui.Table{
-				Headers: ui.TableRow{
-					{Contents: "subsystem", Color: color.New(color.Bold)},
-					{Contents: "status", Color: color.New(color.Bold)},
-					{Contents: "detail", Color: color.New(color.Bold)},
-				},
-				Data: []ui.TableRow{
-					{{Contents: "overall"}, {Contents: "ok", Color: ui.SucceededColor}, {Contents: "2024-01-01T12:00:00Z"}},
-					{{Contents: "database"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: ""}},
-					{{Contents: "workers"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "2/2 running"}},
-					{{Contents: "scheduler"}, {Contents: "healthy", Color: ui.SucceededColor}, {Contents: "paused, last ran: 2024-01-01T11:59:00Z"}},
-				},
-			}))
 		})
 	})
 

--- a/fly/integration/health_test.go
+++ b/fly/integration/health_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 	. "github.com/onsi/ginkgo/v2"
@@ -22,13 +21,6 @@ var _ = Describe("fly health", func() {
 	)
 
 	BeforeEach(func() {
-		createFlyRc(rc.Targets{
-			targetName: {
-				API:      atcServer.URL(),
-				TeamName: teamName,
-				Token:    &rc.TargetToken{Type: "Bearer", Value: validAccessToken(time.Now().Add(time.Hour))},
-			},
-		})
 		atcServer.Reset()
 
 		flyCmd = exec.Command(flyPath, "-t", targetName, "health")
@@ -83,15 +75,6 @@ var _ = Describe("fly health", func() {
 		})
 
 		Context("when the token is expired or missing", func() {
-			BeforeEach(func() {
-				createFlyRc(rc.Targets{
-					targetName: {
-						API:      atcServer.URL(),
-						TeamName: teamName,
-						Token:    &rc.TargetToken{Type: "Bearer", Value: validAccessToken(time.Now().Add(-time.Hour))},
-					},
-				})
-			})
 
 			It("succeeds without requiring a valid token", func() {
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -139,18 +139,19 @@ func LoadTarget(selectedTarget TargetName, tracing bool) (Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	return buildTarget(selectedTarget, targetProps, targetProps.Token, tracing)
+	return buildTarget(selectedTarget, targetProps, true, tracing)
 }
 
+// Use for unauthenticated endpoints of targets, like (health, info, etc.).
 func LoadTargetWithoutAuth(selectedTarget TargetName, tracing bool) (Target, error) {
 	targetProps, err := selectTarget(selectedTarget)
 	if err != nil {
 		return nil, err
 	}
-	return buildTarget(selectedTarget, targetProps, nil, tracing)
+	return buildTarget(selectedTarget, targetProps, false, tracing)
 }
 
-func buildTarget(selectedTarget TargetName, targetProps TargetProps, token *TargetToken, tracing bool) (Target, error) {
+func buildTarget(selectedTarget TargetName, targetProps TargetProps, withAuth bool, tracing bool) (Target, error) {
 	var clientCertificate []tls.Certificate
 
 	caCertPool, err := loadCACertPool(targetProps.CACert)
@@ -163,14 +164,19 @@ func buildTarget(selectedTarget TargetName, targetProps TargetProps, token *Targ
 		return nil, err
 	}
 
-	httpClient := defaultHttpClient(token, targetProps.Insecure, caCertPool, clientCertificate)
+	var httpToken *TargetToken
+	if withAuth {
+		httpToken = targetProps.Token
+	}
+
+	httpClient := defaultHttpClient(httpToken, targetProps.Insecure, caCertPool, clientCertificate)
 	client := concourse.NewClient(targetProps.API, httpClient, tracing)
 
 	return NewTarget(
 		selectedTarget,
 		targetProps.TeamName,
 		targetProps.API,
-		token,
+		targetProps.Token,
 		targetProps.CACert,
 		caCertPool,
 		targetProps.ClientCertPath,

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -135,49 +135,23 @@ func LoadTargetFromURL(url, team string, tracing bool) (Target, TargetName, erro
 }
 
 func LoadTarget(selectedTarget TargetName, tracing bool) (Target, error) {
-	var clientCertificate []tls.Certificate
-
 	targetProps, err := selectTarget(selectedTarget)
 	if err != nil {
 		return nil, err
 	}
-
-	caCertPool, err := loadCACertPool(targetProps.CACert)
-	if err != nil {
-		return nil, err
-	}
-
-	clientCertificate, err = loadClientCertificate(targetProps.ClientCertPath, targetProps.ClientKeyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	httpClient := defaultHttpClient(targetProps.Token, targetProps.Insecure, caCertPool, clientCertificate)
-	client := concourse.NewClient(targetProps.API, httpClient, tracing)
-
-	return NewTarget(
-		selectedTarget,
-		targetProps.TeamName,
-		targetProps.API,
-		targetProps.Token,
-		targetProps.CACert,
-		caCertPool,
-		targetProps.ClientCertPath,
-		targetProps.ClientKeyPath,
-		clientCertificate,
-		targetProps.Insecure,
-		client,
-	), nil
+	return buildTarget(selectedTarget, targetProps, targetProps.Token, tracing)
 }
 
-// Use for unauthenticated endpoints of targets, like (health, info, etc.).
 func LoadTargetWithoutAuth(selectedTarget TargetName, tracing bool) (Target, error) {
-	var clientCertificate []tls.Certificate
-
 	targetProps, err := selectTarget(selectedTarget)
 	if err != nil {
 		return nil, err
 	}
+	return buildTarget(selectedTarget, targetProps, nil, tracing)
+}
+
+func buildTarget(selectedTarget TargetName, targetProps TargetProps, token *TargetToken, tracing bool) (Target, error) {
+	var clientCertificate []tls.Certificate
 
 	caCertPool, err := loadCACertPool(targetProps.CACert)
 	if err != nil {
@@ -189,14 +163,14 @@ func LoadTargetWithoutAuth(selectedTarget TargetName, tracing bool) (Target, err
 		return nil, err
 	}
 
-	httpClient := defaultHttpClient(nil, targetProps.Insecure, caCertPool, clientCertificate)
+	httpClient := defaultHttpClient(token, targetProps.Insecure, caCertPool, clientCertificate)
 	client := concourse.NewClient(targetProps.API, httpClient, tracing)
 
 	return NewTarget(
 		selectedTarget,
 		targetProps.TeamName,
 		targetProps.API,
-		targetProps.Token,
+		token,
 		targetProps.CACert,
 		caCertPool,
 		targetProps.ClientCertPath,


### PR DESCRIPTION
## Changes proposed by this PR

It is mostly nit stuff regarding fly health logic:
* Components that are both paused and have previously run now show paused, last ran: <timestamp> instead of only paused (the last-ran info was being silently dropped)
* Simplify target loading by extracting build logic into a separate function
* Simplified the database error display — the redundant empty-string guard was unnecessary
* Removed the `h` alias from fly health - it feels like `fly help`

Tests:
* Added an assertion to verify no `Authorization` header is sent when the token is expired, so a future regression in auth suppression won't slip through
* Added test cases for components that have never run and components that are paused before their first run

follow-up of #9640