### PR TITLE
atc: Check pinned resources whose pinned version doesn't exist in the version history

### DIFF
--- a/atc/api/resourceserver/check.go
+++ b/atc/api/resourceserver/check.go
@@ -54,9 +54,9 @@ func (s *Server) CheckResource(dbPipeline db.Pipeline) http.Handler {
 			dbResource,
 			dbResourceTypes,
 			reqBody.From,
-			true,
-			!reqBody.Shallow,
-			true,
+			true,             // manually triggered
+			!reqBody.Shallow, // skip interval recursively
+			true,             // to database
 		)
 		if err != nil {
 			logger.Error("failed-to-create-check", err)

--- a/atc/api/resourceserver/check_prototype.go
+++ b/atc/api/resourceserver/check_prototype.go
@@ -54,9 +54,9 @@ func (s *Server) CheckPrototype(dbPipeline db.Pipeline) http.Handler {
 			dbPrototype,
 			dbResourceTypes,
 			reqBody.From,
-			true,
-			!reqBody.Shallow,
-			true,
+			true,             // manually triggered
+			!reqBody.Shallow, // skip interval recursively
+			true,             // to database
 		)
 		if err != nil {
 			logger.Error("failed-to-create-check", err)

--- a/atc/api/resourceserver/check_resource_type.go
+++ b/atc/api/resourceserver/check_resource_type.go
@@ -54,9 +54,9 @@ func (s *Server) CheckResourceType(dbPipeline db.Pipeline) http.Handler {
 			dbResourceType,
 			dbResourceTypes,
 			reqBody.From,
-			true,
-			!reqBody.Shallow,
-			true,
+			true,             // manually triggered
+			!reqBody.Shallow, // skip interval recursively
+			true,             // to database
 		)
 		if err != nil {
 			logger.Error("failed-to-create-check", err)

--- a/atc/api/resourceserver/check_webhook.go
+++ b/atc/api/resourceserver/check_webhook.go
@@ -78,9 +78,9 @@ func (s *Server) CheckResourceWebHook(dbPipeline db.Pipeline) http.Handler {
 			dbResource,
 			dbResourceTypes,
 			nil,
-			true,
-			false,
-			true,
+			true,  // manually triggered
+			false, // skip interval recursively
+			true,  // to database
 		)
 		if err != nil {
 			logger.Error("failed-to-create-check", err)

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -2413,6 +2413,11 @@ var _ = Describe("Build", func() {
 								},
 							},
 							{
+								Config: &atc.GetStep{
+									Name: "some-pinned-resource",
+								},
+							},
+							{
 								Config: &atc.PutStep{
 									Name: "some-put-resource",
 								},
@@ -2467,6 +2472,13 @@ var _ = Describe("Build", func() {
 						Source: atc.Source{"some": "other-source"},
 					},
 					{
+						Name:   "some-pinned-resource",
+						Type:   dbtest.BaseResourceType,
+						Source: atc.Source{"some": "other-source"},
+					},
+					{
+						// Is un-used which verifies that put-only resources
+						// don't block build scheduling
 						Name:   "some-put-resource",
 						Type:   dbtest.BaseResourceType,
 						Source: atc.Source{"some": "put-source"},
@@ -2476,9 +2488,6 @@ var _ = Describe("Build", func() {
 
 			scenario = dbtest.Setup(
 				builder.WithPipeline(pipelineConfig),
-				builder.WithResourceVersions("some-resource", time.Minute, atc.Version{"some": "version"}),
-				builder.WithResourceVersions("some-other-resource", time.Minute, atc.Version{"some": "other-version"}),
-				builder.WithResourceVersions("some-put-resource", time.Minute),
 				builder.WithPendingJobBuild(&build, "some-job"),
 				builder.WithPendingJobBuild(&downstreamBuild, "some-job-downstream"),
 				builder.WithPendingJobBuild(&mixedBuild, "some-job-mixed"),
@@ -2490,6 +2499,7 @@ var _ = Describe("Build", func() {
 				scenario.Run(
 					builder.WithResourceVersions("some-resource", time.Minute),
 					builder.WithResourceVersions("some-other-resource", time.Minute),
+					builder.WithResourceVersions("some-pinned-resource", time.Minute),
 				)
 			})
 
@@ -2503,7 +2513,9 @@ var _ = Describe("Build", func() {
 		Context("when the triggering resources in the build have NOT been checked", func() {
 			BeforeEach(func() {
 				scenario.Run(
-					builder.WithResourceVersions("some-other-resource", time.Minute), //non-triggering resource
+					// checking non-triggering resources
+					builder.WithResourceVersions("some-other-resource", time.Minute),
+					builder.WithResourceVersions("some-pinned-resource", time.Minute),
 				)
 			})
 
@@ -2537,14 +2549,8 @@ var _ = Describe("Build", func() {
 		Context("when a pinned resource in the build has not been checked", func() {
 			BeforeEach(func() {
 				scenario.Run(
-					builder.WithResourceVersions("some-resource", time.Minute),
+					builder.WithResourceVersions("some-other-resource", time.Minute),
 				)
-
-				rcv := scenario.ResourceVersion("some-other-resource", atc.Version{"some": "other-version"})
-
-				found, err := scenario.Resource("some-other-resource").PinVersion(rcv.ID())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
 			})
 
 			It("returns true", func() {

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -199,6 +199,17 @@ func (c *checkFactory) Resources() ([]Resource, error) {
 				          WHERE rcv.resource_config_scope_id = r.resource_config_scope_id
 				        )`),
 			},
+			sq.And{
+				// find non-triggering, pinned resources whose pinned version
+				// has not yet been discovered by a check
+				sq.Eq{"ji.trigger": false},
+				sq.NotEq{"rp.version": nil},
+				sq.Expr(`NOT EXISTS (SELECT 1
+				          FROM resource_config_versions rcv
+				          WHERE rcv.resource_config_scope_id = r.resource_config_scope_id
+				          AND rcv.version @> rp.version
+				        )`),
+			},
 		}).
 		OrderBy("r.id ASC").
 		RunWith(c.conn).

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -577,6 +577,84 @@ var _ = Describe("CheckFactory", func() {
 				Expect(resourceNames).To(ConsistOf("some-resource-trigger", "some-resource"))
 			})
 		})
+
+		Context("when a non-triggering resource is pinned to a version that doesn't exist in the resources version history", func() {
+			BeforeEach(func() {
+				pipelineConfig := atc.Config{
+					Jobs: atc.JobConfigs{
+						{
+							Name: "some-job",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:    "some-resource-trigger",
+										Trigger: true,
+									},
+								},
+								{
+									Config: &atc.GetStep{
+										Name: "some-pinned-resource",
+									},
+								},
+							},
+						},
+					},
+					Resources: atc.ResourceConfigs{
+						{
+							Name: "some-resource-trigger",
+							Type: dbtest.BaseResourceType,
+							Source: atc.Source{
+								"some": "source",
+							},
+						},
+						{
+							Name: "some-pinned-resource",
+							Type: dbtest.BaseResourceType,
+							Source: atc.Source{
+								"some": "source",
+							},
+							Version: atc.Version{"ref": "pinned-version"},
+						},
+					},
+				}
+
+				scenario.Run(
+					builder.WithPipeline(pipelineConfig),
+					builder.WithResourceVersions("some-resource-trigger", time.Minute, atc.Version{"ref": "r1"}),
+					// "some-pinned-resource" has an established version history, but
+					// it does NOT include the version it's currently pinned to
+					// in the pipeline config above
+					builder.WithResourceVersions("some-pinned-resource", time.Minute,
+						atc.Version{"ref": "some-other-version"}),
+				)
+			})
+
+			It("returns the pinned resource so its pinned version can be discovered", func() {
+				resourceNames := []string{}
+				for _, r := range resources {
+					resourceNames = append(resourceNames, r.Name())
+				}
+
+				Expect(resourceNames).To(ConsistOf("some-resource-trigger", "some-pinned-resource"))
+			})
+
+			Context("once the pinned version has been discovered", func() {
+				BeforeEach(func() {
+					scenario.Run(
+						builder.WithResourceVersions("some-pinned-resource", time.Minute, atc.Version{"ref": "pinned-version"}),
+					)
+				})
+
+				It("no longer returns the resource", func() {
+					resourceNames := []string{}
+					for _, r := range resources {
+						resourceNames = append(resourceNames, r.Name())
+					}
+
+					Expect(resourceNames).To(ConsistOf("some-resource-trigger"))
+				})
+			})
+		})
 	})
 
 	Describe("ResourceTypes", func() {

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -133,13 +133,19 @@ func (s *scanner) check(ctx context.Context, checkable db.Checkable, resourceTyp
 	})
 	defer span.End()
 
-	version := checkable.CurrentPinnedVersion()
-
 	if checkable.CheckEvery() != nil && checkable.CheckEvery().Never {
 		return
 	}
 
-	_, created, err := s.checkFactory.TryCreateCheck(lagerctx.NewContext(spanCtx, logger), checkable, resourceTypes, version, false, false, false)
+	_, created, err := s.checkFactory.TryCreateCheck(
+		lagerctx.NewContext(spanCtx, logger),
+		checkable,
+		resourceTypes,
+		checkable.CurrentPinnedVersion(),
+		false, // not manually triggered
+		false, // don't skip interval
+		false, // in-memory check
+	)
 	if err != nil {
 		logger.Error("failed-to-create-check", err)
 		return

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -203,7 +203,7 @@ func (s *buildStarter) createChecks(logger lager.Logger, job db.Job, build Build
 					nil,
 					build.IsManuallyTriggered(),
 					build.IsManuallyTriggered(),
-					false, // Create in-memory checks. BuildTracker will avoid duplicate checks
+					true, // to database
 				)
 				if err != nil {
 					logger.Error("buildstarter-checking-resource", err, lager.Data{

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -1116,7 +1116,7 @@ var _ = Describe("BuildStarter", func() {
 						Expect(version).To(BeNil())
 						Expect(skipInterval).To(BeFalse())
 						Expect(skipIntervalRecurv).To(BeFalse())
-						Expect(toDb).To(BeFalse())
+						Expect(toDb).To(BeTrue())
 					})
 
 					Context("build is manually created", func() {


### PR DESCRIPTION
## Changes proposed by this PR

closes #9646

- Adds an additional SQL filter to the `Resources()` func in the check factory. The check factory will now return resources that are pinned, but their pinned version does not exist in the version history of the resource. Once the pinned version is found the resource will no longer be checked
- ~`BuildStarter` would create in-memory checks. I switched it to creating checks in the database. This ensures multiple checks aren't run across web nodes. Issue I ran into here is what prompted this change: https://github.com/concourse/git-resource/pull/479~ **I ended up reverting this after merging this PR**
- Unrelated to the issue, but I noticed some of the tests I recently added in `atc/db/build_test.go` wouldn't fail in an expected manner due to the way the test was setup. That's now also resolved in this PR.

Suggested changes were initially made by Claude and the issue reporter here: https://github.com/fbehrens51/concourse/tree/fix/pinned-resource-lidar-check

Code is mostly unchanged besides a few nit changes I made to comments and naming. I did test the new query against the db backing https://ci.concourse-ci.org/ to ensure query performance did not degrade. Before/after `EXPLAIN ANALYZE` times are:

```sql
--Before
Planning Time: 1.273 ms
Execution Time: 17.694 ms

--After
Planning Time: 1.336 ms
Execution Time: 17.180 ms
```

I ran both versions of the query multiple times and the above times represent the average results I saw.