### PR TITLE
fly: copy stdin buffer before sending hijack input

### DIFF
--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -470,7 +471,7 @@ type stdinWriter struct {
 
 func (w *stdinWriter) Write(d []byte) (int, error) {
 	w.inputs <- atc.HijackInput{
-		Stdin: d,
+		Stdin: bytes.Clone(d),
 	}
 
 	return len(d), nil

--- a/fly/integration/hijack_test.go
+++ b/fly/integration/hijack_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"os/exec"
@@ -189,6 +190,103 @@ var _ = Describe("hijack", func() {
 
 		It("hijacks the most recent one-off build in the specified working directory", func() {
 			hijack("-s", "some-step")
+		})
+	})
+
+	Context("when a large amount of input is written at once", func() {
+		var receivedStdin chan []byte
+
+		bigInput := func() []byte {
+			var buf bytes.Buffer
+			for i := 0; buf.Len() < 8*1024*1024; i++ {
+				fmt.Fprintf(&buf, "line %08d %s\n", i, strings.Repeat("x", 48))
+			}
+			return buf.Bytes()
+		}()
+
+		BeforeEach(func() {
+			didHijack := make(chan struct{})
+			hijacked = didHijack
+			receivedStdin = make(chan []byte, 1)
+
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/builds"),
+					ghttp.RespondWithJSONEncoded(200, []atc.Build{
+						{ID: 3, Name: "3", Status: "started"},
+					}),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/teams/main/containers", "build_id=3&step_name=some-step"),
+					ghttp.RespondWithJSONEncoded(200, []atc.Container{
+						{ID: "container-id-1", State: atc.ContainerStateCreated, BuildID: 3, Type: "task", StepName: "some-step", User: user},
+					}),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/teams/main/containers/container-id-1/hijack"),
+					func(w http.ResponseWriter, r *http.Request) {
+						defer GinkgoRecover()
+
+						conn, err := upgrader.Upgrade(w, r, nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						defer conn.Close()
+
+						close(didHijack)
+
+						var processSpec atc.HijackProcessSpec
+						err = conn.ReadJSON(&processSpec)
+						Expect(err).NotTo(HaveOccurred())
+
+						time.Sleep(time.Second)
+
+						var stdin []byte
+						for {
+							var payload atc.HijackInput
+							err := conn.ReadJSON(&payload)
+							Expect(err).NotTo(HaveOccurred())
+
+							if payload.Closed {
+								break
+							}
+
+							stdin = append(stdin, payload.Stdin...)
+						}
+
+						receivedStdin <- stdin
+
+						exitStatus := 0
+						err = conn.WriteJSON(atc.HijackOutput{
+							ExitStatus: &exitStatus,
+						})
+						Expect(err).NotTo(HaveOccurred())
+					},
+				),
+			)
+		})
+
+		It("delivers the input to the container intact", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "hijack", "-s", "some-step")
+
+			stdin, err := flyCmd.StdinPipe()
+			Expect(err).NotTo(HaveOccurred())
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(hijacked).Should(BeClosed())
+
+			_, err = stdin.Write(bigInput)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = stdin.Close()
+			Expect(err).NotTo(HaveOccurred())
+
+			var got []byte
+			Eventually(receivedStdin, 10*time.Second).Should(Receive(&got))
+			Expect(got).To(Equal(bigInput))
+
+			<-sess.Exited
 		})
 	})
 


### PR DESCRIPTION
## Changes proposed by this PR

* `stdinWriter.Write` handed `io.Copy`'s buffer straight to the channel that `handleInput` serializes from. `io.Copy` reuses a single 32KB buffer, so the next read could overwrite bytes that hadn't been written to the websocket yet, and the JSON that went out held whatever was in the buffer at marshal time. Fixed by cloning the slice in `Write`.
* Fixing it in `stdinWriter` rather than at the call site, since `io.Writer` says implementations must not retain `p`, so that's the side in the wrong.
* Added an integration test that writes 8MB to fly's stdin in one shot and checks the reassembled `HijackInput` frames match what was sent.

## Notes to reviewer

Typing never hits this because each read is one byte and the round trip finishes long before the next keystroke. Pasting does: the terminal delivers the payload in a burst, the reads come back to back, and the input can land in the container reordered and duplicated once the paste spans more than one read.

How often you see it depends on how your terminal feeds the pty. In my case, Ghostty and Alacritty on macOS push a paste in large writes with no gaps, which trips it easily. Terminals like iTerm that split a paste into smaller writes, or pace them (some rate limit paste input, and anything routing through tmux or ssh gets chunked along the way), leave enough time between reads for the previous frame to go out, so the corruption stays hidden. The race is there either way.

The fake ATC in the integration test sleeps for a second before reading input frames. That fills the socket buffers so fly's `WriteJSON` blocks, which is what opens the race window. Without it the race is 50/50, causing it to pass against the broken code.

To confirm: revert the `bytes.Clone` and the test fails on the byte comparison.

## Release Note

* Fixes corrupted input when pasting into `fly hijack` / `fly intercept`. Pasted text longer than a single terminal read could arrive at the container reordered or duplicated.