### PR TITLE
scheduler: fix scheduling for jobs with `serial: true` and `check_every: never` resource(s)

### DIFF
--- a/atc/lidar/lidar_test.go
+++ b/atc/lidar/lidar_test.go
@@ -1,1 +1,0 @@
-package lidar_test

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -77,12 +77,6 @@ func (s *buildStarter) TryStartPendingBuildsForJob(
 			continue
 		}
 
-		if !results.scheduled {
-			// If max in flight is reached, stop scheduling and retry later
-			needsRetry = true
-			break
-		}
-
 		if !results.readyToDetermineInputs {
 			// Issue checks, stop scheduling, retry later
 			needsRetry = true
@@ -90,6 +84,12 @@ func (s *buildStarter) TryStartPendingBuildsForJob(
 			if err != nil {
 				return false, err
 			}
+			break
+		}
+
+		if !results.scheduled {
+			// If max in flight is reached, stop scheduling and retry later
+			needsRetry = true
 			break
 		}
 
@@ -207,8 +207,9 @@ func (s *buildStarter) createChecks(logger lager.Logger, job db.Job, build Build
 				)
 				if err != nil {
 					logger.Error("buildstarter-checking-resource", err, lager.Data{
-						"job_id":      job.ID(),
-						"resource_id": resource.ID(),
+						"pipeline": job.PipelineName(),
+						"job":      job.Name(),
+						"resource": resource.Name(),
 					})
 				}
 			}(resource)

--- a/testflight/fixtures/serial-groups.yml
+++ b/testflight/fixtures/serial-groups.yml
@@ -12,6 +12,12 @@ resources:
     # this initial version is to make it unique and isnt really used
     initial_version: ((hash))
 
+- name: check-never
+  type: mock
+  check_every: never
+  source:
+    initial_version: ((hash))
+
 jobs:
 - name: some-passing-job
   serial_groups: [serial-group-1]
@@ -22,3 +28,8 @@ jobs:
   serial_groups: [serial-group-1]
   plan:
   - get: pending-resource
+
+- name: serial-true-job
+  serial: true
+  plan:
+    - get: check-never

--- a/testflight/serial_groups_test.go
+++ b/testflight/serial_groups_test.go
@@ -93,4 +93,13 @@ var _ = Describe("serial groups", func() {
 			Expect(pendingS).To(gbytes.Say(guid3))
 		}, DefaultSpecTimeout)
 	})
+
+	Context("when a resource has check_every never configured", func() {
+		It("checks the resource and runs the job", func(ctx SpecContext) {
+			setAndUnpausePipeline("fixtures/serial-groups.yml", "-v", "hash="+hash)
+			By("kicking off serial-true-job")
+			sess := fly("trigger-job", "-j", inPipeline("serial-true-job"), "-w")
+			Eventually(sess).To(gexec.Exit(0))
+		}, DefaultSpecTimeout)
+	})
 })

--- a/testflight/serial_groups_test.go
+++ b/testflight/serial_groups_test.go
@@ -32,7 +32,7 @@ var _ = Describe("serial groups", func() {
 
 		AfterEach(func() {
 			pendingS.Signal(os.Interrupt)
-			<-pendingS.Exited
+			Eventually(pendingS).Should(gexec.Exit())
 		})
 
 		It("runs even when another job in the serial group has a pending build", func(ctx SpecContext) {
@@ -87,8 +87,7 @@ var _ = Describe("serial groups", func() {
 			guid3 := newMockVersion("other-resource", "other-1")
 
 			By("waiting for some-pending-job to finally run")
-			<-pendingS.Exited
-			Expect(pendingS.ExitCode()).To(Equal(0))
+			Eventually(pendingS).Should(gexec.Exit(0))
 			Expect(pendingS).To(gbytes.Say(guid2))
 			Expect(pendingS).To(gbytes.Say(guid3))
 		}, DefaultSpecTimeout)

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -282,18 +282,18 @@ func spawnIn(dir string, argc string, argv ...string) *gexec.Session {
 }
 
 func wait(session *gexec.Session, allowNonZero bool) {
-	<-session.Exited
-	if !allowNonZero {
-		Expect(session.ExitCode()).To(Equal(0), "Output: "+string(session.Out.Contents()))
+	if allowNonZero {
+		Eventually(session).Should(gexec.Exit())
+		return
 	}
+	Eventually(session).Should(gexec.Exit(0))
 }
 
 var colSplit = regexp.MustCompile(`\s{2,}`)
 
 func flyTable(argv ...string) []map[string]string {
 	session := spawnFly(append([]string{"--print-table-headers"}, argv...)...)
-	<-session.Exited
-	Expect(session.ExitCode()).To(Equal(0))
+	Eventually(session).Should(gexec.Exit(0))
 
 	result := []map[string]string{}
 	var headers []string


### PR DESCRIPTION
## Changes proposed by this PR

closes #9665

Changed when we check if the builds max_in_flight has been reached to
**after** checking if inputs need to be determined. This unblocks jobs with
`serial: true` because they would be blocked forever because their
inputs never get determined.

I've added a testflight case that covers this specific scenraio, which
involves an input resource having `check_every: never` configured.

I updated the log line in buildstarter as well to be more useful since
the raw IDs are hard to translate to pipeline/job names without having
access to the database.