### PR TITLE
worker: add --numeric-owner to tar commands when streaming volumes

### DIFF
--- a/go-archive/tarfs/shell_out.go
+++ b/go-archive/tarfs/shell_out.go
@@ -1,4 +1,4 @@
-//+build !windows
+//go:build !windows
 
 package tarfs
 
@@ -19,7 +19,7 @@ func tarExtract(tarPath string, src io.Reader, dest string) error {
 		return err
 	}
 
-	tarCmd := exec.Command(tarPath, "-pxf", "-")
+	tarCmd := exec.Command(tarPath, "--numeric-owner", "-pxf", "-")
 	tarCmd.Dir = dest
 	tarCmd.Stdin = src
 
@@ -39,7 +39,7 @@ func tarExtract(tarPath string, src io.Reader, dest string) error {
 func tarCompress(tarPath string, dest io.Writer, workDir string, paths ...string) error {
 	out := new(bytes.Buffer)
 
-	args := []string{"-cf", "-", "--null", "-T", "-"}
+	args := []string{"-cf", "-", "--numeric-owner", "--null", "-T", "-"}
 	if runtime.GOOS == "darwin" {
 		args = append([]string{"--no-mac-metadata"}, args...)
 	}

--- a/go-archive/tgzfs/shell_out.go
+++ b/go-archive/tgzfs/shell_out.go
@@ -1,4 +1,4 @@
-//+build !windows
+//go:build !windows
 
 package tgzfs
 
@@ -19,7 +19,7 @@ func tarExtract(tarPath string, src io.Reader, dest string) error {
 		return err
 	}
 
-	tarCmd := exec.Command(tarPath, "-pzxf", "-")
+	tarCmd := exec.Command(tarPath, "--numeric-owner", "-pzxf", "-")
 	tarCmd.Dir = dest
 	tarCmd.Stdin = src
 
@@ -39,7 +39,7 @@ func tarExtract(tarPath string, src io.Reader, dest string) error {
 func tarCompress(tarPath string, dest io.Writer, workDir string, paths ...string) error {
 	out := new(bytes.Buffer)
 
-	args := []string{"-czf", "-", "--null", "-T", "-"}
+	args := []string{"-czf", "-", "--numeric-owner", "--null", "-T", "-"}
 	if runtime.GOOS == "darwin" {
 		args = append([]string{"--no-mac-metadata"}, args...)
 	}

--- a/worker/baggageclaim/api/volume_server_linux_test.go
+++ b/worker/baggageclaim/api/volume_server_linux_test.go
@@ -186,5 +186,51 @@ var _ = Describe("Volume Server", func() {
 				})
 			})
 		})
+
+		Context("when tar entries carry symbolic owner names", func() {
+			BeforeEach(func() {
+				isPrivileged = true
+				tgzBuffer = new(bytes.Buffer)
+				gzWriter := gzip.NewWriter(tgzBuffer)
+				tarWriter := tar.NewWriter(gzWriter)
+
+				// Without --numeric-owner, tar resolves "root" to UID 0 on
+				// extract. With the flag, the numeric 1234 is preserved as-is.
+				err := tarWriter.WriteHeader(&tar.Header{
+					Name:  "some-file",
+					Mode:  0600,
+					Size:  int64(len("file-content")),
+					Uid:   1234,
+					Gid:   1234,
+					Uname: "root",
+					Gname: "root",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				_, err = tarWriter.Write([]byte("file-content"))
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(tarWriter.Close()).To(Succeed())
+				Expect(gzWriter.Close()).To(Succeed())
+			})
+
+			It("preserves numeric ownership rather than resolving names", func() {
+				request, err := http.NewRequest("PUT", fmt.Sprintf("/volumes/%s/stream-in?path=%s", myVolume.Handle, "dest-path"), tgzBuffer)
+				Expect(err).NotTo(HaveOccurred())
+				request.Header.Set("Content-Encoding", "gzip")
+				recorder := httptest.NewRecorder()
+				handler.ServeHTTP(recorder, request)
+				Expect(recorder.Code).To(Equal(204))
+
+				tarInfoPath := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "dest-path", "some-file")
+				Expect(tarInfoPath).To(BeAnExistingFile())
+
+				stat, err := os.Stat(tarInfoPath)
+				Expect(err).ToNot(HaveOccurred())
+
+				sysStat := stat.Sys().(*syscall.Stat_t)
+				Expect(sysStat.Uid).To(Equal(uint32(1234)))
+				Expect(sysStat.Gid).To(Equal(uint32(1234)))
+			})
+		})
 	})
 })

--- a/worker/baggageclaim/volume/repository_test.go
+++ b/worker/baggageclaim/volume/repository_test.go
@@ -1292,15 +1292,16 @@ var _ = Describe("Repository", func() {
 					BeforeEach(func() {
 						serverResponseCode = http.StatusNoContent
 					})
-					It("should fail", func() {
+					It("should not fail", func() {
 						Expect(streamErr).ToNot(HaveOccurred())
 					})
-					It("should http request", func() {
+					It("should receive the http request", func() {
 						Expect(serverCalled).To(BeTrue())
 					})
 					It("remote should receive bytes", func() {
 						b := new(bytes.Buffer)
-						tgzfs.Compress(b, filepath.Dir(tempFile.Name()), filepath.Base(tempFile.Name()))
+						err := tgzfs.Compress(b, filepath.Dir(tempFile.Name()), filepath.Base(tempFile.Name()))
+						Expect(err).ToNot(HaveOccurred())
 						Expect(len(serverReadBytes)).To(Equal(len(b.Bytes())))
 						n := len(serverReadBytes)
 						Expect(serverReadBytes[:n]).To(Equal(b.Bytes()[:n]))

--- a/worker/baggageclaim/volume/stream_in_out_linux.go
+++ b/worker/baggageclaim/volume/stream_in_out_linux.go
@@ -235,7 +235,7 @@ func tarCmd(namespacer uidgid.Namespacer, privileged bool, dir string, args ...s
 		return nil, nil, err
 	}
 
-	tarCommand := exec.Command("tar", append([]string{"-C", "/dev/fd/3"}, args...)...)
+	tarCommand := exec.Command("tar", append([]string{"-C", "/dev/fd/3", "--numeric-owner"}, args...)...)
 	tarCommand.ExtraFiles = []*os.File{dirFd}
 
 	if !privileged {


### PR DESCRIPTION
## Changes proposed by this PR

closes #9662

File ownership on streamed volumes is now preserved numerically rather than re-resolved by name on the destination, which is the default tar behaviour. This caused issues if workers had different UID->User mappings, which is NOT a common setup for workers. After streaming, we'd re-map to the UID mapping inside the container and that's when ownership would break.

I don't think this will break anything for existing Concourse clusters that don't already have this issue. You'd only have this issue if the UID mapping on your workers were different, which is typically NOT the case when people setup a Concourse cluster. Workers are typically homogeneous, avoiding this issue entirely.