### PR TITLE
go-archives: symlink extraction attack tests

### DIFF
--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -252,3 +252,135 @@ var _ = Describe("ExtractEntry", func() {
 		})
 	})
 })
+
+var _ = Describe("Extract will not create paths outside the specified directory", func() {
+	var (
+		extractionDest string
+		outside        string
+
+		archive archivetest.Archive
+	)
+
+	BeforeEach(func() {
+		var err error
+
+		extractionDest, err = os.MkdirTemp("", "extract-dest")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Stands in for a location outside the extraction root, e.g.
+		// the user's home directory on Unix or C:\Users\... on Windows. Because
+		// it comes from the OS temp dir it is always an absolute, platform-native
+		// path, so these specs exercise the attack on Unix and Windows alike.
+		outside, err = os.MkdirTemp("", "extract-outside")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set PATH to a temporary directory to ensure that the tar executable
+		// will not be found. The directory must exist, so that the lookup fails
+		// identically on every platform. GinkgoT().Setenv will restore PATH after
+		// the spec.
+		GinkgoT().Setenv("PATH", GinkgoT().TempDir())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(extractionDest)
+		os.RemoveAll(outside)
+	})
+
+	Context("when a directory symlink escapes via an absolute path", func() {
+		BeforeEach(func() {
+			archive = archivetest.Archive{
+				{Name: "escape", Link: filepath.ToSlash(outside)},
+				{Name: "escape/evil.txt", Body: "pwned"},
+			}
+		})
+
+		It("refuses to create the file outside the destination", func() {
+			src, err := archive.TarStream()
+			Expect(err).NotTo(HaveOccurred())
+
+			extractionErr := tarfs.Extract(src, extractionDest)
+			Expect(extractionErr).To(HaveOccurred())
+
+			escapedFile := filepath.Join(outside, "evil.txt")
+			_, statErr := os.Stat(escapedFile)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"extraction escaped and wrote %q outside the destination", escapedFile)
+		})
+	})
+
+	Context("when a directory symlink escapes via a relative .. path", func() {
+		BeforeEach(func() {
+			escapeLink, err := filepath.Rel(extractionDest, outside)
+			Expect(err).NotTo(HaveOccurred())
+
+			archive = archivetest.Archive{
+				{Name: "escape", Link: filepath.ToSlash(escapeLink)},
+				{Name: "escape/evil.txt", Body: "pwned"},
+			}
+		})
+
+		It("refuses to create the file outside the destination", func() {
+			src, err := archive.TarStream()
+			Expect(err).NotTo(HaveOccurred())
+
+			extractionErr := tarfs.Extract(src, extractionDest)
+			Expect(extractionErr).To(HaveOccurred())
+
+			escapedFile := filepath.Join(outside, "evil.txt")
+			_, statErr := os.Stat(escapedFile)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"extraction escaped and wrote %q outside the destination", escapedFile)
+		})
+	})
+
+	Context("when a file symlink escapes via an absolute path", func() {
+		BeforeEach(func() {
+			target := filepath.Join(outside, "evil.txt")
+
+			archive = archivetest.Archive{
+				{Name: "escape", Link: filepath.ToSlash(target)},
+				{Name: "escape", Body: "pwned"},
+			}
+		})
+
+		It("refuses to write the file outside the destination", func() {
+			src, err := archive.TarStream()
+			Expect(err).NotTo(HaveOccurred())
+
+			extractionErr := tarfs.Extract(src, extractionDest)
+			Expect(extractionErr).To(HaveOccurred())
+
+			target := filepath.Join(outside, "evil.txt")
+			_, statErr := os.Stat(target)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"extraction escaped and wrote %q outside the destination", target)
+		})
+	})
+
+	Context("when a file symlink escapes via a relative .. path", func() {
+		BeforeEach(func() {
+			target := filepath.Join(outside, "evil.txt")
+
+			escapeLink, err := filepath.Rel(extractionDest, target)
+			Expect(err).NotTo(HaveOccurred())
+
+			archive = archivetest.Archive{
+				{Name: "escape", Link: filepath.ToSlash(escapeLink)},
+				{Name: "escape", Body: "pwned"},
+			}
+		})
+
+		It("refuses to write the file outside the destination", func() {
+			src, err := archive.TarStream()
+			Expect(err).NotTo(HaveOccurred())
+
+			extractionErr := tarfs.Extract(src, extractionDest)
+			Expect(extractionErr).To(HaveOccurred())
+
+			target := filepath.Join(outside, "evil.txt")
+			_, statErr := os.Stat(target)
+			Expect(os.IsNotExist(statErr)).To(BeTrue(),
+				"extraction escaped and wrote %q outside the destination", target)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Add regression tests that exercise classic symlink-based tar extraction attacks against `tarfs.Extract`.

These cover the attack shapes that matter in practice:

- directory symlink → write a file through it (absolute and `../` relative targets)
- file symlink → overwrite the same path with file contents (absolute and `../` relative targets)

In each case, extraction must fail, and nothing may appear outside the destination directory.

## Why

[`os.Root`](https://pkg.go.dev/os#Root) is what makes this safe after [#9601](https://github.com/concourse/concourse/pull/9601). That change intentionally relaxed the overly strict breakout checks from [#9486](https://github.com/concourse/concourse/pull/9486) so legitimate intra-repo relative symlinks (especially on Windows) work again, while still blocking writes that would escape the extraction root.

Without tests like these, it is easy to “simplify” extraction later and accidentally undo that protection — for example, by reverting [#9601](https://github.com/concourse/concourse/pull/9601) or dropping `os.Root` without understanding why it is there.

These specs are also concrete evidence that the security issue addressed in [#9486](https://github.com/concourse/concourse/pull/9486) remains fixed under the `#9601` approach: escaping symlinks may be created in some cases, but following them to write outside the destination is refused.
