### PR TITLE
fix tarfs absolute symlink test for Windows

### DIFF
--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -219,10 +219,15 @@ var _ = Describe("ExtractEntry", func() {
 
 	Context("symlinks", func() {
 		It("does not modify absolute paths", func() {
+			linkname := "/absolute/path/file"
+			if runtime.GOOS == "windows" {
+				linkname = `C:\absolute\path\file`
+			}
+
 			header := &tar.Header{
 				Typeflag: tar.TypeSymlink,
 				Name:     "abs",
-				Linkname: "/absolute/path/file",
+				Linkname: linkname,
 			}
 
 			err := tarfs.ExtractEntry(header, dest, strings.NewReader(""), false)
@@ -230,7 +235,7 @@ var _ = Describe("ExtractEntry", func() {
 
 			l, err := os.Readlink(filepath.Join(dest, "abs"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(l).To(Equal(filepath.FromSlash(header.Linkname)))
+			Expect(l).To(Equal(linkname))
 		})
 
 		It("returns a BreakoutErr when a symlink points outside the destination", func() {


### PR DESCRIPTION
Why was https://github.com/concourse/concourse/commit/146ab3352284e09afe823cf81e326d1316adb048 the wrong fix?

Code path for absolute path `/absolute/path/file` on Linux:

<img width="1117" height="669" alt="linux" src="https://github.com/user-attachments/assets/3c9d0ba6-ff08-4b09-b807-fd23add3dfbf" />

Code path for path `/absolute/path/file` on Windows:

<img width="1117" height="669" alt="623207706-326c2525-12c6-4b7b-8ddc-f7272118954a" src="https://github.com/user-attachments/assets/dc902ff6-3d1b-492d-a0dc-07498c4b6b97" />

We must ensure we are testing the same code path on each platform. Hence, we must test an absolute path (`/absolute/path/file`)  on Unix and an absolute path on Windows (`C:\foo`).

The fact that the test was green at the end (after `filepath.FromSlash(header.Linkname)` manipulation ) is just due to the fact that at the end, by chance, in both cases, we end up calling the same L134 in production code:
```
err = root.Symlink(filepath.FromSlash(header.Linkname), filePath)
```