### PR TITLE
worker-pinning: Add a flag to the job to allow all tasks to run on one worker

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -25,6 +25,7 @@ func (planner Planner) Create(
 	inputs []db.BuildInput,
 	manuallyTriggered bool,
 	tags atc.Tags,
+	pinWorker bool,
 ) (atc.Plan, error) {
 	visitor := &planVisitor{
 		planFactory: planner.planFactory,
@@ -42,6 +43,8 @@ func (planner Planner) Create(
 	if err != nil {
 		return atc.Plan{}, err
 	}
+
+	visitor.plan.PinWorker = pinWorker
 
 	return visitor.plan, nil
 }

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -23,6 +23,40 @@ func TestPlanner(t *testing.T) {
 	})
 }
 
+func TestPlannerPinWorker(t *testing.T) {
+	factory := builds.NewPlanner(atc.NewPlanFactory(0))
+
+	plan, err := factory.Create(
+		&atc.DoStep{Steps: []atc.Step{{Config: &atc.TaskStep{Name: "some-task"}}}},
+		resources,
+		defaultResourceTypes,
+		atc.Prototypes{},
+		nil,
+		false,
+		nil,
+		true,
+	)
+	require.NoError(t, err)
+	require.True(t, plan.PinWorker, "PinWorker should be set to true on the root plan")
+}
+
+func TestPlannerPinWorkerFalse(t *testing.T) {
+	factory := builds.NewPlanner(atc.NewPlanFactory(0))
+
+	plan, err := factory.Create(
+		&atc.DoStep{Steps: []atc.Step{{Config: &atc.TaskStep{Name: "some-task"}}}},
+		resources,
+		defaultResourceTypes,
+		atc.Prototypes{},
+		nil,
+		false,
+		nil,
+		false,
+	)
+	require.NoError(t, err)
+	require.False(t, plan.PinWorker, "PinWorker should be false on the root plan")
+}
+
 type PlannerTest struct {
 	Title string
 
@@ -2115,7 +2149,7 @@ func (test PlannerTest) Run(s *PlannerSuite) {
 	if test.OverwriteResourceTypes != nil {
 		resourceTypes = test.OverwriteResourceTypes
 	}
-	actualPlan, actualErr := factory.Create(test.Config, resources, resourceTypes, prototypes, test.Inputs, test.ManuallyTriggered, test.Tags)
+	actualPlan, actualErr := factory.Create(test.Config, resources, resourceTypes, prototypes, test.Inputs, test.ManuallyTriggered, test.Tags, false)
 
 	if test.Err != nil {
 		s.Equal(test.Err, actualErr)

--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -17,11 +17,11 @@ const supportedSchema = "exec.v2"
 
 //counterfeiter:generate . CoreStepFactory
 type CoreStepFactory interface {
-	GetStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, DelegateFactory) exec.Step
-	PutStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, DelegateFactory) exec.Step
-	TaskStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, DelegateFactory) exec.Step
+	GetStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, DelegateFactory) exec.Step
+	PutStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, DelegateFactory) exec.Step
+	TaskStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, DelegateFactory) exec.Step
 	RunStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, DelegateFactory) exec.Step
-	CheckStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, DelegateFactory) exec.Step
+	CheckStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, DelegateFactory) exec.Step
 	SetPipelineStep(atc.Plan, exec.StepMetadata, DelegateFactory) exec.Step
 	LoadVarStep(atc.Plan, exec.StepMetadata, DelegateFactory) exec.Step
 	ArtifactInputStep(atc.Plan, db.Build) exec.Step
@@ -64,10 +64,16 @@ type planBuilder struct {
 	factory     *stepperFactory
 	build       db.Build
 	buildStatus string
+	pinWorker   bool
 }
 
 func (pb *planBuilder) withBuildStatus(state string) *planBuilder {
-	return &planBuilder{factory: pb.factory, build: pb.build, buildStatus: state}
+	return &planBuilder{
+		factory:     pb.factory,
+		build:       pb.build,
+		buildStatus: state,
+		pinWorker:   pb.pinWorker,
+	}
 }
 
 func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, error) {
@@ -75,7 +81,11 @@ func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, er
 		return nil, errors.New("schema not supported")
 	}
 
-	pb := &planBuilder{factory: factory, build: build}
+	pb := &planBuilder{
+		factory:   factory,
+		build:     build,
+		pinWorker: build.PrivatePlan().PinWorker,
+	}
 	return func(plan atc.Plan) exec.Step {
 		return pb.buildStep(plan)
 	}, nil
@@ -295,6 +305,7 @@ func (pb *planBuilder) buildGetStep(plan atc.Plan) exec.Step {
 		plan,
 		stepMetadata,
 		containerMetadata,
+		pb.pinWorker,
 		pb.buildDelegateFactory(plan),
 	)
 }
@@ -313,6 +324,7 @@ func (pb *planBuilder) buildPutStep(plan atc.Plan) exec.Step {
 		plan,
 		stepMetadata,
 		containerMetadata,
+		pb.pinWorker,
 		pb.buildDelegateFactory(plan),
 	)
 }
@@ -330,6 +342,7 @@ func (pb *planBuilder) buildCheckStep(plan atc.Plan) exec.Step {
 		plan,
 		stepMetadata,
 		containerMetadata,
+		pb.pinWorker,
 		pb.buildDelegateFactory(plan),
 	)
 }
@@ -365,6 +378,7 @@ func (pb *planBuilder) buildTaskStep(plan atc.Plan) exec.Step {
 		plan,
 		stepMetadata,
 		containerMetadata,
+		pb.pinWorker,
 		pb.buildDelegateFactory(plan),
 	)
 }

--- a/atc/engine/builder_test.go
+++ b/atc/engine/builder_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Builder", func() {
 
 					Context("constructing outputs", func() {
 						It("constructs the put correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.PutStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.PutStepArgsForCall(0)
 							Expect(plan).To(Equal(putPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -189,7 +189,7 @@ var _ = Describe("Builder", func() {
 								BuildName:            "42",
 							}))
 
-							plan, stepMetadata, containerMetadata, _ = fakeCoreStepFactory.PutStepArgsForCall(1)
+							plan, stepMetadata, containerMetadata, _, _ = fakeCoreStepFactory.PutStepArgsForCall(1)
 							Expect(plan).To(Equal(otherPutPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -252,7 +252,7 @@ var _ = Describe("Builder", func() {
 
 					Context("constructing outputs", func() {
 						It("constructs the put correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.PutStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.PutStepArgsForCall(0)
 							Expect(plan).To(Equal(putPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -267,7 +267,7 @@ var _ = Describe("Builder", func() {
 								BuildName:            "42",
 							}))
 
-							plan, stepMetadata, containerMetadata, _ = fakeCoreStepFactory.PutStepArgsForCall(1)
+							plan, stepMetadata, containerMetadata, _, _ = fakeCoreStepFactory.PutStepArgsForCall(1)
 							Expect(plan).To(Equal(otherPutPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -344,7 +344,7 @@ var _ = Describe("Builder", func() {
 					})
 
 					It("constructs the first get correctly", func() {
-						plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
+						plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
 						expectedPlan := getPlan
 						expectedPlan.Attempts = []int{1}
 						Expect(plan).To(Equal(expectedPlan))
@@ -364,7 +364,7 @@ var _ = Describe("Builder", func() {
 					})
 
 					It("constructs the second get correctly", func() {
-						plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(1)
+						plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.GetStepArgsForCall(1)
 						expectedPlan := getPlan
 						expectedPlan.Attempts = []int{3}
 						Expect(plan).To(Equal(expectedPlan))
@@ -388,7 +388,7 @@ var _ = Describe("Builder", func() {
 					})
 
 					It("constructs nested steps correctly", func() {
-						plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
+						plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
 						expectedPlan := taskPlan
 						expectedPlan.Attempts = []int{2, 1}
 						Expect(plan).To(Equal(expectedPlan))
@@ -406,7 +406,7 @@ var _ = Describe("Builder", func() {
 							Attempt:              "2.1",
 						}))
 
-						plan, stepMetadata, containerMetadata, _ = fakeCoreStepFactory.TaskStepArgsForCall(1)
+						plan, stepMetadata, containerMetadata, _, _ = fakeCoreStepFactory.TaskStepArgsForCall(1)
 						expectedPlan = taskPlan
 						expectedPlan.Attempts = []int{2, 2}
 						Expect(plan).To(Equal(expectedPlan))
@@ -477,15 +477,15 @@ var _ = Describe("Builder", func() {
 					It("constructs nested steps correctly", func() {
 						Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(6))
 
-						_, _, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
+						_, _, containerMetadata, _, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
-						_, _, containerMetadata, _ = fakeCoreStepFactory.TaskStepArgsForCall(1)
+						_, _, containerMetadata, _, _ = fakeCoreStepFactory.TaskStepArgsForCall(1)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
-						_, _, containerMetadata, _ = fakeCoreStepFactory.TaskStepArgsForCall(2)
+						_, _, containerMetadata, _, _ = fakeCoreStepFactory.TaskStepArgsForCall(2)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
-						_, _, containerMetadata, _ = fakeCoreStepFactory.TaskStepArgsForCall(3)
+						_, _, containerMetadata, _, _ = fakeCoreStepFactory.TaskStepArgsForCall(3)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
-						_, _, containerMetadata, _ = fakeCoreStepFactory.TaskStepArgsForCall(4)
+						_, _, containerMetadata, _, _ = fakeCoreStepFactory.TaskStepArgsForCall(4)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
 					})
 				})
@@ -506,7 +506,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs inputs correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(expectedPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -534,7 +534,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs tasks correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
 							Expect(plan).To(Equal(expectedPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -607,7 +607,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs the step correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.CheckStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.CheckStepArgsForCall(0)
 							Expect(plan).To(Equal(expectedPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -658,7 +658,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs the put correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.PutStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.PutStepArgsForCall(0)
 							Expect(plan).To(Equal(putPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -675,7 +675,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs the dependent get correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(dependentGetPlan))
 							expectedMetadataWithoutCreatedBy.BuildStatus = db.BuildStatusSucceeded.String()
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
@@ -742,7 +742,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the step correctly", func() {
 							Expect(fakeCoreStepFactory.GetStepCallCount()).To(Equal(1))
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(inputPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -760,7 +760,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the completion hook correctly", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(2)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.TaskStepArgsForCall(2)
 							Expect(plan).To(Equal(completionTaskPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -778,7 +778,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the failure hook correctly", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
 							Expect(plan).To(Equal(failureTaskPlan))
 							expectedMetadataWithoutCreatedBy.BuildStatus = db.BuildStatusFailed.String()
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
@@ -797,7 +797,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the success hook correctly", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(1)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.TaskStepArgsForCall(1)
 							Expect(plan).To(Equal(successTaskPlan))
 							expectedMetadataWithoutCreatedBy.BuildStatus = db.BuildStatusSucceeded.String()
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
@@ -816,7 +816,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the next step correctly", func() {
 							Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(4))
-							plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.TaskStepArgsForCall(3)
+							plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.TaskStepArgsForCall(3)
 							Expect(plan).To(Equal(nextTaskPlan))
 							expectedMetadataWithoutCreatedBy.BuildStatus = db.BuildStatusSucceeded.String()
 							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
@@ -850,7 +850,7 @@ var _ = Describe("Builder", func() {
 
 					It("constructs the step correctly", func() {
 						Expect(fakeCoreStepFactory.GetStepCallCount()).To(Equal(1))
-						plan, stepMetadata, containerMetadata, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
+						plan, stepMetadata, containerMetadata, _, _ := fakeCoreStepFactory.GetStepArgsForCall(0)
 						Expect(plan).To(Equal(inputPlan))
 						Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
 						Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -868,5 +868,78 @@ var _ = Describe("Builder", func() {
 				})
 			})
 		})
+	})
+
+	Describe("pin_worker", func() {
+		var (
+			fakeCoreStepFactory *enginefakes.FakeCoreStepFactory
+			fakeRateLimiter     *enginefakes.FakeRateLimiter
+			fakePolicyChecker   *policyfakes.FakeChecker
+			fakeWorkerFactory   *dbfakes.FakeWorkerFactory
+			fakeLockFactory     *lockfakes.FakeLockFactory
+			fakeBuild           *dbfakes.FakeBuild
+
+			planFactory    atc.PlanFactory
+			stepperFactory engine.StepperFactory
+		)
+
+		BeforeEach(func() {
+			fakeCoreStepFactory = new(enginefakes.FakeCoreStepFactory)
+			fakeRateLimiter = new(enginefakes.FakeRateLimiter)
+			fakePolicyChecker = new(policyfakes.FakeChecker)
+			fakeWorkerFactory = new(dbfakes.FakeWorkerFactory)
+			fakeLockFactory = new(lockfakes.FakeLockFactory)
+			fakeBuild = new(dbfakes.FakeBuild)
+
+			planFactory = atc.NewPlanFactory(0)
+
+			stepperFactory = engine.NewStepperFactory(
+				fakeCoreStepFactory,
+				"http://example.com",
+				fakeRateLimiter,
+				fakePolicyChecker,
+				fakeWorkerFactory,
+				fakeLockFactory,
+			)
+
+			fakeBuild.SchemaReturns("exec.v2")
+		})
+
+		Context("when the build's plan has PinWorker set to true", func() {
+			It("passes pinWorker=true to the task step factory", func() {
+				fakeBuild.PrivatePlanReturns(atc.Plan{
+					ID:        "1",
+					PinWorker: true,
+					Task:      &atc.TaskPlan{Name: "some-task"},
+				})
+
+				stepper, err := stepperFactory.StepperForBuild(fakeBuild)
+				Expect(err).ToNot(HaveOccurred())
+				stepper(fakeBuild.PrivatePlan())
+
+				Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(1))
+				_, _, _, pinWorker, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
+				Expect(pinWorker).To(BeTrue())
+			})
+		})
+
+		Context("when the build's plan has PinWorker set to false", func() {
+			It("passes pinWorker=false to the task step factory", func() {
+				fakeBuild.PrivatePlanReturns(atc.Plan{
+					ID:   "1",
+					Task: &atc.TaskPlan{Name: "some-task"},
+				})
+
+				stepper, err := stepperFactory.StepperForBuild(fakeBuild)
+				Expect(err).ToNot(HaveOccurred())
+				stepper(fakeBuild.PrivatePlan())
+
+				Expect(fakeCoreStepFactory.TaskStepCallCount()).To(Equal(1))
+				_, _, _, pinWorker, _ := fakeCoreStepFactory.TaskStepArgsForCall(0)
+				Expect(pinWorker).To(BeFalse())
+			})
+		})
+
+		_ = planFactory // silence unused warning if no other test uses it
 	})
 })

--- a/atc/engine/enginefakes/fake_core_step_factory.go
+++ b/atc/engine/enginefakes/fake_core_step_factory.go
@@ -35,13 +35,14 @@ type FakeCoreStepFactory struct {
 	artifactOutputStepReturnsOnCall map[int]struct {
 		result1 exec.Step
 	}
-	CheckStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step
+	CheckStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) exec.Step
 	checkStepMutex       sync.RWMutex
 	checkStepArgsForCall []struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
-		arg4 engine.DelegateFactory
+		arg4 bool
+		arg5 engine.DelegateFactory
 	}
 	checkStepReturns struct {
 		result1 exec.Step
@@ -49,13 +50,14 @@ type FakeCoreStepFactory struct {
 	checkStepReturnsOnCall map[int]struct {
 		result1 exec.Step
 	}
-	GetStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step
+	GetStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) exec.Step
 	getStepMutex       sync.RWMutex
 	getStepArgsForCall []struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
-		arg4 engine.DelegateFactory
+		arg4 bool
+		arg5 engine.DelegateFactory
 	}
 	getStepReturns struct {
 		result1 exec.Step
@@ -76,13 +78,14 @@ type FakeCoreStepFactory struct {
 	loadVarStepReturnsOnCall map[int]struct {
 		result1 exec.Step
 	}
-	PutStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step
+	PutStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) exec.Step
 	putStepMutex       sync.RWMutex
 	putStepArgsForCall []struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
-		arg4 engine.DelegateFactory
+		arg4 bool
+		arg5 engine.DelegateFactory
 	}
 	putStepReturns struct {
 		result1 exec.Step
@@ -117,13 +120,14 @@ type FakeCoreStepFactory struct {
 	setPipelineStepReturnsOnCall map[int]struct {
 		result1 exec.Step
 	}
-	TaskStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step
+	TaskStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) exec.Step
 	taskStepMutex       sync.RWMutex
 	taskStepArgsForCall []struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
-		arg4 engine.DelegateFactory
+		arg4 bool
+		arg5 engine.DelegateFactory
 	}
 	taskStepReturns struct {
 		result1 exec.Step
@@ -259,21 +263,22 @@ func (fake *FakeCoreStepFactory) ArtifactOutputStepReturnsOnCall(i int, result1 
 	}{result1}
 }
 
-func (fake *FakeCoreStepFactory) CheckStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 engine.DelegateFactory) exec.Step {
+func (fake *FakeCoreStepFactory) CheckStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 bool, arg5 engine.DelegateFactory) exec.Step {
 	fake.checkStepMutex.Lock()
 	ret, specificReturn := fake.checkStepReturnsOnCall[len(fake.checkStepArgsForCall)]
 	fake.checkStepArgsForCall = append(fake.checkStepArgsForCall, struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
-		arg4 engine.DelegateFactory
-	}{arg1, arg2, arg3, arg4})
+		arg4 bool
+		arg5 engine.DelegateFactory
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.CheckStepStub
 	fakeReturns := fake.checkStepReturns
-	fake.recordInvocation("CheckStep", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("CheckStep", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.checkStepMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -287,17 +292,17 @@ func (fake *FakeCoreStepFactory) CheckStepCallCount() int {
 	return len(fake.checkStepArgsForCall)
 }
 
-func (fake *FakeCoreStepFactory) CheckStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step) {
+func (fake *FakeCoreStepFactory) CheckStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) exec.Step) {
 	fake.checkStepMutex.Lock()
 	defer fake.checkStepMutex.Unlock()
 	fake.CheckStepStub = stub
 }
 
-func (fake *FakeCoreStepFactory) CheckStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) {
+func (fake *FakeCoreStepFactory) CheckStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) {
 	fake.checkStepMutex.RLock()
 	defer fake.checkStepMutex.RUnlock()
 	argsForCall := fake.checkStepArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeCoreStepFactory) CheckStepReturns(result1 exec.Step) {
@@ -323,21 +328,22 @@ func (fake *FakeCoreStepFactory) CheckStepReturnsOnCall(i int, result1 exec.Step
 	}{result1}
 }
 
-func (fake *FakeCoreStepFactory) GetStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 engine.DelegateFactory) exec.Step {
+func (fake *FakeCoreStepFactory) GetStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 bool, arg5 engine.DelegateFactory) exec.Step {
 	fake.getStepMutex.Lock()
 	ret, specificReturn := fake.getStepReturnsOnCall[len(fake.getStepArgsForCall)]
 	fake.getStepArgsForCall = append(fake.getStepArgsForCall, struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
-		arg4 engine.DelegateFactory
-	}{arg1, arg2, arg3, arg4})
+		arg4 bool
+		arg5 engine.DelegateFactory
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.GetStepStub
 	fakeReturns := fake.getStepReturns
-	fake.recordInvocation("GetStep", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("GetStep", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.getStepMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -351,17 +357,17 @@ func (fake *FakeCoreStepFactory) GetStepCallCount() int {
 	return len(fake.getStepArgsForCall)
 }
 
-func (fake *FakeCoreStepFactory) GetStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step) {
+func (fake *FakeCoreStepFactory) GetStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) exec.Step) {
 	fake.getStepMutex.Lock()
 	defer fake.getStepMutex.Unlock()
 	fake.GetStepStub = stub
 }
 
-func (fake *FakeCoreStepFactory) GetStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) {
+func (fake *FakeCoreStepFactory) GetStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) {
 	fake.getStepMutex.RLock()
 	defer fake.getStepMutex.RUnlock()
 	argsForCall := fake.getStepArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeCoreStepFactory) GetStepReturns(result1 exec.Step) {
@@ -450,21 +456,22 @@ func (fake *FakeCoreStepFactory) LoadVarStepReturnsOnCall(i int, result1 exec.St
 	}{result1}
 }
 
-func (fake *FakeCoreStepFactory) PutStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 engine.DelegateFactory) exec.Step {
+func (fake *FakeCoreStepFactory) PutStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 bool, arg5 engine.DelegateFactory) exec.Step {
 	fake.putStepMutex.Lock()
 	ret, specificReturn := fake.putStepReturnsOnCall[len(fake.putStepArgsForCall)]
 	fake.putStepArgsForCall = append(fake.putStepArgsForCall, struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
-		arg4 engine.DelegateFactory
-	}{arg1, arg2, arg3, arg4})
+		arg4 bool
+		arg5 engine.DelegateFactory
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.PutStepStub
 	fakeReturns := fake.putStepReturns
-	fake.recordInvocation("PutStep", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("PutStep", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.putStepMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -478,17 +485,17 @@ func (fake *FakeCoreStepFactory) PutStepCallCount() int {
 	return len(fake.putStepArgsForCall)
 }
 
-func (fake *FakeCoreStepFactory) PutStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step) {
+func (fake *FakeCoreStepFactory) PutStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) exec.Step) {
 	fake.putStepMutex.Lock()
 	defer fake.putStepMutex.Unlock()
 	fake.PutStepStub = stub
 }
 
-func (fake *FakeCoreStepFactory) PutStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) {
+func (fake *FakeCoreStepFactory) PutStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) {
 	fake.putStepMutex.RLock()
 	defer fake.putStepMutex.RUnlock()
 	argsForCall := fake.putStepArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeCoreStepFactory) PutStepReturns(result1 exec.Step) {
@@ -641,21 +648,22 @@ func (fake *FakeCoreStepFactory) SetPipelineStepReturnsOnCall(i int, result1 exe
 	}{result1}
 }
 
-func (fake *FakeCoreStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 engine.DelegateFactory) exec.Step {
+func (fake *FakeCoreStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 bool, arg5 engine.DelegateFactory) exec.Step {
 	fake.taskStepMutex.Lock()
 	ret, specificReturn := fake.taskStepReturnsOnCall[len(fake.taskStepArgsForCall)]
 	fake.taskStepArgsForCall = append(fake.taskStepArgsForCall, struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
-		arg4 engine.DelegateFactory
-	}{arg1, arg2, arg3, arg4})
+		arg4 bool
+		arg5 engine.DelegateFactory
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.TaskStepStub
 	fakeReturns := fake.taskStepReturns
-	fake.recordInvocation("TaskStep", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("TaskStep", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.taskStepMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -669,17 +677,17 @@ func (fake *FakeCoreStepFactory) TaskStepCallCount() int {
 	return len(fake.taskStepArgsForCall)
 }
 
-func (fake *FakeCoreStepFactory) TaskStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step) {
+func (fake *FakeCoreStepFactory) TaskStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) exec.Step) {
 	fake.taskStepMutex.Lock()
 	defer fake.taskStepMutex.Unlock()
 	fake.TaskStepStub = stub
 }
 
-func (fake *FakeCoreStepFactory) TaskStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) {
+func (fake *FakeCoreStepFactory) TaskStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, bool, engine.DelegateFactory) {
 	fake.taskStepMutex.RLock()
 	defer fake.taskStepMutex.RUnlock()
 	argsForCall := fake.taskStepArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeCoreStepFactory) TaskStepReturns(result1 exec.Step) {

--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -75,6 +75,7 @@ func (factory *coreStepFactory) GetStep(
 	plan atc.Plan,
 	stepMetadata exec.StepMetadata,
 	containerMetadata db.ContainerMetadata,
+	pinWorker bool,
 	delegateFactory DelegateFactory,
 ) exec.Step {
 	containerMetadata.WorkingDirectory = resource.ResourcesDir("get")
@@ -87,6 +88,7 @@ func (factory *coreStepFactory) GetStep(
 		factory.lockFactory,
 		factory.resourceCacheFactory,
 		factory.noInputStrategy,
+		pinWorker,
 		delegateFactory,
 		factory.pool,
 		factory.defaultGetTimeout,
@@ -103,6 +105,7 @@ func (factory *coreStepFactory) PutStep(
 	plan atc.Plan,
 	stepMetadata exec.StepMetadata,
 	containerMetadata db.ContainerMetadata,
+	pinWorker bool,
 	delegateFactory DelegateFactory,
 ) exec.Step {
 	containerMetadata.WorkingDirectory = resource.ResourcesDir("put")
@@ -113,6 +116,7 @@ func (factory *coreStepFactory) PutStep(
 		stepMetadata,
 		containerMetadata,
 		factory.strategy,
+		pinWorker,
 		factory.pool,
 		delegateFactory,
 		factory.defaultPutTimeout,
@@ -129,6 +133,7 @@ func (factory *coreStepFactory) CheckStep(
 	plan atc.Plan,
 	stepMetadata exec.StepMetadata,
 	containerMetadata db.ContainerMetadata,
+	pinWorker bool,
 	delegateFactory DelegateFactory,
 ) exec.Step {
 	containerMetadata.WorkingDirectory = resource.ResourcesDir("check")
@@ -141,6 +146,7 @@ func (factory *coreStepFactory) CheckStep(
 		containerMetadata,
 		factory.noInputStrategy,
 		factory.checkStrategy,
+		pinWorker,
 		factory.pool,
 		delegateFactory,
 		factory.defaultCheckTimeout,
@@ -178,6 +184,7 @@ func (factory *coreStepFactory) TaskStep(
 	plan atc.Plan,
 	stepMetadata exec.StepMetadata,
 	containerMetadata db.ContainerMetadata,
+	pinWorker bool,
 	delegateFactory DelegateFactory,
 ) exec.Step {
 	sum := sha256.Sum256([]byte(plan.Task.Name))
@@ -190,6 +197,7 @@ func (factory *coreStepFactory) TaskStep(
 		stepMetadata,
 		containerMetadata,
 		factory.strategy,
+		pinWorker,
 		factory.pool,
 		factory.streamer,
 		delegateFactory,

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -27,6 +27,7 @@ type CheckStep struct {
 	resourceConfigFactory db.ResourceConfigFactory
 	noInputStrategy       worker.PlacementStrategy
 	checkStrategy         worker.PlacementStrategy
+	pinWorker             bool
 	delegateFactory       CheckDelegateFactory
 	workerPool            Pool
 	defaultCheckTimeout   time.Duration
@@ -58,6 +59,7 @@ func NewCheckStep(
 	containerMetadata db.ContainerMetadata,
 	noInputStrategy worker.PlacementStrategy,
 	checkStrategy worker.PlacementStrategy,
+	pinWorker bool,
 	pool Pool,
 	delegateFactory CheckDelegateFactory,
 	defaultCheckTimeout time.Duration,
@@ -71,6 +73,7 @@ func NewCheckStep(
 		workerPool:            pool,
 		noInputStrategy:       noInputStrategy,
 		checkStrategy:         checkStrategy,
+		pinWorker:             pinWorker,
 		delegateFactory:       delegateFactory,
 		defaultCheckTimeout:   defaultCheckTimeout,
 	}
@@ -195,7 +198,7 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 			ctx = lagerctx.NewContext(ctx, logger)
 		}
 
-		versions, processResult, runErr := step.runCheck(ctx, logger, delegate, imageSpec, resourceConfig, source, fromVersion)
+		versions, processResult, runErr := step.runCheck(ctx, logger, state, delegate, imageSpec, resourceConfig, source, fromVersion)
 		if runErr != nil || processResult.ExitStatus != 0 {
 			metric.Metrics.ChecksFinishedWithError.Inc()
 
@@ -250,6 +253,7 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 func (step *CheckStep) runCheck(
 	ctx context.Context,
 	logger lager.Logger,
+	state RunState,
 	delegate CheckDelegate,
 	imageSpec runtime.ImageSpec,
 	resourceConfig db.ResourceConfig,
@@ -289,7 +293,7 @@ func (step *CheckStep) runCheck(
 	if step.plan.IsResourceCheck() {
 		strategy = step.checkStrategy
 	}
-	worker, err := step.workerPool.FindOrSelectWorker(ctx, containerOwner, containerSpec, workerSpec, strategy, delegate)
+	worker, err := step.selectWorker(ctx, state, delegate, containerOwner, containerSpec, workerSpec, strategy)
 	if err != nil {
 		return nil, runtime.ProcessResult{}, err
 	}
@@ -341,5 +345,31 @@ func (step *CheckStep) containerOwner(delegate CheckDelegate, resourceConfig db.
 		resourceConfig.ID(),
 		resourceConfig.OriginBaseResourceType().ID,
 		expires,
+	)
+}
+
+// selectWorker picks a worker for the check step, honoring the build's pinned
+// worker (if the job has pin_worker: true). The first step to need a
+// worker sets the pinned worker; subsequent steps are forced to use the
+// same one. See selectStepWorker for the race-handling details.
+func (step *CheckStep) selectWorker(
+	ctx context.Context,
+	state RunState,
+	delegate worker.PoolCallback,
+	containerOwner db.ContainerOwner,
+	containerSpec runtime.ContainerSpec,
+	workerSpec worker.Spec,
+	strategy worker.PlacementStrategy,
+) (runtime.Worker, error) {
+	return selectStepWorker(
+		ctx,
+		step.workerPool,
+		strategy,
+		step.pinWorker,
+		state,
+		delegate,
+		containerOwner,
+		containerSpec,
+		workerSpec,
 	)
 }

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -175,6 +175,7 @@ var _ = Describe("CheckStep", func() {
 			containerMetadata,
 			noInputStrategy,
 			checkStrategy,
+			false,
 			fakePool,
 			fakeDelegateFactory,
 			defaultTimeout,

--- a/atc/exec/execfakes/fake_pool.go
+++ b/atc/exec/execfakes/fake_pool.go
@@ -32,6 +32,25 @@ type FakePool struct {
 		result1 runtime.Worker
 		result2 error
 	}
+	FindOrSelectWorkerOnPinnedStub        func(context.Context, db.ContainerOwner, runtime.ContainerSpec, worker.Spec, string, worker.PlacementStrategy, worker.PoolCallback) (runtime.Worker, error)
+	findOrSelectWorkerOnPinnedMutex       sync.RWMutex
+	findOrSelectWorkerOnPinnedArgsForCall []struct {
+		arg1 context.Context
+		arg2 db.ContainerOwner
+		arg3 runtime.ContainerSpec
+		arg4 worker.Spec
+		arg5 string
+		arg6 worker.PlacementStrategy
+		arg7 worker.PoolCallback
+	}
+	findOrSelectWorkerOnPinnedReturns struct {
+		result1 runtime.Worker
+		result2 error
+	}
+	findOrSelectWorkerOnPinnedReturnsOnCall map[int]struct {
+		result1 runtime.Worker
+		result2 error
+	}
 	FindResourceCacheVolumeStub        func(context.Context, int, db.ResourceCache, worker.Spec, time.Time) (runtime.Volume, bool, error)
 	findResourceCacheVolumeMutex       sync.RWMutex
 	findResourceCacheVolumeArgsForCall []struct {
@@ -165,6 +184,76 @@ func (fake *FakePool) FindOrSelectWorkerReturnsOnCall(i int, result1 runtime.Wor
 		})
 	}
 	fake.findOrSelectWorkerReturnsOnCall[i] = struct {
+		result1 runtime.Worker
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePool) FindOrSelectWorkerOnPinned(arg1 context.Context, arg2 db.ContainerOwner, arg3 runtime.ContainerSpec, arg4 worker.Spec, arg5 string, arg6 worker.PlacementStrategy, arg7 worker.PoolCallback) (runtime.Worker, error) {
+	fake.findOrSelectWorkerOnPinnedMutex.Lock()
+	ret, specificReturn := fake.findOrSelectWorkerOnPinnedReturnsOnCall[len(fake.findOrSelectWorkerOnPinnedArgsForCall)]
+	fake.findOrSelectWorkerOnPinnedArgsForCall = append(fake.findOrSelectWorkerOnPinnedArgsForCall, struct {
+		arg1 context.Context
+		arg2 db.ContainerOwner
+		arg3 runtime.ContainerSpec
+		arg4 worker.Spec
+		arg5 string
+		arg6 worker.PlacementStrategy
+		arg7 worker.PoolCallback
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	stub := fake.FindOrSelectWorkerOnPinnedStub
+	fakeReturns := fake.findOrSelectWorkerOnPinnedReturns
+	fake.recordInvocation("FindOrSelectWorkerOnPinned", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.findOrSelectWorkerOnPinnedMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePool) FindOrSelectWorkerOnPinnedCallCount() int {
+	fake.findOrSelectWorkerOnPinnedMutex.RLock()
+	defer fake.findOrSelectWorkerOnPinnedMutex.RUnlock()
+	return len(fake.findOrSelectWorkerOnPinnedArgsForCall)
+}
+
+func (fake *FakePool) FindOrSelectWorkerOnPinnedCalls(stub func(context.Context, db.ContainerOwner, runtime.ContainerSpec, worker.Spec, string, worker.PlacementStrategy, worker.PoolCallback) (runtime.Worker, error)) {
+	fake.findOrSelectWorkerOnPinnedMutex.Lock()
+	defer fake.findOrSelectWorkerOnPinnedMutex.Unlock()
+	fake.FindOrSelectWorkerOnPinnedStub = stub
+}
+
+func (fake *FakePool) FindOrSelectWorkerOnPinnedArgsForCall(i int) (context.Context, db.ContainerOwner, runtime.ContainerSpec, worker.Spec, string, worker.PlacementStrategy, worker.PoolCallback) {
+	fake.findOrSelectWorkerOnPinnedMutex.RLock()
+	defer fake.findOrSelectWorkerOnPinnedMutex.RUnlock()
+	argsForCall := fake.findOrSelectWorkerOnPinnedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+}
+
+func (fake *FakePool) FindOrSelectWorkerOnPinnedReturns(result1 runtime.Worker, result2 error) {
+	fake.findOrSelectWorkerOnPinnedMutex.Lock()
+	defer fake.findOrSelectWorkerOnPinnedMutex.Unlock()
+	fake.FindOrSelectWorkerOnPinnedStub = nil
+	fake.findOrSelectWorkerOnPinnedReturns = struct {
+		result1 runtime.Worker
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePool) FindOrSelectWorkerOnPinnedReturnsOnCall(i int, result1 runtime.Worker, result2 error) {
+	fake.findOrSelectWorkerOnPinnedMutex.Lock()
+	defer fake.findOrSelectWorkerOnPinnedMutex.Unlock()
+	fake.FindOrSelectWorkerOnPinnedStub = nil
+	if fake.findOrSelectWorkerOnPinnedReturnsOnCall == nil {
+		fake.findOrSelectWorkerOnPinnedReturnsOnCall = make(map[int]struct {
+			result1 runtime.Worker
+			result2 error
+		})
+	}
+	fake.findOrSelectWorkerOnPinnedReturnsOnCall[i] = struct {
 		result1 runtime.Worker
 		result2 error
 	}{result1, result2}

--- a/atc/exec/execfakes/fake_run_state.go
+++ b/atc/exec/execfakes/fake_run_state.go
@@ -81,6 +81,16 @@ type FakeRunState struct {
 	parentReturnsOnCall map[int]struct {
 		result1 exec.RunState
 	}
+	PinnedWorkerStub        func() string
+	pinnedWorkerMutex       sync.RWMutex
+	pinnedWorkerArgsForCall []struct {
+	}
+	pinnedWorkerReturns struct {
+		result1 string
+	}
+	pinnedWorkerReturnsOnCall map[int]struct {
+		result1 string
+	}
 	ResultStub        func(atc.PlanID, any) bool
 	resultMutex       sync.RWMutex
 	resultArgsForCall []struct {
@@ -106,6 +116,17 @@ type FakeRunState struct {
 	runReturnsOnCall map[int]struct {
 		result1 bool
 		result2 error
+	}
+	SetPinnedWorkerStub        func(string) string
+	setPinnedWorkerMutex       sync.RWMutex
+	setPinnedWorkerArgsForCall []struct {
+		arg1 string
+	}
+	setPinnedWorkerReturns struct {
+		result1 string
+	}
+	setPinnedWorkerReturnsOnCall map[int]struct {
+		result1 string
 	}
 	StoreResultStub        func(atc.PlanID, any)
 	storeResultMutex       sync.RWMutex
@@ -465,6 +486,59 @@ func (fake *FakeRunState) ParentReturnsOnCall(i int, result1 exec.RunState) {
 	}{result1}
 }
 
+func (fake *FakeRunState) PinnedWorker() string {
+	fake.pinnedWorkerMutex.Lock()
+	ret, specificReturn := fake.pinnedWorkerReturnsOnCall[len(fake.pinnedWorkerArgsForCall)]
+	fake.pinnedWorkerArgsForCall = append(fake.pinnedWorkerArgsForCall, struct {
+	}{})
+	stub := fake.PinnedWorkerStub
+	fakeReturns := fake.pinnedWorkerReturns
+	fake.recordInvocation("PinnedWorker", []interface{}{})
+	fake.pinnedWorkerMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRunState) PinnedWorkerCallCount() int {
+	fake.pinnedWorkerMutex.RLock()
+	defer fake.pinnedWorkerMutex.RUnlock()
+	return len(fake.pinnedWorkerArgsForCall)
+}
+
+func (fake *FakeRunState) PinnedWorkerCalls(stub func() string) {
+	fake.pinnedWorkerMutex.Lock()
+	defer fake.pinnedWorkerMutex.Unlock()
+	fake.PinnedWorkerStub = stub
+}
+
+func (fake *FakeRunState) PinnedWorkerReturns(result1 string) {
+	fake.pinnedWorkerMutex.Lock()
+	defer fake.pinnedWorkerMutex.Unlock()
+	fake.PinnedWorkerStub = nil
+	fake.pinnedWorkerReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeRunState) PinnedWorkerReturnsOnCall(i int, result1 string) {
+	fake.pinnedWorkerMutex.Lock()
+	defer fake.pinnedWorkerMutex.Unlock()
+	fake.PinnedWorkerStub = nil
+	if fake.pinnedWorkerReturnsOnCall == nil {
+		fake.pinnedWorkerReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.pinnedWorkerReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeRunState) Result(arg1 atc.PlanID, arg2 any) bool {
 	fake.resultMutex.Lock()
 	ret, specificReturn := fake.resultReturnsOnCall[len(fake.resultArgsForCall)]
@@ -590,6 +664,67 @@ func (fake *FakeRunState) RunReturnsOnCall(i int, result1 bool, result2 error) {
 		result1 bool
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeRunState) SetPinnedWorker(arg1 string) string {
+	fake.setPinnedWorkerMutex.Lock()
+	ret, specificReturn := fake.setPinnedWorkerReturnsOnCall[len(fake.setPinnedWorkerArgsForCall)]
+	fake.setPinnedWorkerArgsForCall = append(fake.setPinnedWorkerArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.SetPinnedWorkerStub
+	fakeReturns := fake.setPinnedWorkerReturns
+	fake.recordInvocation("SetPinnedWorker", []interface{}{arg1})
+	fake.setPinnedWorkerMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRunState) SetPinnedWorkerCallCount() int {
+	fake.setPinnedWorkerMutex.RLock()
+	defer fake.setPinnedWorkerMutex.RUnlock()
+	return len(fake.setPinnedWorkerArgsForCall)
+}
+
+func (fake *FakeRunState) SetPinnedWorkerCalls(stub func(string) string) {
+	fake.setPinnedWorkerMutex.Lock()
+	defer fake.setPinnedWorkerMutex.Unlock()
+	fake.SetPinnedWorkerStub = stub
+}
+
+func (fake *FakeRunState) SetPinnedWorkerArgsForCall(i int) string {
+	fake.setPinnedWorkerMutex.RLock()
+	defer fake.setPinnedWorkerMutex.RUnlock()
+	argsForCall := fake.setPinnedWorkerArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRunState) SetPinnedWorkerReturns(result1 string) {
+	fake.setPinnedWorkerMutex.Lock()
+	defer fake.setPinnedWorkerMutex.Unlock()
+	fake.SetPinnedWorkerStub = nil
+	fake.setPinnedWorkerReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeRunState) SetPinnedWorkerReturnsOnCall(i int, result1 string) {
+	fake.setPinnedWorkerMutex.Lock()
+	defer fake.setPinnedWorkerMutex.Unlock()
+	fake.SetPinnedWorkerStub = nil
+	if fake.setPinnedWorkerReturnsOnCall == nil {
+		fake.setPinnedWorkerReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.setPinnedWorkerReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
 }
 
 func (fake *FakeRunState) StoreResult(arg1 atc.PlanID, arg2 any) {

--- a/atc/exec/export_test.go
+++ b/atc/exec/export_test.go
@@ -1,0 +1,35 @@
+package exec
+
+import (
+	"context"
+
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/runtime"
+	"github.com/concourse/concourse/atc/worker"
+)
+
+// SelectStepWorkerForTest exposes the unexported selectStepWorker for
+// tests in the exec_test package.
+func SelectStepWorkerForTest(
+	ctx context.Context,
+	pool Pool,
+	strategy worker.PlacementStrategy,
+	pinWorker bool,
+	state RunState,
+	callback worker.PoolCallback,
+	owner db.ContainerOwner,
+	containerSpec runtime.ContainerSpec,
+	spec worker.Spec,
+) (runtime.Worker, error) {
+	return selectStepWorker(
+		ctx,
+		pool,
+		strategy,
+		pinWorker,
+		state,
+		callback,
+		owner,
+		containerSpec,
+		spec,
+	)
+}

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -90,6 +90,7 @@ type GetStep struct {
 	containerMetadata    db.ContainerMetadata
 	resourceCacheFactory db.ResourceCacheFactory
 	strategy             worker.PlacementStrategy
+	pinWorker            bool
 	workerPool           Pool
 	lockFactory          lock.LockFactory
 	delegateFactory      GetDelegateFactory
@@ -104,6 +105,7 @@ func NewGetStep(
 	lockFactory lock.LockFactory,
 	resourceCacheFactory db.ResourceCacheFactory,
 	strategy worker.PlacementStrategy,
+	pinWorker bool,
 	delegateFactory GetDelegateFactory,
 	pool Pool,
 	defaultGetTimeout time.Duration,
@@ -115,6 +117,7 @@ func NewGetStep(
 		containerMetadata:    containerMetadata,
 		resourceCacheFactory: resourceCacheFactory,
 		strategy:             strategy,
+		pinWorker:            pinWorker,
 		lockFactory:          lockFactory,
 		delegateFactory:      delegateFactory,
 		workerPool:           pool,
@@ -216,6 +219,7 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 	volume, fromCache, versionResult, processResult, err := step.retrieveFromCacheOrPerformGet(
 		ctx,
 		logger,
+		state,
 		delegate,
 		resourceCache,
 		resource.Resource{
@@ -270,6 +274,7 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 func (step *GetStep) retrieveFromCacheOrPerformGet(
 	ctx context.Context,
 	logger lager.Logger,
+	state RunState,
 	delegate GetDelegate,
 	resourceCache db.ResourceCache,
 	getResource resource.Resource,
@@ -295,7 +300,7 @@ func (step *GetStep) retrieveFromCacheOrPerformGet(
 			return nil, false, resource.VersionResult{}, runtime.ProcessResult{}, err
 		}
 
-		worker, err = step.workerPool.FindOrSelectWorker(ctx, containerOwner, containerSpec, workerSpec, step.strategy, delegate)
+		worker, err = step.selectWorker(ctx, state, delegate, containerOwner, containerSpec, workerSpec)
 		if err != nil {
 			logger.Error("failed-to-select-worker", err)
 			return nil, false, resource.VersionResult{}, runtime.ProcessResult{}, err
@@ -359,7 +364,7 @@ func (step *GetStep) retrieveFromCacheOrPerformGet(
 
 		defer lock.Release()
 
-		volume, versionResult, processResult, err := step.performGetAndInitCache(ctx, logger, delegate, getResource, resourceCache, workerSpec, containerSpec, containerOwner, worker)
+		volume, versionResult, processResult, err := step.performGetAndInitCache(ctx, logger, state, delegate, getResource, resourceCache, workerSpec, containerSpec, containerOwner, worker)
 		if err != nil {
 			return nil, false, resource.VersionResult{}, runtime.ProcessResult{}, false, err
 		}
@@ -441,6 +446,7 @@ func (step *GetStep) retrieveFromCache(
 func (step *GetStep) performGetAndInitCache(
 	ctx context.Context,
 	logger lager.Logger,
+	state RunState,
 	delegate GetDelegate,
 	getResource resource.Resource,
 	resourceCache db.ResourceCache,
@@ -463,7 +469,7 @@ func (step *GetStep) performGetAndInitCache(
 			return nil, resource.VersionResult{}, runtime.ProcessResult{}, err
 		}
 
-		worker, err = step.workerPool.FindOrSelectWorker(ctx, containerOwner, containerSpec, workerSpec, step.strategy, delegate)
+		worker, err = step.selectWorker(ctx, state, delegate, containerOwner, containerSpec, workerSpec)
 		if err != nil {
 			logger.Error("failed-to-select-worker", err)
 			return nil, resource.VersionResult{}, runtime.ProcessResult{}, err
@@ -518,6 +524,31 @@ func (step *GetStep) performGetAndInitCache(
 	}
 
 	return volume, versionResult, processResult, nil
+}
+
+// selectWorker picks a worker for the get step, honoring the build's pinned
+// worker (if the job has pin_worker: true). The first step to need a
+// worker sets the pinned worker; subsequent steps are forced to use the
+// same one. See selectStepWorker for the race-handling details.
+func (step *GetStep) selectWorker(
+	ctx context.Context,
+	state RunState,
+	delegate worker.PoolCallback,
+	containerOwner db.ContainerOwner,
+	containerSpec runtime.ContainerSpec,
+	workerSpec worker.Spec,
+) (runtime.Worker, error) {
+	return selectStepWorker(
+		ctx,
+		step.workerPool,
+		step.strategy,
+		step.pinWorker,
+		state,
+		delegate,
+		containerOwner,
+		containerSpec,
+		workerSpec,
+	)
 }
 
 func (step *GetStep) resourceMountVolume(mounts []runtime.VolumeMount) runtime.Volume {

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -167,6 +167,7 @@ var _ = Describe("GetStep", func() {
 			fakeLockFactory,
 			fakeResourceCacheFactory,
 			nil,
+			false,
 			fakeDelegateFactory,
 			fakePool,
 			defaultGetTimeout,

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -55,6 +55,7 @@ type PutStep struct {
 	metadata          StepMetadata
 	containerMetadata db.ContainerMetadata
 	strategy          worker.PlacementStrategy
+	pinWorker         bool
 	workerPool        Pool
 	delegateFactory   PutDelegateFactory
 	defaultPutTimeout time.Duration
@@ -66,6 +67,7 @@ func NewPutStep(
 	metadata StepMetadata,
 	containerMetadata db.ContainerMetadata,
 	strategy worker.PlacementStrategy,
+	pinWorker bool,
 	workerPool Pool,
 	delegateFactory PutDelegateFactory,
 	defaultPutTimeout time.Duration,
@@ -77,6 +79,7 @@ func NewPutStep(
 		containerMetadata: containerMetadata,
 		workerPool:        workerPool,
 		strategy:          strategy,
+		pinWorker:         pinWorker,
 		delegateFactory:   delegateFactory,
 		defaultPutTimeout: defaultPutTimeout,
 	}
@@ -187,7 +190,7 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 		return false, err
 	}
 
-	worker, err := step.workerPool.FindOrSelectWorker(ctx, owner, containerSpec, workerSpec, step.strategy, delegate)
+	worker, err := step.selectWorker(ctx, state, delegate, owner, containerSpec, workerSpec)
 	if err != nil {
 		return false, err
 	}
@@ -248,4 +251,29 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 	delegate.Finished(logger, 0, versionResult)
 
 	return true, nil
+}
+
+// selectWorker picks a worker for the put step, honoring the build's pinned
+// worker (if the job has pin_worker: true). The first step to need a
+// worker sets the pinned worker; subsequent steps are forced to use the
+// same one. See selectStepWorker for the race-handling details.
+func (step *PutStep) selectWorker(
+	ctx context.Context,
+	state RunState,
+	delegate worker.PoolCallback,
+	owner db.ContainerOwner,
+	containerSpec runtime.ContainerSpec,
+	workerSpec worker.Spec,
+) (runtime.Worker, error) {
+	return selectStepWorker(
+		ctx,
+		step.workerPool,
+		step.strategy,
+		step.pinWorker,
+		state,
+		delegate,
+		owner,
+		containerSpec,
+		workerSpec,
+	)
 }

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -161,6 +161,7 @@ var _ = Describe("PutStep", func() {
 			stepMetadata,
 			containerMetadata,
 			nil,
+			false,
 			fakePool,
 			fakeDelegateFactory,
 			defaultPutTimeout,

--- a/atc/exec/run_state.go
+++ b/atc/exec/run_state.go
@@ -19,6 +19,13 @@ type runState struct {
 	results   *sync.Map
 
 	parent RunState
+
+	pinnedWorker *pinnedWorker
+}
+
+type pinnedWorker struct {
+	mu   sync.Mutex
+	name string
 }
 
 type Stepper func(atc.Plan) Step
@@ -34,6 +41,8 @@ func NewRunState(
 
 		artifacts: build.NewRepository(),
 		results:   &sync.Map{},
+
+		pinnedWorker: &pinnedWorker{},
 	}
 }
 
@@ -76,6 +85,10 @@ func (state *runState) NewLocalScope() RunState {
 	clone.vars = state.vars.NewLocalScope()
 	clone.artifacts = state.artifacts.NewLocalScope()
 	clone.parent = state
+	// Share the build's pinned worker with the new scope so across
+	// substeps remain on the same worker as the rest of the build. The
+	// embedded mutex is safe to share because SetPinnedWorker is
+	// idempotent and only writes when the pinned worker is empty.
 	return &clone
 }
 
@@ -89,4 +102,26 @@ func (state *runState) AddLocalVar(name string, val any, redact bool) {
 
 func (state *runState) Run(ctx context.Context, plan atc.Plan) (bool, error) {
 	return state.stepper(plan).Run(ctx, state)
+}
+
+func (state *runState) PinnedWorker() string {
+	state.pinnedWorker.mu.Lock()
+	defer state.pinnedWorker.mu.Unlock()
+	return state.pinnedWorker.name
+}
+
+// SetPinnedWorker records the worker that subsequent steps in the build
+// should be pinned to. The check-and-set is atomic, so when two steps
+// race to pin a worker, exactly one of them will see their own name
+// returned and the other will see the winner's name. If a worker has
+// already been pinned, the new value is ignored and the existing
+// pinned worker is returned. This guarantees the build only ever pins
+// to a single worker.
+func (state *runState) SetPinnedWorker(name string) string {
+	state.pinnedWorker.mu.Lock()
+	defer state.pinnedWorker.mu.Unlock()
+	if state.pinnedWorker.name == "" {
+		state.pinnedWorker.name = name
+	}
+	return state.pinnedWorker.name
 }

--- a/atc/exec/run_state_test.go
+++ b/atc/exec/run_state_test.go
@@ -336,4 +336,40 @@ var _ = Describe("RunState", func() {
 			})
 		})
 	})
+
+	Describe("PinnedWorker", func() {
+		It("returns an empty string when no worker has been pinned", func() {
+			Expect(state.PinnedWorker()).To(BeEmpty())
+		})
+
+		It("returns the pinned worker name after SetPinnedWorker is called", func() {
+			state.SetPinnedWorker("worker-1")
+			Expect(state.PinnedWorker()).To(Equal("worker-1"))
+		})
+
+		It("ignores subsequent SetPinnedWorker calls once a worker is pinned", func() {
+			state.SetPinnedWorker("worker-1")
+			state.SetPinnedWorker("worker-2")
+			Expect(state.PinnedWorker()).To(Equal("worker-1"))
+		})
+
+		It("returns the existing pinned worker name from SetPinnedWorker on subsequent calls", func() {
+			first := state.SetPinnedWorker("worker-1")
+			Expect(first).To(Equal("worker-1"))
+			second := state.SetPinnedWorker("worker-2")
+			Expect(second).To(Equal("worker-1"))
+		})
+
+		It("shares the pinned worker state across local scopes", func() {
+			state.SetPinnedWorker("worker-1")
+			scope := state.NewLocalScope()
+			Expect(scope.PinnedWorker()).To(Equal("worker-1"))
+		})
+
+		It("shares pinned worker writes from a local scope back to the parent", func() {
+			scope := state.NewLocalScope()
+			scope.SetPinnedWorker("worker-1")
+			Expect(state.PinnedWorker()).To(Equal("worker-1"))
+		})
+	})
 })

--- a/atc/exec/step.go
+++ b/atc/exec/step.go
@@ -56,6 +56,15 @@ type RunState interface {
 	Run(context.Context, atc.Plan) (bool, error)
 
 	Parent() RunState
+
+	// PinnedWorker returns the name of the worker that the build is pinned
+	// to. Returns an empty string if no worker is pinned.
+	PinnedWorker() string
+
+	// SetPinnedWorker records the worker that subsequent steps in the build
+	// should be pinned to. It is a no-op if a worker has already been
+	// pinned, returning the name of the existing pinned worker.
+	SetPinnedWorker(name string) string
 }
 
 // ExitStatus is the resulting exit code from the process that the step ran.
@@ -72,6 +81,7 @@ type OutputHandler func(io.Writer) error
 //counterfeiter:generate . Pool
 type Pool interface {
 	FindOrSelectWorker(context.Context, db.ContainerOwner, runtime.ContainerSpec, worker.Spec, worker.PlacementStrategy, worker.PoolCallback) (runtime.Worker, error)
+	FindOrSelectWorkerOnPinned(context.Context, db.ContainerOwner, runtime.ContainerSpec, worker.Spec, string, worker.PlacementStrategy, worker.PoolCallback) (runtime.Worker, error)
 	FindResourceCacheVolume(context.Context, int, db.ResourceCache, worker.Spec, time.Time) (runtime.Volume, bool, error)
 	FindResourceCacheVolumeOnWorker(context.Context, db.ResourceCache, worker.Spec, string, time.Time) (runtime.Volume, bool, error)
 	ReleaseWorker(lager.Logger, runtime.ContainerSpec, runtime.Worker, worker.PlacementStrategy)

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -92,6 +92,7 @@ type TaskStep struct {
 	metadata            StepMetadata
 	containerMetadata   db.ContainerMetadata
 	strategy            worker.PlacementStrategy
+	pinWorker           bool
 	workerPool          Pool
 	streamer            Streamer
 	delegateFactory     TaskDelegateFactory
@@ -106,6 +107,7 @@ func NewTaskStep(
 	metadata StepMetadata,
 	containerMetadata db.ContainerMetadata,
 	strategy worker.PlacementStrategy,
+	pinWorker bool,
 	workerPool Pool,
 	streamer Streamer,
 	delegateFactory TaskDelegateFactory,
@@ -119,6 +121,7 @@ func NewTaskStep(
 		metadata:            metadata,
 		containerMetadata:   containerMetadata,
 		strategy:            strategy,
+		pinWorker:           pinWorker,
 		workerPool:          workerPool,
 		streamer:            streamer,
 		delegateFactory:     delegateFactory,
@@ -268,14 +271,7 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 		return false, err
 	}
 
-	worker, err := step.workerPool.FindOrSelectWorker(
-		ctx,
-		owner,
-		containerSpec,
-		step.workerSpec(config),
-		step.strategy,
-		delegate,
-	)
+	worker, err := step.selectWorker(ctx, state, delegate, owner, containerSpec, config)
 	if err != nil {
 		return false, err
 	}
@@ -485,6 +481,31 @@ func (step *TaskStep) workerSpec(config atc.TaskConfig) worker.Spec {
 		Tags:     step.plan.Tags,
 		TeamID:   step.metadata.TeamID,
 	}
+}
+
+// selectWorker picks a worker for the task, honoring the build's pinned
+// worker (if the job has pin_worker: true). The first step to need a
+// worker sets the pinned worker; subsequent steps are forced to use the
+// same one. See selectStepWorker for the race-handling details.
+func (step *TaskStep) selectWorker(
+	ctx context.Context,
+	state RunState,
+	delegate TaskDelegate,
+	owner db.ContainerOwner,
+	containerSpec runtime.ContainerSpec,
+	config atc.TaskConfig,
+) (runtime.Worker, error) {
+	return selectStepWorker(
+		ctx,
+		step.workerPool,
+		step.strategy,
+		step.pinWorker,
+		state,
+		delegate,
+		owner,
+		containerSpec,
+		step.workerSpec(config),
+	)
 }
 
 func (step *TaskStep) registerOutputs(logger lager.Logger, repository *build.Repository, config atc.TaskConfig, volumeMounts []runtime.VolumeMount, metadata db.ContainerMetadata) {

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -122,6 +122,7 @@ var _ = Describe("TaskStep", func() {
 			stepMetadata,
 			containerMetadata,
 			nil,
+			false,
 			fakePool,
 			fakeStreamer,
 			fakeDelegateFactory,
@@ -1184,5 +1185,145 @@ var _ = Describe("TaskStep", func() {
 				Expect(repo.AsMap()).To(BeEmpty())
 			})
 		})
+	})
+})
+
+// fakeRuntimeWorker is a minimal runtime.Worker that returns a fixed name
+// and returns an error from FindOrCreateContainer so tests can observe the
+// worker-selection behavior of pin_worker without exercising the full
+// container lifecycle. The other methods are unimplemented and will panic
+// if called.
+type fakeRuntimeWorker struct {
+	name string
+}
+
+func (f *fakeRuntimeWorker) Name() string { return f.name }
+func (f *fakeRuntimeWorker) FindOrCreateContainer(
+	_ context.Context, _ db.ContainerOwner, _ db.ContainerMetadata,
+	_ runtime.ContainerSpec, _ runtime.BuildStepDelegate,
+) (runtime.Container, []runtime.VolumeMount, error) {
+	return nil, nil, errors.New("stop after worker selection")
+}
+func (f *fakeRuntimeWorker) CreateVolumeForArtifact(
+	_ context.Context, _ int,
+) (runtime.Volume, db.WorkerArtifact, error) {
+	panic("unimplemented")
+}
+func (f *fakeRuntimeWorker) LookupContainer(
+	_ context.Context, _ string,
+) (runtime.Container, bool, error) {
+	panic("unimplemented")
+}
+func (f *fakeRuntimeWorker) LookupVolume(
+	_ context.Context, _ string,
+) (runtime.Volume, bool, error) {
+	panic("unimplemented")
+}
+func (f *fakeRuntimeWorker) DBWorker() db.Worker {
+	panic("unimplemented")
+}
+
+var _ = Describe("TaskStep pin_worker", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+
+		fakePool            *execfakes.FakePool
+		fakeStreamer        *execfakes.FakeStreamer
+		fakeDelegate        *execfakes.FakeTaskDelegate
+		fakeDelegateFactory *execfakes.FakeTaskDelegateFactory
+		state               exec.RunState
+
+		taskPlan         = &atc.TaskPlan{Name: "some-task"}
+		stepMetadata     = exec.StepMetadata{BuildID: 1234, TeamID: 123}
+		containerMetadata = db.ContainerMetadata{
+			WorkingDirectory: "some-artifact-root",
+			Type:             db.ContainerTypeTask,
+			StepName:         "some-step",
+		}
+		planID = atc.PlanID("42")
+	)
+
+	// Provide a minimal valid task config so the step reaches worker
+	// selection instead of failing config validation.
+	taskPlan.Config = &atc.TaskConfig{
+		Platform: "some-platform",
+		Run:      atc.TaskRunConfig{Path: "true"},
+	}
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+
+		fakePool = new(execfakes.FakePool)
+		fakeStreamer = new(execfakes.FakeStreamer)
+
+		fakeDelegate = new(execfakes.FakeTaskDelegate)
+		fakeDelegate.StartSpanReturns(ctx, tracing.NoopSpan)
+		stdoutBuf := gbytes.NewBuffer()
+		stderrBuf := gbytes.NewBuffer()
+		fakeDelegate.StdoutReturns(stdoutBuf)
+		fakeDelegate.StderrReturns(stderrBuf)
+
+		fakeDelegateFactory = new(execfakes.FakeTaskDelegateFactory)
+		fakeDelegateFactory.TaskDelegateReturns(fakeDelegate)
+
+		state = exec.NewRunState(noopStepper, vars.StaticVariables{})
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	newStep := func(pinWorker bool) exec.Step {
+		plan := atc.Plan{ID: planID, Task: taskPlan}
+		return exec.NewTaskStep(
+			plan.ID,
+			*plan.Task,
+			atc.ContainerLimits{},
+			stepMetadata,
+			containerMetadata,
+			nil,
+			pinWorker,
+			fakePool,
+			fakeStreamer,
+			fakeDelegateFactory,
+			0,
+			0,
+		)
+	}
+
+	It("records the chosen worker as the build's pinned worker when no worker was pinned", func() {
+		fakePool.FindOrSelectWorkerReturns(&fakeRuntimeWorker{name: "chosen-worker"}, nil)
+
+		step := newStep(true)
+		_, _ = step.Run(ctx, state)
+
+		Expect(fakePool.FindOrSelectWorkerCallCount()).To(Equal(1))
+		Expect(fakePool.FindOrSelectWorkerOnPinnedCallCount()).To(Equal(0))
+		Expect(state.PinnedWorker()).To(Equal("chosen-worker"))
+	})
+
+	It("uses FindOrSelectWorkerOnPinned when a worker is already pinned", func() {
+		state.SetPinnedWorker("pinned-worker")
+
+		fakePool.FindOrSelectWorkerOnPinnedReturns(&fakeRuntimeWorker{name: "pinned-worker"}, nil)
+
+		step := newStep(true)
+		_, _ = step.Run(ctx, state)
+
+		Expect(fakePool.FindOrSelectWorkerCallCount()).To(Equal(0))
+		Expect(fakePool.FindOrSelectWorkerOnPinnedCallCount()).To(Equal(1))
+		_, _, _, _, pinnedName, _, _ := fakePool.FindOrSelectWorkerOnPinnedArgsForCall(0)
+		Expect(pinnedName).To(Equal("pinned-worker"))
+		Expect(state.PinnedWorker()).To(Equal("pinned-worker"))
+	})
+
+	It("does not pin a worker when pin_worker is false", func() {
+		fakePool.FindOrSelectWorkerReturns(&fakeRuntimeWorker{name: "chosen-worker"}, nil)
+
+		step := newStep(false)
+		_, _ = step.Run(ctx, state)
+
+		Expect(state.PinnedWorker()).To(BeEmpty())
 	})
 })

--- a/atc/exec/worker_selector.go
+++ b/atc/exec/worker_selector.go
@@ -1,0 +1,99 @@
+package exec
+
+import (
+	"context"
+
+	"code.cloudfoundry.org/lager/v3/lagerctx"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/runtime"
+	"github.com/concourse/concourse/atc/worker"
+)
+
+// selectStepWorker picks a worker for a step, honoring the build's pinned
+// worker (when the job has pin_worker: true).
+//
+// When no worker is pinned yet, this is the step that picks one (the first
+// to call). Subsequent steps are forced to use the same worker.
+//
+// If two parallel steps both see no pinned worker and both call
+// FindOrSelectWorker concurrently, the loser's candidate is released and
+// it re-selects on the winner's worker. The check-and-set in
+// SetPinnedWorker is atomic, so only one of the parallel steps can win
+// the race.
+func selectStepWorker(
+	ctx context.Context,
+	pool Pool,
+	strategy worker.PlacementStrategy,
+	pinWorker bool,
+	state RunState,
+	callback worker.PoolCallback,
+	owner db.ContainerOwner,
+	containerSpec runtime.ContainerSpec,
+	spec worker.Spec,
+) (runtime.Worker, error) {
+	if !pinWorker {
+		return pool.FindOrSelectWorker(
+			ctx,
+			owner,
+			containerSpec,
+			spec,
+			strategy,
+			callback,
+		)
+	}
+
+	// Fast path: a worker has already been pinned for this build. All
+	// subsequent steps in the build, including across substeps, will go
+	// through this path.
+	if pinned := state.PinnedWorker(); pinned != "" {
+		return pool.FindOrSelectWorkerOnPinned(
+			ctx,
+			owner,
+			containerSpec,
+			spec,
+			pinned,
+			strategy,
+			callback,
+		)
+	}
+
+	// Slow path: this is the first step to need a worker in the build.
+	// Pick a worker, then try to claim it as the build's pinned worker.
+	candidate, err := pool.FindOrSelectWorker(
+		ctx,
+		owner,
+		containerSpec,
+		spec,
+		strategy,
+		callback,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if candidate == nil {
+		return nil, nil
+	}
+	actualPinned := state.SetPinnedWorker(candidate.Name())
+	if actualPinned == candidate.Name() {
+		return candidate, nil
+	}
+
+	// We lost the race against another parallel step. Release our
+	// candidate and re-select on the winning worker so the build ends up
+	// on a single worker as promised by pin_worker.
+	pool.ReleaseWorker(
+		lagerctx.FromContext(ctx),
+		containerSpec,
+		candidate,
+		strategy,
+	)
+	return pool.FindOrSelectWorkerOnPinned(
+		ctx,
+		owner,
+		containerSpec,
+		spec,
+		actualPinned,
+		strategy,
+		callback,
+	)
+}

--- a/atc/exec/worker_selector_test.go
+++ b/atc/exec/worker_selector_test.go
@@ -1,0 +1,131 @@
+package exec_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/exec"
+	"github.com/concourse/concourse/atc/exec/execfakes"
+	"github.com/concourse/concourse/atc/runtime"
+	"github.com/concourse/concourse/atc/runtime/runtimetest"
+	"github.com/concourse/concourse/atc/worker"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("selectStepWorker", func() {
+	var (
+		ctx           context.Context
+		fakePool      *execfakes.FakePool
+		fakeState     *execfakes.FakeRunState
+		owner         db.ContainerOwner
+		containerSpec runtime.ContainerSpec
+		spec          worker.Spec
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		fakePool = new(execfakes.FakePool)
+		fakeState = new(execfakes.FakeRunState)
+		owner = db.NewFixedHandleContainerOwner("any")
+		containerSpec = runtime.ContainerSpec{Type: db.ContainerTypeTask}
+		spec = worker.Spec{}
+	})
+
+	It("calls FindOrSelectWorker when pin_worker is false", func() {
+		w := runtimetest.NewWorker("any")
+		fakePool.FindOrSelectWorkerReturns(w, nil)
+
+		got, err := exec.SelectStepWorkerForTest(ctx, fakePool, nil, false, fakeState, nil, owner, containerSpec, spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(w))
+
+		Expect(fakePool.FindOrSelectWorkerCallCount()).To(Equal(1))
+		Expect(fakePool.FindOrSelectWorkerOnPinnedCallCount()).To(Equal(0))
+		Expect(fakePool.ReleaseWorkerCallCount()).To(Equal(0))
+	})
+
+	It("calls FindOrSelectWorkerOnPinned when a worker is already pinned", func() {
+		fakeState.PinnedWorkerReturns("pinned-worker")
+		w := runtimetest.NewWorker("pinned-worker")
+		fakePool.FindOrSelectWorkerOnPinnedReturns(w, nil)
+
+		got, err := exec.SelectStepWorkerForTest(ctx, fakePool, nil, true, fakeState, nil, owner, containerSpec, spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(w))
+
+		Expect(fakePool.FindOrSelectWorkerCallCount()).To(Equal(0))
+		Expect(fakePool.FindOrSelectWorkerOnPinnedCallCount()).To(Equal(1))
+		_, _, _, _, pinnedName, _, _ := fakePool.FindOrSelectWorkerOnPinnedArgsForCall(0)
+		Expect(pinnedName).To(Equal("pinned-worker"))
+	})
+
+	It("pins the chosen worker and returns it when no worker was previously pinned", func() {
+		fakeState.PinnedWorkerReturns("")
+		fakeState.SetPinnedWorkerStub = func(name string) string {
+			// First call: nothing pinned yet, so we win.
+			Expect(name).To(Equal("candidate"))
+			return name
+		}
+
+		candidate := runtimetest.NewWorker("candidate")
+		fakePool.FindOrSelectWorkerReturns(candidate, nil)
+
+		got, err := exec.SelectStepWorkerForTest(ctx, fakePool, nil, true, fakeState, nil, owner, containerSpec, spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(candidate))
+
+		Expect(fakePool.FindOrSelectWorkerCallCount()).To(Equal(1))
+		Expect(fakePool.FindOrSelectWorkerOnPinnedCallCount()).To(Equal(0))
+		Expect(fakePool.ReleaseWorkerCallCount()).To(Equal(0))
+	})
+
+	It("releases the candidate and re-selects on the winning worker when losing the pin race", func() {
+		// PinnedWorker() returns "" the first time (no pinned worker yet),
+		// but SetPinnedWorker returns "winner-worker" — simulating a
+		// parallel step that won the race between the helper's check
+		// and pin.
+		fakeState.PinnedWorkerReturns("")
+		fakeState.SetPinnedWorkerStub = func(_ string) string {
+			return "winner-worker"
+		}
+
+		candidate := runtimetest.NewWorker("candidate")
+		winner := runtimetest.NewWorker("winner-worker")
+		fakePool.FindOrSelectWorkerReturns(candidate, nil)
+		fakePool.FindOrSelectWorkerOnPinnedReturns(winner, nil)
+
+		got, err := exec.SelectStepWorkerForTest(ctx, fakePool, nil, true, fakeState, nil, owner, containerSpec, spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(winner))
+
+		Expect(fakePool.FindOrSelectWorkerCallCount()).To(Equal(1))
+		Expect(fakePool.FindOrSelectWorkerOnPinnedCallCount()).To(Equal(1))
+		Expect(fakePool.ReleaseWorkerCallCount()).To(Equal(1))
+		_, _, _, _, pinnedName, _, _ := fakePool.FindOrSelectWorkerOnPinnedArgsForCall(0)
+		Expect(pinnedName).To(Equal("winner-worker"))
+	})
+
+	It("returns nil when FindOrSelectWorker returns no worker and nothing is pinned", func() {
+		fakeState.PinnedWorkerReturns("")
+		fakePool.FindOrSelectWorkerReturns(nil, nil)
+
+		got, err := exec.SelectStepWorkerForTest(ctx, fakePool, nil, true, fakeState, nil, owner, containerSpec, spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(BeNil())
+
+		Expect(fakePool.FindOrSelectWorkerCallCount()).To(Equal(1))
+		Expect(fakePool.ReleaseWorkerCallCount()).To(Equal(0))
+	})
+
+	It("propagates errors from FindOrSelectWorker", func() {
+		disaster := errors.New("boom")
+		fakePool.FindOrSelectWorkerReturns(nil, disaster)
+
+		got, err := exec.SelectStepWorkerForTest(ctx, fakePool, nil, false, fakeState, nil, owner, containerSpec, spec)
+		Expect(err).To(MatchError(disaster))
+		Expect(got).To(BeNil())
+	})
+})

--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -11,6 +11,7 @@ type JobConfig struct {
 	Interruptible        bool     `json:"interruptible,omitempty"`
 	SerialGroups         []string `json:"serial_groups,omitempty"`
 	RawMaxInFlight       int      `json:"max_in_flight,omitempty"`
+	PinWorker            bool     `json:"pin_worker,omitempty"`
 	Tags                 Tags     `json:"tags,omitempty"`
 
 	// Deprecated: users should use BuildLogRetention

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -4,6 +4,10 @@ type Plan struct {
 	ID       PlanID `json:"id"`
 	Attempts []int  `json:"attempts,omitempty"`
 
+	// PinWorker, when set on the root plan, causes every step in the build to
+	// select and stay on a single worker for the duration of the build.
+	PinWorker bool `json:"pin_worker,omitempty"`
+
 	Get         *GetPlan         `json:"get,omitempty"`
 	Put         *PutPlan         `json:"put,omitempty"`
 	Check       *CheckPlan       `json:"check,omitempty"`

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -24,7 +24,7 @@ type BuildStarter interface {
 
 //counterfeiter:generate . BuildPlanner
 type BuildPlanner interface {
-	Create(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags) (atc.Plan, error)
+	Create(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags, bool) (atc.Plan, error)
 }
 
 type Build interface {
@@ -297,7 +297,7 @@ func (s *buildStarter) tryStartNextPendingBuild(
 		return startResults{}, fmt.Errorf("config: %w", err)
 	}
 
-	plan, err := s.planner.Create(config.StepConfig(), job.Resources, job.ResourceTypes, job.Prototypes, buildInputs, nextPendingBuild.IsManuallyTriggered(), config.Tags)
+	plan, err := s.planner.Create(config.StepConfig(), job.Resources, job.ResourceTypes, job.Prototypes, buildInputs, nextPendingBuild.IsManuallyTriggered(), config.Tags, config.PinWorker)
 	if err != nil {
 		logger.Error("failed-to-create-build-plan", err)
 

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -505,7 +505,7 @@ var _ = Describe("BuildStarter", func() {
 								})
 
 								It("creates the build plan with manually triggered", func() {
-									_, _, _, _, _, actualManuallyTriggered, _ := fakePlanner.CreateArgsForCall(0)
+									_, _, _, _, _, actualManuallyTriggered, _, _ := fakePlanner.CreateArgsForCall(0)
 									Expect(actualManuallyTriggered).To(Equal(true))
 								})
 							})
@@ -796,7 +796,7 @@ var _ = Describe("BuildStarter", func() {
 									It("creates build plans for all builds", func() {
 										Expect(fakePlanner.CreateCallCount()).To(Equal(3))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags := fakePlanner.CreateArgsForCall(0)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags, _ := fakePlanner.CreateArgsForCall(0)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))
@@ -805,7 +805,7 @@ var _ = Describe("BuildStarter", func() {
 										Expect(actualManuallyTriggered).To(Equal(false))
 										Expect(actualJobTags).To(Equal(jobConfig.Tags))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags = fakePlanner.CreateArgsForCall(1)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags, _ = fakePlanner.CreateArgsForCall(1)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))
@@ -814,7 +814,7 @@ var _ = Describe("BuildStarter", func() {
 										Expect(actualManuallyTriggered).To(Equal(false))
 										Expect(actualJobTags).To(Equal(jobConfig.Tags))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags = fakePlanner.CreateArgsForCall(2)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered, actualJobTags, _ = fakePlanner.CreateArgsForCall(2)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))

--- a/atc/scheduler/schedulerfakes/fake_build_planner.go
+++ b/atc/scheduler/schedulerfakes/fake_build_planner.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FakeBuildPlanner struct {
-	CreateStub        func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags) (atc.Plan, error)
+	CreateStub        func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags, bool) (atc.Plan, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
 		arg1 atc.StepConfig
@@ -20,6 +20,7 @@ type FakeBuildPlanner struct {
 		arg5 []db.BuildInput
 		arg6 bool
 		arg7 atc.Tags
+		arg8 bool
 	}
 	createReturns struct {
 		result1 atc.Plan
@@ -33,7 +34,7 @@ type FakeBuildPlanner struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResources, arg3 atc.ResourceTypes, arg4 atc.Prototypes, arg5 []db.BuildInput, arg6 bool, arg7 atc.Tags) (atc.Plan, error) {
+func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResources, arg3 atc.ResourceTypes, arg4 atc.Prototypes, arg5 []db.BuildInput, arg6 bool, arg7 atc.Tags, arg8 bool) (atc.Plan, error) {
 	var arg5Copy []db.BuildInput
 	if arg5 != nil {
 		arg5Copy = make([]db.BuildInput, len(arg5))
@@ -49,13 +50,14 @@ func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResou
 		arg5 []db.BuildInput
 		arg6 bool
 		arg7 atc.Tags
-	}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
+		arg8 bool
+	}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7, arg8})
 	stub := fake.CreateStub
 	fakeReturns := fake.createReturns
-	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
+	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7, arg8})
 	fake.createMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -69,17 +71,17 @@ func (fake *FakeBuildPlanner) CreateCallCount() int {
 	return len(fake.createArgsForCall)
 }
 
-func (fake *FakeBuildPlanner) CreateCalls(stub func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags) (atc.Plan, error)) {
+func (fake *FakeBuildPlanner) CreateCalls(stub func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags, bool) (atc.Plan, error)) {
 	fake.createMutex.Lock()
 	defer fake.createMutex.Unlock()
 	fake.CreateStub = stub
 }
 
-func (fake *FakeBuildPlanner) CreateArgsForCall(i int) (atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags) {
+func (fake *FakeBuildPlanner) CreateArgsForCall(i int) (atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool, atc.Tags, bool) {
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	argsForCall := fake.createArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8
 }
 
 func (fake *FakeBuildPlanner) CreateReturns(result1 atc.Plan, result2 error) {

--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -110,6 +110,123 @@ func (pool Pool) FindOrSelectWorker(
 	return pool.factory.NewWorker(logger, worker), nil
 }
 
+// FindOrSelectWorkerOnPinned selects the named worker for the given step, or
+// waits for it to become available. The named worker must be compatible with
+// the step's spec (platform, tags, resource type, team, version) and must
+// pass the strategy's Approve check (e.g., not over its active-tasks limit).
+// If the worker no longer exists in the database, the function returns an
+// error.
+//
+// When pinnedWorker is empty, this falls through to the normal
+// FindOrSelectWorker behavior.
+func (pool Pool) FindOrSelectWorkerOnPinned(
+	ctx context.Context,
+	owner db.ContainerOwner,
+	containerSpec runtime.ContainerSpec,
+	workerSpec Spec,
+	pinnedWorker string,
+	strategy PlacementStrategy,
+	callback PoolCallback,
+) (runtime.Worker, error) {
+	if pinnedWorker == "" {
+		return pool.FindOrSelectWorker(ctx, owner, containerSpec, workerSpec, strategy, callback)
+	}
+
+	logger := lagerctx.FromContext(ctx)
+
+	started := time.Now()
+	labels := metric.StepsWaitingLabels{
+		Platform:   workerSpec.Platform,
+		TeamId:     strconv.Itoa(workerSpec.TeamID),
+		TeamName:   containerSpec.TeamName,
+		Type:       string(containerSpec.Type),
+		WorkerTags: strings.Join(workerSpec.Tags, "_"),
+	}
+	var worker db.Worker
+	var pollingTicker *time.Ticker
+	for {
+		var err error
+		worker, err = pool.findOrSelectWorkerOnPinned(logger, owner, containerSpec, workerSpec, pinnedWorker, strategy)
+		if err != nil {
+			return nil, err
+		}
+		if worker != nil {
+			break
+		}
+
+		if pollingTicker == nil {
+			pollingTicker = time.NewTicker(PollingInterval)
+			defer pollingTicker.Stop()
+
+			logger.Debug("waiting-for-pinned-worker", lager.Data{"worker": pinnedWorker})
+
+			_, ok := metric.Metrics.StepsWaiting[labels]
+			if !ok {
+				metric.Metrics.StepsWaiting[labels] = &metric.Gauge{}
+			}
+
+			metric.Metrics.StepsWaiting[labels].Inc()
+			defer metric.Metrics.StepsWaiting[labels].Dec()
+
+			if callback != nil {
+				callback.WaitingForWorker(logger)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			logger.Info("aborted-waiting-for-pinned-worker")
+			return nil, ctx.Err()
+		case <-pollingTicker.C:
+		case <-pool.waker:
+		}
+	}
+
+	elapsed := time.Since(started)
+	metric.StepsWaitingDuration{
+		Labels:   labels,
+		Duration: elapsed,
+	}.Emit(logger)
+
+	return pool.factory.NewWorker(logger, worker), nil
+}
+
+func (pool Pool) findOrSelectWorkerOnPinned(
+	logger lager.Logger,
+	owner db.ContainerOwner,
+	containerSpec runtime.ContainerSpec,
+	workerSpec Spec,
+	pinnedWorkerName string,
+	strategy PlacementStrategy,
+) (db.Worker, error) {
+	pinnedWorker, found, err := pool.db.WorkerFactory.GetWorker(pinnedWorkerName)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("pinned worker %q no longer exists", pinnedWorkerName)
+	}
+
+	if !pool.isWorkerCompatibleAndRunning(logger, pinnedWorker, workerSpec) {
+		// Worker is not currently compatible (down, draining, wrong
+		// platform/tags, etc.) or is not running. Signal the caller to
+		// keep polling until it comes back or the build is aborted.
+		return nil, nil
+	}
+
+	if err := strategy.Approve(logger, pinnedWorker, containerSpec); err != nil {
+		// Strategy (e.g. active-tasks / active-containers limit) rejects
+		// the worker. Signal the caller to keep polling.
+		logger.Debug("pinned-worker-rejected-by-strategy", lager.Data{
+			"worker": pinnedWorkerName,
+			"error":  err.Error(),
+		})
+		return nil, nil
+	}
+
+	return pinnedWorker, nil
+}
+
 func (pool Pool) findOrSelectWorker(logger lager.Logger, owner db.ContainerOwner, containerSpec runtime.ContainerSpec, workerSpec Spec, strategy PlacementStrategy) (db.Worker, error) {
 	worker, compatibleWorkers, found, err := pool.findWorkerForContainer(logger, owner, workerSpec)
 	if err != nil {

--- a/atc/worker/pool_test.go
+++ b/atc/worker/pool_test.go
@@ -344,6 +344,95 @@ var _ = Describe("Pool", func() {
 		})
 	})
 
+	Describe("FindOrSelectWorkerOnPinned", func() {
+		Test("selects the pinned worker when it is compatible", func() {
+			concurrentId := GinkgoParallelProcess()
+			scenario := Setup(
+				workertest.WithWorkers(
+					grt.NewWorker(fmt.Sprintf("worker1-%d", concurrentId)),
+					grt.NewWorker(fmt.Sprintf("worker2-%d", concurrentId)),
+				),
+			)
+
+			worker, err := scenario.Pool.FindOrSelectWorkerOnPinned(
+				ctx,
+				db.NewFixedHandleContainerOwner("any"),
+				runtime.ContainerSpec{},
+				worker.Spec{},
+				fmt.Sprintf("worker2-%d", concurrentId),
+				nil,
+				nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(worker).ToNot(BeNil())
+			Expect(worker.Name()).To(Equal(fmt.Sprintf("worker2-%d", concurrentId)))
+		})
+
+		Test("falls back to FindOrSelectWorker when pinned worker is empty", func() {
+			concurrentId := GinkgoParallelProcess()
+			scenario := Setup(
+				workertest.WithWorkers(
+					grt.NewWorker(fmt.Sprintf("worker1-%d", concurrentId)),
+				),
+			)
+
+			worker, err := scenario.Pool.FindOrSelectWorkerOnPinned(
+				ctx,
+				db.NewFixedHandleContainerOwner("any"),
+				runtime.ContainerSpec{},
+				worker.Spec{},
+				"",
+				nil,
+				nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(worker.Name()).To(Equal(fmt.Sprintf("worker1-%d", concurrentId)))
+		})
+
+		Test("returns an error when the pinned worker has been removed", func() {
+			concurrentId := GinkgoParallelProcess()
+			scenario := Setup(
+				workertest.WithWorkers(
+					grt.NewWorker(fmt.Sprintf("worker1-%d", concurrentId)),
+				),
+			)
+
+			_, err := scenario.Pool.FindOrSelectWorkerOnPinned(
+				ctx,
+				db.NewFixedHandleContainerOwner("any"),
+				runtime.ContainerSpec{},
+				worker.Spec{},
+				"does-not-exist",
+				nil,
+				nil,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does-not-exist"))
+		})
+
+		Test("ignores the pinned worker when it is not in the compatible set (wrong tags)", func() {
+			concurrentId := GinkgoParallelProcess()
+			scenario := Setup(
+				workertest.WithWorkers(
+					grt.NewWorker(fmt.Sprintf("worker1-%d", concurrentId)).
+						WithTags("linux"),
+				),
+			)
+
+			worker, err := scenario.Pool.FindOrSelectWorkerOnPinned(
+				ctx,
+				db.NewFixedHandleContainerOwner("any"),
+				runtime.ContainerSpec{},
+				worker.Spec{Tags: []string{"windows"}},
+				fmt.Sprintf("worker1-%d", concurrentId),
+				nil,
+				nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(worker).To(BeNil())
+		})
+	})
+
 	Describe("FindResourceCacheVolume", func() {
 		Test("finds a resource cache volume among multiple workers", func() {
 			concurrentId := GinkgoParallelProcess()


### PR DESCRIPTION
## Changes proposed by this PR

This adds a flag named "pin_worker" to the job which instructs the planner to keep job tasks on the chosen worker for that buildrun.

(aka, once a job starts on a worker, keep all tasks on the selected worker)

Current behavior is tasks can run on "any worker" and stream data around (which may be an extremely poor choice if workers are in differing locations).

The workaround in the past has been abuse of tags["workera"] to keep pipelines rigid on one worker (which makes jobs less-reliable as they can't choose better workers)

## Notes to reviewer

This needs tested in a big way.   Definitely do not merge until it has been validated (i'm working on this now)

## Release Note

* Add ```pin_worker``` job flag to instruct the planner to keep all tasks of a job within the chosen worker. This can be helpful when workers are located in geographically diverse locations and streaming data between them is slow and unnecessary.
