### PR TITLE
testflight: refactor to use Eventually() everywhere we were blocking on a bare channel

### DIFF
--- a/testflight/container_hermetic_test.go
+++ b/testflight/container_hermetic_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("A job with a task that has hermetic set to true", func() {
@@ -12,16 +13,16 @@ var _ = Describe("A job with a task that has hermetic set to true", func() {
 		setAndUnpausePipeline("fixtures/container_hermetic.yml")
 
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-hermetic-job"), "-w")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit())
 
 		if config.Runtime == "containerd" {
 			By("containerd runtime it should fail to establish a network connection")
 			Expect(watch).To(gbytes.Say("1 packets transmitted, 0 packets received, 100% packet loss"))
-			Expect(watch.ExitCode()).ToNot(Equal(0))
+			Expect(watch).To(gexec.Exit(1))
 		} else {
 			By("guardian runtime it should succeed in establishing network connection")
 			Expect(watch).To(gbytes.Say("1 packets transmitted, 1 packets received, 0% packet loss"))
-			Expect(watch.ExitCode()).To(Equal(0))
+			Expect(watch).To(gexec.Exit(0))
 		}
 	}, DefaultSpecTimeout)
 })

--- a/testflight/container_limits_test.go
+++ b/testflight/container_limits_test.go
@@ -14,7 +14,7 @@ var _ = Describe("A job with a task that has container limits", func() {
 		setAndUnpausePipeline("fixtures/container_limits.yml")
 
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-limits-job"), "-w")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit())
 
 		match, _ := regexp.MatchString(`open /sys/fs/cgroup/memory/.*/memory\.memsw\.limit_in_bytes: (permission denied)?(no such file or directory)?`,
 			string(watch.Out.Contents()))
@@ -36,7 +36,7 @@ var _ = Describe("A job with a task that has container limits", func() {
 		setAndUnpausePipeline("fixtures/container_limits_failing.yml")
 
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-limits-failing-job"), "-w")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit())
 
 		match, _ := regexp.MatchString(`open /sys/fs/cgroup/memory/.*/memory\.memsw\.limit_in_bytes: (permission denied)?(no such file or directory)?`,
 			string(watch.Out.Contents()))

--- a/testflight/containers_scoped_to_team_test.go
+++ b/testflight/containers_scoped_to_team_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Intercepting containers", func() {
@@ -29,8 +30,7 @@ var _ = Describe("Intercepting containers", func() {
 		for _, handle := range handles {
 			withFlyTarget(testflightGuestFlyTarget, func() {
 				intercept := spawnFly("intercept", "--handle", handle, "hostname")
-				<-intercept.Exited
-				Expect(intercept.ExitCode()).ToNot(Equal(0))
+				Eventually(intercept).Should(gexec.Exit(1))
 				Expect(intercept.Err).To(gbytes.Say("no containers matched the given handle id"))
 			})
 		}
@@ -38,7 +38,7 @@ var _ = Describe("Intercepting containers", func() {
 		By("stopping the build")
 		fly("intercept", "-j", inPipeline("wait"), "-s", "wait-for-intercept", "touch", "/tmp/stop-waiting")
 
-		<-wait.Exited
+		Eventually(wait).Should(gexec.Exit(0))
 		Expect(wait).To(gbytes.Say("done"))
 	}, DefaultSpecTimeout)
 })

--- a/testflight/fail_test.go
+++ b/testflight/fail_test.go
@@ -14,9 +14,8 @@ var _ = Describe("A job with a task that always fails", func() {
 
 	It("causes the build to fail", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("failing-job"), "-w")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit(1))
 		Expect(watch).To(gbytes.Say("initializing"))
 		Expect(watch).To(gbytes.Say("failed"))
-		Expect(watch).To(gexec.Exit(1))
 	}, DefaultSpecTimeout)
 })

--- a/testflight/hooks_test.go
+++ b/testflight/hooks_test.go
@@ -15,12 +15,11 @@ var _ = Describe("A pipeline containing jobs with hooks", func() {
 	It("performs hooks under the right conditions", func(ctx SpecContext) {
 		By("performing ensure and on_success outputs on success")
 		watch := spawnFly("trigger-job", "-j", inPipeline("some-passing-job"), "-w")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit(0))
 		Expect(watch).To(gbytes.Say("passing job on success"))
 		Expect(watch).To(gbytes.Say("passing job ensure"))
 		Expect(watch).To(gbytes.Say("passing job on job success"))
 		Expect(watch).To(gbytes.Say("passing job on job ensure"))
-		Expect(watch).To(gexec.Exit(0))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("passing job on failure"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("passing job on job failure"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("passing job on abort"))
@@ -30,12 +29,11 @@ var _ = Describe("A pipeline containing jobs with hooks", func() {
 
 		By("performing ensure and on_failure steps on failure")
 		watch = spawnFly("trigger-job", "-j", inPipeline("some-failing-job"), "-w")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit(1))
 		Expect(watch).To(gbytes.Say("failing job on failure"))
 		Expect(watch).To(gbytes.Say("failing job ensure"))
 		Expect(watch).To(gbytes.Say("failing job on job failure"))
 		Expect(watch).To(gbytes.Say("failing job on job ensure"))
-		Expect(watch).To(gexec.Exit(1))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("failing job on success"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("failing job on job success"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("failing job on abort"))
@@ -49,12 +47,11 @@ var _ = Describe("A pipeline containing jobs with hooks", func() {
 		Eventually(watch).Should(gbytes.Say("echo waiting to be aborted"))
 		Eventually(watch).Should(gbytes.Say("waiting to be aborted"))
 		fly("abort-build", "-j", inPipeline("some-aborted-job"), "-b", "1")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit(3))
 		Expect(watch).To(gbytes.Say("aborted job on abort"))
 		Expect(watch).To(gbytes.Say("aborted job ensure"))
 		Expect(watch).To(gbytes.Say("aborted job on job abort"))
 		Expect(watch).To(gbytes.Say("aborted job on job ensure"))
-		Expect(watch).To(gexec.Exit(3))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("aborted job on success"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("aborted job on job success"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("aborted job on failure"))
@@ -64,12 +61,11 @@ var _ = Describe("A pipeline containing jobs with hooks", func() {
 
 		By("performing ensure and on_error steps on error")
 		watch = spawnFly("trigger-job", "-j", inPipeline("some-errored-job"), "-w")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit(2))
 		Expect(watch).To(gbytes.Say("errored job on error"))
 		Expect(watch).To(gbytes.Say("errored job ensure"))
 		Expect(watch).To(gbytes.Say("errored job on job error"))
 		Expect(watch).To(gbytes.Say("errored job on job ensure"))
-		Expect(watch).To(gexec.Exit(2))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("errored job on success"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("errored job on job success"))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("errored job on failure"))

--- a/testflight/matrix_test.go
+++ b/testflight/matrix_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("A job with a complicated build plan", func() {
@@ -24,8 +25,7 @@ var _ = Describe("A job with a complicated build plan", func() {
 
 	It("executes the build plan correctly", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("fancy-build-matrix"), "-w")
-		<-watch.Exited
-		Expect(watch.ExitCode()).To(Equal(1)) // expect failure
+		Eventually(watch).Should(gexec.Exit(1))
 		Expect(watch).To(gbytes.Say("passing-unit-1/file passing-unit-2/file " + initialVersion))
 		Expect(watch).To(gbytes.Say("failed in_parallel " + initialVersion))
 	}, DefaultSpecTimeout)

--- a/testflight/prototype_test.go
+++ b/testflight/prototype_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Pipeline with prototypes", func() {
@@ -13,9 +12,7 @@ var _ = Describe("Pipeline with prototypes", func() {
 	})
 
 	It("executes the build plan correctly", func(ctx SpecContext) {
-		watch := spawnFly("trigger-job", "-j", inPipeline("job"), "-w")
-		<-watch.Exited
-		Expect(watch).To(gexec.Exit(0))
+		watch := fly("trigger-job", "-j", inPipeline("job"), "-w")
 
 		// XXX(prototypes): eventually, this'll need to test the real implementation
 		Expect(watch).To(gbytes.Say("run some-message on prototype some-prototype"))

--- a/testflight/put_inputs_test.go
+++ b/testflight/put_inputs_test.go
@@ -13,8 +13,7 @@ var _ = Describe("A put step with inputs", func() {
 
 	Context("when specific inputs are specified", func() {
 		It("attaches only the specified inputs to the put container", func(ctx SpecContext) {
-			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-specified-inputs"), "-w")
-			<-watch.Exited
+			flyUnsafe("trigger-job", "-j", inPipeline("job-using-specified-inputs"), "-w")
 
 			interceptS := fly("intercept", "-j", inPipeline("job-using-specified-inputs"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 			Expect(interceptS).To(gbytes.Say("specified-input"))
@@ -24,8 +23,7 @@ var _ = Describe("A put step with inputs", func() {
 
 	Context("when it uses all inputs", func() {
 		It("attached all inputs to the put container", func(ctx SpecContext) {
-			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-all-inputs"), "-w")
-			<-watch.Exited
+			flyUnsafe("trigger-job", "-j", inPipeline("job-using-all-inputs"), "-w")
 
 			interceptS := fly("intercept", "-j", inPipeline("job-using-all-inputs"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 			Expect(string(interceptS.Out.Contents())).To(ContainSubstring("all-input"))
@@ -35,8 +33,7 @@ var _ = Describe("A put step with inputs", func() {
 
 	Context("when an empty slice of inputs are specified", func() {
 		It("no inputs are attached to the put container", func(ctx SpecContext) {
-			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-empty-inputs"), "-w")
-			<-watch.Exited
+			flyUnsafe("trigger-job", "-j", inPipeline("job-using-empty-inputs"), "-w")
 
 			interceptS := fly("intercept", "-j", inPipeline("job-using-empty-inputs"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 			Expect(string(interceptS.Out.Contents())).ToNot(ContainSubstring("all-input"))
@@ -46,8 +43,7 @@ var _ = Describe("A put step with inputs", func() {
 
 	Context("when no inputs are specified", func() {
 		It("attaches only the detected inputs to the put container", func(ctx SpecContext) {
-			watch := spawnFly("trigger-job", "-j", inPipeline("job-using-no-inputs"), "-w")
-			<-watch.Exited
+			flyUnsafe("trigger-job", "-j", inPipeline("job-using-no-inputs"), "-w")
 
 			interceptS := fly("intercept", "-j", inPipeline("job-using-no-inputs"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 			logs := string(interceptS.Out.Contents())
@@ -59,8 +55,7 @@ var _ = Describe("A put step with inputs", func() {
 	Context("when inputs are detected", func() {
 		Context("when params are only strings", func() {
 			It("attaches only the detected inputs to the put container", func(ctx SpecContext) {
-				watch := spawnFly("trigger-job", "-j", inPipeline("job-using-detect-inputs-simple"), "-w")
-				<-watch.Exited
+				flyUnsafe("trigger-job", "-j", inPipeline("job-using-detect-inputs-simple"), "-w")
 
 				interceptS := fly("intercept", "-j", inPipeline("job-using-detect-inputs-simple"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 				Expect(string(interceptS.Out.Contents())).To(ContainSubstring("specified-input"))
@@ -70,8 +65,7 @@ var _ = Describe("A put step with inputs", func() {
 
 		Context("when params have slices and maps", func() {
 			It("attaches the inputs detected in the slices", func(ctx SpecContext) {
-				watch := spawnFly("trigger-job", "-j", inPipeline("job-using-detect-inputs-complex"), "-w")
-				<-watch.Exited
+				flyUnsafe("trigger-job", "-j", inPipeline("job-using-detect-inputs-complex"), "-w")
 
 				interceptS := fly("intercept", "-j", inPipeline("job-using-detect-inputs-complex"), "-s", "some-resource", "--step-type", "put", "--", "ls")
 				Expect(string(interceptS.Out.Contents())).To(ContainSubstring("specified-input"))

--- a/testflight/resource_check_test.go
+++ b/testflight/resource_check_test.go
@@ -43,8 +43,7 @@ var _ = Describe("Checking a resource", func() {
 
 		It("shows the check status failed", func(ctx SpecContext) {
 			check := spawnFly("check-resource", "-r", inPipeline("my-resource"))
-			<-check.Exited
-			Expect(check).To(gexec.Exit(1))
+			Eventually(check).Should(gexec.Exit(1))
 			Expect(check).To(gbytes.Say("super broken"))
 			Expect(check).To(gbytes.Say("failed"))
 

--- a/testflight/resource_check_timeout_test.go
+++ b/testflight/resource_check_timeout_test.go
@@ -30,8 +30,7 @@ var _ = Describe("A resource check which times out", func() {
 
 		It("prints an error and cancels the check", func(ctx SpecContext) {
 			check := spawnFly("check-resource", "-r", inPipeline("my-resource"))
-			<-check.Exited
-			Expect(check).To(gexec.Exit(1))
+			Eventually(check).Should(gexec.Exit(1))
 			Expect(check).To(gbytes.Say("timeout exceeded"))
 			Expect(check).To(gbytes.Say("failed"))
 		}, DefaultSpecTimeout)

--- a/testflight/retry_test.go
+++ b/testflight/retry_test.go
@@ -28,8 +28,7 @@ var _ = Describe("A job with a step that retries", func() {
 		BeforeEach(func() {
 			watch := spawnFly("trigger-job", "-j", inPipeline("retry-job-fail-for-hijacking"), "-w")
 			// wait until job finishes before trying to hijack
-			<-watch.Exited
-			Expect(watch).To(gexec.Exit(1))
+			Eventually(watch).Should(gexec.Exit(1))
 		})
 
 		It("permits hijacking a specific attempt", func(ctx SpecContext) {

--- a/testflight/set-pipeline-step_test.go
+++ b/testflight/set-pipeline-step_test.go
@@ -51,8 +51,7 @@ var _ = Describe("set-pipeline Step", func() {
 		It("sets the other pipeline", func(ctx SpecContext) {
 			By("second pipeline should initially not exist")
 			execS := spawnFly("get-pipeline", "-p", createdPipelineName)
-			<-execS.Exited
-			Expect(execS).To(gexec.Exit(1))
+			Eventually(execS).Should(gexec.Exit(1))
 			Expect(execS.Err).To(gbytes.Say("pipeline not found"))
 
 			By("set-pipeline step should succeed")
@@ -73,8 +72,7 @@ var _ = Describe("set-pipeline Step", func() {
 			It("sets the other pipeline as instanced pipeline", func(ctx SpecContext) {
 				By("second pipeline should initially not exist")
 				execS := spawnFly("get-pipeline", "-p", createdPipelineName+currentInstanceVars)
-				<-execS.Exited
-				Expect(execS).To(gexec.Exit(1))
+				Eventually(execS).Should(gexec.Exit(1))
 				Expect(execS.Err).To(gbytes.Say("pipeline not found"))
 
 				By("set-pipeline step should succeed")
@@ -99,8 +97,7 @@ var _ = Describe("set-pipeline Step", func() {
 			By("second pipeline should initially not exist")
 			withFlyTarget(testflightFlyTarget, func() {
 				execS := spawnFly("get-pipeline", "-p", createdPipelineName)
-				<-execS.Exited
-				Expect(execS).To(gexec.Exit(1))
+				Eventually(execS).Should(gexec.Exit(1))
 				Expect(execS.Err).To(gbytes.Say("pipeline not found"))
 			})
 
@@ -135,16 +132,14 @@ var _ = Describe("set-pipeline Step", func() {
 			By("second pipeline should initially not exist")
 			withFlyTarget(adminFlyTarget, func() {
 				execS := spawnFly("get-pipeline", "-p", createdPipelineName)
-				<-execS.Exited
-				Expect(execS).To(gexec.Exit(1))
+				Eventually(execS).Should(gexec.Exit(1))
 				Expect(execS.Err).To(gbytes.Say("pipeline not found"))
 			})
 
 			By("set-pipeline step should fail")
 			withFlyTarget(testflightFlyTarget, func() {
 				execS := spawnFly("trigger-job", "-w", "-j", pipelineName+"/sp")
-				<-execS.Exited
-				Expect(execS).To(gexec.Exit(2))
+				Eventually(execS).Should(gexec.Exit(2))
 				Expect(execS.Out).To(gbytes.Say("only main team can set another team's pipeline"))
 				Expect(execS.Out).To(gbytes.Say("errored"))
 			})
@@ -152,8 +147,7 @@ var _ = Describe("set-pipeline Step", func() {
 			By("second pipeline should still not exist")
 			withFlyTarget(adminFlyTarget, func() {
 				execS := spawnFly("get-pipeline", "-p", createdPipelineName)
-				<-execS.Exited
-				Expect(execS).To(gexec.Exit(1))
+				Eventually(execS).Should(gexec.Exit(1))
 				Expect(execS.Err).To(gbytes.Say("pipeline not found"))
 			})
 		})

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -63,8 +63,6 @@ func TestTestflight(t *testing.T) {
 	RunSpecs(t, "TestFlight Suite")
 }
 
-const DefaultSpecTimeout = SpecTimeout(6 * time.Minute)
-
 var _ = SynchronizedBeforeSuite(func() []byte {
 	atcURL := os.Getenv("ATC_URL")
 	if atcURL != "" {
@@ -144,6 +142,8 @@ var _ = SynchronizedAfterSuite(func() {
 	os.Remove(config.FlyBin)
 })
 
+const DefaultSpecTimeout = SpecTimeout(6 * time.Minute)
+
 var _ = BeforeEach(func() {
 	SetDefaultEventuallyTimeout(5 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
@@ -194,6 +194,8 @@ func randomPipelineName() string {
 	return fmt.Sprintf("%s-%d-%s", pipelinePrefix, GinkgoParallelProcess(), guid)
 }
 
+// Runs the fly command and waits for it to Exit. Will fail the test if exit
+// code is non-zero
 func fly(argv ...string) *gexec.Session {
 	sess := spawnFly(argv...)
 	wait(sess, false)
@@ -206,6 +208,8 @@ func flyIn(dir string, argv ...string) *gexec.Session {
 	return sess
 }
 
+// Runs the fly command and waits for it to Exit. Only fails the test if the
+// command fails to exit before the timeout
 func flyUnsafe(argv ...string) *gexec.Session {
 	sess := spawnFly(argv...)
 	wait(sess, true)
@@ -362,7 +366,7 @@ func waitForBuildAndWatch(jobName string, buildName ...string) *gexec.Session {
 	keepPollingCheck := regexp.MustCompile("job has no builds|build not found|failed to get build")
 	for {
 		session := spawnFly(args...)
-		<-session.Exited
+		Eventually(session).Should(gexec.Exit())
 
 		if session.ExitCode() == 1 {
 			output := strings.TrimSpace(string(session.Err.Contents()))

--- a/testflight/task_missing_outputs_test.go
+++ b/testflight/task_missing_outputs_test.go
@@ -14,8 +14,7 @@ var _ = Describe("A task with no outputs declared", func() {
 
 	It("doesn't mount its file system into the next task", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("missing-outputs-job"), "-w")
-		<-watch.Exited
-		Expect(watch).To(gexec.Exit(2))
+		Eventually(watch).Should(gexec.Exit(2))
 		Expect(watch).To(gbytes.Say("missing inputs: missing-outputs"))
 	}, DefaultSpecTimeout)
 })

--- a/testflight/task_vars_test.go
+++ b/testflight/task_vars_test.go
@@ -91,8 +91,7 @@ run:
 		Context("when not all required vars are passed from the pipeline", func() {
 			It("fails pipeline job with external task due to an uninterpolated variable", func(ctx SpecContext) {
 				execS := spawnFly("trigger-job", "-w", "-j", pipelineName+"/external-task-failure")
-				<-execS.Exited
-				Expect(execS).To(gexec.Exit(2))
+				Eventually(execS).Should(gexec.Exit(2))
 				Expect(execS.Out).To(gbytes.Say("undefined vars: echo_text"))
 			}, DefaultSpecTimeout)
 		})
@@ -124,8 +123,7 @@ echo_text: Hello World From Command Line
 		Context("when not all required vars are passed from command line", func() {
 			It("fails external task via fly execute due to an uninterpolated variable", func(ctx SpecContext) {
 				execS := spawnFlyIn(fixture, "execute", "-c", "task.yml", "-v", "image_resource_type=mock")
-				<-execS.Exited
-				Expect(execS).To(gexec.Exit(2))
+				Eventually(execS).Should(gexec.Exit(2))
 				Expect(execS.Out).To(gbytes.Say("undefined vars: echo_text"))
 			}, DefaultSpecTimeout)
 		})

--- a/testflight/timeout_hooks_test.go
+++ b/testflight/timeout_hooks_test.go
@@ -14,10 +14,9 @@ var _ = Describe("A pipeline containing a job with a timeout and hooks", func() 
 
 	It("runs the failure and ensure hooks", func(ctx SpecContext) {
 		watch := spawnFly("trigger-job", "-j", inPipeline("duration-fail-job"), "-w")
-		<-watch.Exited
+		Eventually(watch).Should(gexec.Exit(1))
 		Expect(watch).To(gbytes.Say("duration fail job on failure"))
 		Expect(watch).To(gbytes.Say("duration fail job ensure"))
-		Expect(watch).To(gexec.Exit(1))
 		Expect(watch.Out.Contents()).NotTo(ContainSubstring("duration fail job on success"))
 	}, DefaultSpecTimeout)
 })

--- a/testflight/timeout_test.go
+++ b/testflight/timeout_test.go
@@ -17,15 +17,13 @@ var _ = Describe("A job with a task with a timeout", func() {
 		failedWatch := spawnFly("trigger-job", "-j", inPipeline("duration-fail-job"), "-w")
 
 		By("not aborting if the step completes in time")
-		<-successWatch.Exited
+		Eventually(successWatch).Should(gexec.Exit(0))
 		Expect(successWatch).To(gbytes.Say("initializing"))
 		Expect(successWatch).To(gbytes.Say("passing-task succeeded"))
-		Expect(successWatch).To(gexec.Exit(0))
 
 		By("aborting when the step takes too long")
-		<-failedWatch.Exited
+		Eventually(failedWatch).Should(gexec.Exit(1))
 		Expect(failedWatch).To(gbytes.Say("initializing"))
 		Expect(failedWatch).To(gbytes.Say("timeout exceeded"))
-		Expect(failedWatch).To(gexec.Exit(1))
 	}, DefaultSpecTimeout)
 })

--- a/testflight/user_lookup_test.go
+++ b/testflight/user_lookup_test.go
@@ -11,8 +11,6 @@ var _ = Describe("user lookup", func() {
 		It("runs as root", func(ctx SpecContext) {
 			// clearlinux doesn't have an /etc/passwd file
 			session := fly("execute", "-c", "fixtures/clearlinux.yml")
-			<-session.Exited
-			Expect(session.ExitCode()).To(Equal(0))
 			Expect(session.Out).To(gbytes.Say("running as root"))
 		}, DefaultSpecTimeout)
 	})


### PR DESCRIPTION
## Changes proposed by this PR

Makes the errors cleaner to read. The suite already has a default timeout for `Eventually()` of 5mins and each spec has a timeout of 6mins.