### PR TITLE
Fail put step when saving output fails

### DIFF
--- a/atc/engine/put_delegate.go
+++ b/atc/engine/put_delegate.go
@@ -84,7 +84,7 @@ func (d *putDelegate) Finished(logger lager.Logger, exitStatus exec.ExitStatus, 
 	logger.Info("finished", lager.Data{"exit-status": exitStatus, "version-info": info})
 }
 
-func (d *putDelegate) SaveOutput(log lager.Logger, plan atc.PutPlan, source atc.Source, imageResourceCache db.ResourceCache, info resource.VersionResult) {
+func (d *putDelegate) SaveOutput(log lager.Logger, plan atc.PutPlan, source atc.Source, imageResourceCache db.ResourceCache, info resource.VersionResult) error {
 	logger := log.WithData(lager.Data{
 		"step":          plan.Name,
 		"resource":      plan.Resource,
@@ -103,6 +103,7 @@ func (d *putDelegate) SaveOutput(log lager.Logger, plan atc.PutPlan, source atc.
 	)
 	if err != nil {
 		logger.Error("failed-to-save-output", err)
-		return
 	}
+
+	return err
 }

--- a/atc/engine/put_delegate_test.go
+++ b/atc/engine/put_delegate_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -33,6 +34,7 @@ var _ = Describe("PutDelegate", func() {
 		delegate   exec.PutDelegate
 		info       resource.VersionResult
 		exitStatus exec.ExitStatus
+		saveErr    error
 	)
 
 	BeforeEach(func() {
@@ -78,7 +80,7 @@ var _ = Describe("PutDelegate", func() {
 		var source atc.Source
 		var resourceCache *dbfakes.FakeResourceCache
 
-		JustBeforeEach(func() {
+		BeforeEach(func() {
 			plan = atc.PutPlan{
 				Name:     "some-name",
 				Type:     "some-type",
@@ -87,11 +89,15 @@ var _ = Describe("PutDelegate", func() {
 			source = atc.Source{"some": "source"}
 			resourceCache = new(dbfakes.FakeResourceCache)
 			resourceCache.IDReturns(123)
+		})
 
-			delegate.SaveOutput(logger, plan, source, resourceCache, info)
+		JustBeforeEach(func() {
+			saveErr = delegate.SaveOutput(logger, plan, source, resourceCache, info)
 		})
 
 		It("saves the build output", func() {
+			Expect(saveErr).ToNot(HaveOccurred())
+
 			Expect(fakeBuild.SaveOutputCallCount()).To(Equal(1))
 			resourceType, rc, sourceArg, version, metadata, name, resource := fakeBuild.SaveOutputArgsForCall(0)
 			Expect(resourceType).To(Equal(plan.Type))
@@ -101,6 +107,18 @@ var _ = Describe("PutDelegate", func() {
 			Expect(metadata).To(Equal(db.NewResourceConfigMetadataFields(info.Metadata)))
 			Expect(name).To(Equal(plan.Name))
 			Expect(resource).To(Equal(plan.Resource))
+		})
+
+		Context("when saving the build output fails", func() {
+			disaster := errors.New("nope")
+
+			BeforeEach(func() {
+				fakeBuild.SaveOutputReturns(disaster)
+			})
+
+			It("returns the error", func() {
+				Expect(saveErr).To(MatchError(disaster))
+			})
 		})
 	})
 })

--- a/atc/exec/execfakes/fake_put_delegate.go
+++ b/atc/exec/execfakes/fake_put_delegate.go
@@ -75,7 +75,7 @@ type FakePutDelegate struct {
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
 	}
-	SaveOutputStub        func(lager.Logger, atc.PutPlan, atc.Source, db.ResourceCache, resource.VersionResult)
+	SaveOutputStub        func(lager.Logger, atc.PutPlan, atc.Source, db.ResourceCache, resource.VersionResult) error
 	saveOutputMutex       sync.RWMutex
 	saveOutputArgsForCall []struct {
 		arg1 lager.Logger
@@ -83,6 +83,12 @@ type FakePutDelegate struct {
 		arg3 atc.Source
 		arg4 db.ResourceCache
 		arg5 resource.VersionResult
+	}
+	saveOutputReturns struct {
+		result1 error
+	}
+	saveOutputReturnsOnCall map[int]struct {
+		result1 error
 	}
 	SelectedWorkerStub        func(lager.Logger, string)
 	selectedWorkerMutex       sync.RWMutex
@@ -437,8 +443,9 @@ func (fake *FakePutDelegate) InitializingArgsForCall(i int) lager.Logger {
 	return argsForCall.arg1
 }
 
-func (fake *FakePutDelegate) SaveOutput(arg1 lager.Logger, arg2 atc.PutPlan, arg3 atc.Source, arg4 db.ResourceCache, arg5 resource.VersionResult) {
+func (fake *FakePutDelegate) SaveOutput(arg1 lager.Logger, arg2 atc.PutPlan, arg3 atc.Source, arg4 db.ResourceCache, arg5 resource.VersionResult) error {
 	fake.saveOutputMutex.Lock()
+	ret, specificReturn := fake.saveOutputReturnsOnCall[len(fake.saveOutputArgsForCall)]
 	fake.saveOutputArgsForCall = append(fake.saveOutputArgsForCall, struct {
 		arg1 lager.Logger
 		arg2 atc.PutPlan
@@ -447,11 +454,16 @@ func (fake *FakePutDelegate) SaveOutput(arg1 lager.Logger, arg2 atc.PutPlan, arg
 		arg5 resource.VersionResult
 	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.SaveOutputStub
+	fakeReturns := fake.saveOutputReturns
 	fake.recordInvocation("SaveOutput", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.saveOutputMutex.Unlock()
 	if stub != nil {
-		fake.SaveOutputStub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
 }
 
 func (fake *FakePutDelegate) SaveOutputCallCount() int {
@@ -460,7 +472,7 @@ func (fake *FakePutDelegate) SaveOutputCallCount() int {
 	return len(fake.saveOutputArgsForCall)
 }
 
-func (fake *FakePutDelegate) SaveOutputCalls(stub func(lager.Logger, atc.PutPlan, atc.Source, db.ResourceCache, resource.VersionResult)) {
+func (fake *FakePutDelegate) SaveOutputCalls(stub func(lager.Logger, atc.PutPlan, atc.Source, db.ResourceCache, resource.VersionResult) error) {
 	fake.saveOutputMutex.Lock()
 	defer fake.saveOutputMutex.Unlock()
 	fake.SaveOutputStub = stub
@@ -471,6 +483,29 @@ func (fake *FakePutDelegate) SaveOutputArgsForCall(i int) (lager.Logger, atc.Put
 	defer fake.saveOutputMutex.RUnlock()
 	argsForCall := fake.saveOutputArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *FakePutDelegate) SaveOutputReturns(result1 error) {
+	fake.saveOutputMutex.Lock()
+	defer fake.saveOutputMutex.Unlock()
+	fake.SaveOutputStub = nil
+	fake.saveOutputReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePutDelegate) SaveOutputReturnsOnCall(i int, result1 error) {
+	fake.saveOutputMutex.Lock()
+	defer fake.saveOutputMutex.Unlock()
+	fake.SaveOutputStub = nil
+	if fake.saveOutputReturnsOnCall == nil {
+		fake.saveOutputReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.saveOutputReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakePutDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -44,7 +44,7 @@ type PutDelegate interface {
 	WaitingForStreamedVolume(lager.Logger, string, string)
 	BuildStartTime() time.Time
 
-	SaveOutput(lager.Logger, atc.PutPlan, atc.Source, db.ResourceCache, resource.VersionResult)
+	SaveOutput(lager.Logger, atc.PutPlan, atc.Source, db.ResourceCache, resource.VersionResult) error
 }
 
 // PutStep produces a resource version using preconfigured params and any data
@@ -238,7 +238,9 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 	// step.plan.Resource maps to an actual resource that may have been used outside of a pipeline context.
 	// Hence, if it was used outside the pipeline context, we don't want to save the output.
 	if step.plan.Resource != "" {
-		delegate.SaveOutput(logger, step.plan, source, imageResourceCache, versionResult)
+		if err := delegate.SaveOutput(logger, step.plan, source, imageResourceCache, versionResult); err != nil {
+			return false, err
+		}
 	}
 
 	state.StoreResult(step.planID, versionResult.Version)

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -636,6 +636,29 @@ var _ = Describe("PutStep", func() {
 		})
 	})
 
+	Context("when saving the build output fails", func() {
+		disaster := errors.New("failed to save output")
+
+		BeforeEach(func() {
+			fakeDelegate.SaveOutputReturns(disaster)
+		})
+
+		It("returns the error", func() {
+			Expect(stepErr).To(MatchError(disaster))
+		})
+
+		It("is not successful", func() {
+			Expect(stepOk).To(BeFalse())
+		})
+
+		It("does not finish the step or store its result", func() {
+			Expect(fakeDelegate.FinishedCallCount()).To(Equal(0))
+
+			var result atc.Version
+			Expect(state.Result(planID, &result)).To(BeFalse())
+		})
+	})
+
 	Context("when running the script exits unsuccessfully", func() {
 		BeforeEach(func() {
 			chosenContainer.ProcessDefs[0].Stub.ExitStatus = 42


### PR DESCRIPTION
Fail a put-step when saving output does not succeed.

- propagate SaveOutput errors so that put steps do not succeed when their resource version cannot be persisted.

To confirm that this was fixed, I just created the pipeline as explained in the issue section: steps to reproduce. 

Here are the logs from my tests.

1. run from master branch:

```
selected worker: b2b6554cdd58
Uploading to S3 from dir=out ...
Running: aws s3 cp /tmp/build/put/out "s3://concourse/s3-resource-simple/test/" 
upload: dir1/dir2/witness-2-2026-07-23_13:33:39 to s3://concourse/s3-resource-simple/test/dir1/dir2/witness-2-2026-07-23_13:33:39
upload: ./witness-0-2026-07-23_13:33:39 to s3://concourse/s3-resource-simple/test/witness-0-2026-07-23_13:33:39
upload: dir1/witness-1-2026-07-23_13:33:39 to s3://concourse/s3-resource-simple/test/dir1/witness-1-2026-07-23_13:33:39
upload: ./hello.txt to s3://concourse/s3-resource-simple/test/hello.txt
...done.
succeeded

$ docker compose -f docker-compose.yml -f hack/overrides/minio.yml logs web \
  | rg 'failed-to-save-output|put-step.finished|finish.succeeded'

web-1  | {"timestamp":"2026-07-23T13:33:52.943765545Z","level":"error","source":"atc","message":"atc.tracker.notify.run.put-step.failed-to-save-output","data":{"build":"5","build_id":5,"error":"resource output version is empty. Version must contain at least one key-value pair","job":"upload-artifact","job-id":1,"pipeline":"s3simple-minio","resource":"bucket.s3simple","resource-type":"s3-resource-simple","session":"27.7.2.19","step":"bucket.s3simple","step-name":"bucket.s3simple","team":"main","version":{}}}
web-1  | {"timestamp":"2026-07-23T13:33:52.944451919Z","level":"info","source":"atc","message":"atc.tracker.notify.run.put-step.finished","data":{"build":"5","build_id":5,"exit-status":0,"job":"upload-artifact","job-id":1,"pipeline":"s3simple-minio","session":"27.7.2.19","step-name":"bucket.s3simple","team":"main","version-info":{"version":{}}}}
web-1  | {"timestamp":"2026-07-23T13:33:52.952853046Z","level":"info","source":"atc","message":"atc.tracker.notify.run.finish.succeeded","data":{"build":"5","build_id":5,"job":"upload-artifact","pipeline":"s3simple-minio","session":"27.7.2.35","team":"main"}}
```
shows that in ATC logs that the put step errored and failed to save the version to the database, while the user is informed that the put-step succeeded.


2 .run from PR branch:

```
selected worker: f550a79daec7
Uploading to S3 from dir=out ...
Running: aws s3 cp /tmp/build/put/out "s3://concourse/s3-resource-simple/test/" 
upload: dir1/dir2/witness-2-2026-07-23_13:28:39 to s3://concourse/s3-resource-simple/test/dir1/dir2/witness-2-2026-07-23_13:28:39
upload: ./witness-0-2026-07-23_13:28:39 to s3://concourse/s3-resource-simple/test/witness-0-2026-07-23_13:28:39
upload: dir1/witness-1-2026-07-23_13:28:39 to s3://concourse/s3-resource-simple/test/dir1/witness-1-2026-07-23_13:28:39
upload: ./hello.txt to s3://concourse/s3-resource-simple/test/hello.txt
...done.
resource output version is empty. Version must contain at least one key-value pair
errored

$ docker compose -f docker-compose.yml -f hack/overrides/minio.yml logs web \
  | rg 'failed-to-save-output|put-step.finished|finish.succeeded'
  
web-1  | {"timestamp":"2026-07-23T13:28:51.539431225Z","level":"error","source":"atc","message":"atc.tracker.notify.run.put-step.failed-to-save-output","data":{"build":"4","build_id":4,"error":"resource output version is empty. Version must contain at least one key-value pair","job":"upload-artifact","job-id":1,"pipeline":"s3simple-minio","resource":"bucket.s3simple","resource-type":"s3-resource-simple","session":"27.26.2.22","step":"bucket.s3simple","step-name":"bucket.s3simple","team":"main","version":{}}}
```

and we can see that both ATC logs and user have the same information; put step did not succeed.

The main problem described in: https://github.com/concourse/concourse/issues/9632 has been resolved by this PR. The put step will not silently succeed.

In the follow-up PR, we can improve the confusing error messages from the JSON decoder.

> Note that there is a 2nd variation of the same issue, where the put step fails, but the error message is confusing (error: invalid character '}' looking for beginning of value) and not very useful or understandable by everyone. It can occur if the resource emits a version like: {"version": }