### PR TITLE
add support for shared path in Conjur

### DIFF
--- a/atc/creds/conjur/conjur.go
+++ b/atc/creds/conjur/conjur.go
@@ -15,13 +15,15 @@ type Conjur struct {
 	log             lager.Logger
 	client          IConjurClient
 	secretTemplates []*creds.SecretTemplate
+	sharedPath      string
 }
 
-func NewConjur(log lager.Logger, client IConjurClient, secretTemplates []*creds.SecretTemplate) *Conjur {
+func NewConjur(log lager.Logger, client IConjurClient, secretTemplates []*creds.SecretTemplate, sharedPath string) *Conjur {
 	return &Conjur{
 		log:             log,
 		client:          client,
 		secretTemplates: secretTemplates,
+		sharedPath:      sharedPath,
 	}
 }
 
@@ -32,6 +34,9 @@ func (c Conjur) NewSecretLookupPaths(teamName string, pipelineName string, allow
 		if lPath := creds.NewSecretLookupWithTemplate(template, teamName, pipelineName); lPath != nil {
 			lookupPaths = append(lookupPaths, lPath)
 		}
+	}
+	if c.sharedPath != "" {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(c.sharedPath+"/"))
 	}
 
 	return lookupPaths

--- a/atc/creds/conjur/conjur_factory.go
+++ b/atc/creds/conjur/conjur_factory.go
@@ -11,16 +11,18 @@ type conjurFactory struct {
 	log             lager.Logger
 	client          *conjurapi.Client
 	secretTemplates []*creds.SecretTemplate
+	sharedPath      string
 }
 
-func NewConjurFactory(log lager.Logger, client *conjurapi.Client, secretTemplates []*creds.SecretTemplate) *conjurFactory {
+func NewConjurFactory(log lager.Logger, client *conjurapi.Client, secretTemplates []*creds.SecretTemplate, sharedPath string) *conjurFactory {
 	return &conjurFactory{
 		log:             log,
 		client:          client,
 		secretTemplates: secretTemplates,
+		sharedPath:      sharedPath,
 	}
 }
 
 func (factory *conjurFactory) NewSecrets() creds.Secrets {
-	return NewConjur(factory.log, factory.client, factory.secretTemplates)
+	return NewConjur(factory.log, factory.client, factory.secretTemplates, factory.sharedPath)
 }

--- a/atc/creds/conjur/conjur_test.go
+++ b/atc/creds/conjur/conjur_test.go
@@ -36,16 +36,19 @@ var _ = Describe("Conjur", func() {
 	var variables vars.Variables
 	var varRef vars.Reference
 	var mockService MockConjurService
+	var t1 *creds.SecretTemplate
+	var t2 *creds.SecretTemplate
 
 	JustBeforeEach(func() {
 		varRef = vars.Reference{Path: "cheery"}
-		t1, err := creds.BuildSecretTemplate("t1", DefaultPipelineSecretTemplate)
+		var err error
+		t1, err = creds.BuildSecretTemplate("t1", DefaultPipelineSecretTemplate)
 		Expect(t1).NotTo(BeNil())
 		Expect(err).To(BeNil())
-		t2, err := creds.BuildSecretTemplate("t2", DefaultTeamSecretTemplate)
+		t2, err = creds.BuildSecretTemplate("t2", DefaultTeamSecretTemplate)
 		Expect(t2).NotTo(BeNil())
 		Expect(err).To(BeNil())
-		secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{t1, t2})
+		secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{t1, t2}, "")
 		variables = creds.NewVariables(secretAccess, creds.SecretLookupParams{Team: "alpha", Pipeline: "bogus"}, false)
 		Expect(secretAccess).NotTo(BeNil())
 		mockService.stubGetParameter = func(input string) ([]byte, error) {
@@ -98,7 +101,7 @@ var _ = Describe("Conjur", func() {
 		})
 
 		It("should allow full variable path when no templates were configured", func() {
-			secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{})
+			secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{}, "")
 			variables := creds.NewVariables(secretAccess, creds.SecretLookupParams{Team: "", Pipeline: ""}, false)
 			mockService.stubGetParameter = func(input string) ([]byte, error) {
 				Expect(input).To(Equal("cheery"))
@@ -106,6 +109,21 @@ var _ = Describe("Conjur", func() {
 			}
 			value, found, err := variables.Get(varRef)
 			Expect(value).To(BeEquivalentTo("full path secret"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should get shared parameter if exists", func() {
+			secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{t1, t2}, "concourse/shared")
+			variables := creds.NewVariables(secretAccess, creds.SecretLookupParams{Team: "alpha", Pipeline: "bogus"}, false)
+			mockService.stubGetParameter = func(input string) ([]byte, error) {
+				if input != "concourse/shared/cheery" {
+					return nil, errors.New("Variable not found")
+				}
+				return []byte("shared secret"), nil
+			}
+			value, found, err := variables.Get(varRef)
+			Expect(value).To(BeEquivalentTo("shared secret"))
 			Expect(found).To(BeTrue())
 			Expect(err).To(BeNil())
 		})

--- a/atc/creds/conjur/manager.go
+++ b/atc/creds/conjur/manager.go
@@ -26,6 +26,7 @@ type Manager struct {
 	PipelineSecretTemplate string `long:"pipeline-secret-template" description:"Conjur secret identifier template used for pipeline specific parameter" default:"concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"`
 	TeamSecretTemplate     string `long:"team-secret-template" description:"Conjur secret identifier template used for team specific parameter" default:"concourse/{{.Team}}/{{.Secret}}"`
 	SecretTemplate         string `long:"secret-template" description:"Conjur secret identifier template used for full path conjur secrets" default:"vaultName/{{.Secret}}"`
+	SharedPath             string `long:"shared-path" description:"Path under which to lookup shared credentials"`
 	Conjur                 *Conjur
 }
 
@@ -59,8 +60,9 @@ func (manager *Manager) Init(log lager.Logger) error {
 	}
 
 	manager.Conjur = &Conjur{
-		log:    log,
-		client: conjur,
+		log:        log,
+		client:     conjur,
+		sharedPath: manager.SharedPath,
 	}
 
 	return nil
@@ -141,7 +143,7 @@ func (manager *Manager) NewSecretsFactory(log lager.Logger) (creds.SecretsFactor
 		return nil, err
 	}
 
-	return NewConjurFactory(log, client, []*creds.SecretTemplate{pipelineSecretTemplate, teamSecretTemplate, secretTemplate}), nil
+	return NewConjurFactory(log, client, []*creds.SecretTemplate{pipelineSecretTemplate, teamSecretTemplate, secretTemplate}, manager.SharedPath), nil
 }
 
 func (manager Manager) Close(logger lager.Logger) {


### PR DESCRIPTION
Changes proposed by this PR

As of now, it is not possible to configure shared paths for Conjur secret manager as opposed to other cred managers such as Vault,AWS. So I propose to add a new parameter --conjur-shared-path similar to the Vault cred manager. This parameter can be optional (as with Vault). This PR provides all the changes needed for this functionality.
Notes to reviewer

Release Note

Added --conjur-shared-path to configure shared secret paths for Conjur secrets manager similarly to the one for Vault, SSM.

PR is for the issue: https://github.com/concourse/concourse/issues/9062