### PR TITLE
normalize symlink path since root.Symlink doesn't

### DIFF
--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -128,7 +128,10 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 			}
 		}
 
-		err = root.Symlink(header.Linkname, filePath)
+		// TODO: the filepath.FromSlash() is a workaround until the same fix
+		// lands in Go 1.27. It can be removed once we're on Go 1.27
+		// https://github.com/golang/go/issues/80073
+		err = root.Symlink(filepath.FromSlash(header.Linkname), filePath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixing this error in the release branch:

```
  [FAILED] Expected
      <string>: /absolute/path/file
  to equal
      <string>: \\absolute\\path\\file
  In [It] at: C:/work/containers/00003tjklu7/tmp/build/e6ae5024/concourse/go-archive/tarfs/extract_test.go:233
```

Commit is cherry picked from master where the test is passing. This was the only diff between the branches.