### PR TITLE
Fix go-archive PATH stubbing for cross-platform tests

### DIFF
--- a/go-archive/tarfs/compress_test.go
+++ b/go-archive/tarfs/compress_test.go
@@ -122,18 +122,12 @@ var _ = Describe("Compress", func() {
 	})
 
 	Context("with tar not in the PATH", func() {
-		var oldPATH string
-
 		BeforeEach(func() {
-			oldPATH = os.Getenv("PATH")
-			Expect(os.Setenv("PATH", "/dev/null")).To(Succeed())
-
-			_, err := exec.LookPath("tar")
-			Expect(err).To(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			Expect(os.Setenv("PATH", oldPATH)).To(Succeed())
+			// Set PATH to a temporary directory to ensure that the tar executable
+			// will not be found. The directory must exist, so that the lookup fails
+			// identically on every platform. GinkgoT().Setenv will restore PATH after
+			// the spec.
+			GinkgoT().Setenv("PATH", GinkgoT().TempDir())
 		})
 
 		examples()

--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -143,18 +143,12 @@ var _ = Describe("Extract", func() {
 	})
 
 	Context("when 'tar' is not in the PATH", func() {
-		var oldPATH string
-
 		BeforeEach(func() {
-			oldPATH = os.Getenv("PATH")
-			Expect(os.Setenv("PATH", "/dev/null")).To(Succeed())
-
-			_, err := exec.LookPath("tar")
-			Expect(err).To(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			Expect(os.Setenv("PATH", oldPATH)).To(Succeed())
+			// Set PATH to a temporary directory to ensure that the tar executable
+			// will not be found. The directory must exist, so that the lookup fails
+			// identically on every platform. GinkgoT().Setenv will restore PATH after
+			// the spec.
+			GinkgoT().Setenv("PATH", GinkgoT().TempDir())
 		})
 
 		It("extracts the TGZ's files, generating directories, and honoring file permissions and symlinks", extractionTest)

--- a/go-archive/tgzfs/compress_test.go
+++ b/go-archive/tgzfs/compress_test.go
@@ -125,18 +125,12 @@ var _ = Describe("Compress", func() {
 	})
 
 	Context("with tar not in the PATH", func() {
-		var oldPATH string
-
 		BeforeEach(func() {
-			oldPATH = os.Getenv("PATH")
-			Expect(os.Setenv("PATH", "/dev/null")).To(Succeed())
-
-			_, err := exec.LookPath("tar")
-			Expect(err).To(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			Expect(os.Setenv("PATH", oldPATH)).To(Succeed())
+			// Set PATH to a temporary directory to ensure that the tar executable
+			// will not be found. The directory must exist, so that the lookup fails
+			// identically on every platform. GinkgoT().Setenv will restore PATH after
+			// the spec.
+			GinkgoT().Setenv("PATH", GinkgoT().TempDir())
 		})
 
 		examples()

--- a/go-archive/tgzfs/extract_test.go
+++ b/go-archive/tgzfs/extract_test.go
@@ -121,18 +121,12 @@ var _ = Describe("Extract", func() {
 	})
 
 	Context("when 'tar' is not in the PATH", func() {
-		var oldPATH string
-
 		BeforeEach(func() {
-			oldPATH = os.Getenv("PATH")
-			Expect(os.Setenv("PATH", "/dev/null")).To(Succeed())
-
-			_, err := exec.LookPath("tar")
-			Expect(err).To(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			Expect(os.Setenv("PATH", oldPATH)).To(Succeed())
+			// Set PATH to a temporary directory to ensure that the tar executable
+			// will not be found. The directory must exist, so that the lookup fails
+			// identically on every platform. GinkgoT().Setenv will restore PATH after
+			// the spec.
+			GinkgoT().Setenv("PATH", GinkgoT().TempDir())
 		})
 
 		It("extracts the TGZ's files, generating directories, and honoring file permissions and symlinks", extractionTest)

--- a/go-archive/zipfs/extract_test.go
+++ b/go-archive/zipfs/extract_test.go
@@ -121,18 +121,12 @@ var _ = Describe("Extract", func() {
 	})
 
 	Context("when 'unzip' is not in the PATH", func() {
-		var oldPATH string
-
 		BeforeEach(func() {
-			oldPATH = os.Getenv("PATH")
-			os.Setenv("PATH", "/dev/null")
-
-			_, err := exec.LookPath("unzip")
-			Expect(err).To(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			os.Setenv("PATH", oldPATH)
+			// Set PATH to a temporary directory to ensure that the unzip executable
+			// will not be found. The directory must exist, so that the lookup fails
+			// identically on every platform. GinkgoT().Setenv will restore PATH after
+			// the spec.
+			GinkgoT().Setenv("PATH", GinkgoT().TempDir())
 		})
 
 		It("extracts the ZIP's files, generating directories, and honoring file permissions and symlinks", extractionTest)


### PR DESCRIPTION
Fix go-archive PATH stubbing for cross-platform tests

Replace `PATH=/dev/null` with `GinkgoT().Setenv + TempDir` so missing `tar/unzip` lookups fail the same way on every platform, and `PATH` is restored automatically after each spec.