### PR TITLE
Revert "add support for shared path in Conjur"

### DIFF
--- a/atc/creds/conjur/conjur.go
+++ b/atc/creds/conjur/conjur.go
@@ -15,15 +15,13 @@ type Conjur struct {
 	log             lager.Logger
 	client          IConjurClient
 	secretTemplates []*creds.SecretTemplate
-	sharedPath      string
 }
 
-func NewConjur(log lager.Logger, client IConjurClient, secretTemplates []*creds.SecretTemplate, sharedPath string) *Conjur {
+func NewConjur(log lager.Logger, client IConjurClient, secretTemplates []*creds.SecretTemplate) *Conjur {
 	return &Conjur{
 		log:             log,
 		client:          client,
 		secretTemplates: secretTemplates,
-		sharedPath:      sharedPath,
 	}
 }
 
@@ -34,9 +32,6 @@ func (c Conjur) NewSecretLookupPaths(teamName string, pipelineName string, allow
 		if lPath := creds.NewSecretLookupWithTemplate(template, teamName, pipelineName); lPath != nil {
 			lookupPaths = append(lookupPaths, lPath)
 		}
-	}
-	if c.sharedPath != "" {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(c.sharedPath+"/"))
 	}
 
 	return lookupPaths

--- a/atc/creds/conjur/conjur_factory.go
+++ b/atc/creds/conjur/conjur_factory.go
@@ -11,18 +11,16 @@ type conjurFactory struct {
 	log             lager.Logger
 	client          *conjurapi.Client
 	secretTemplates []*creds.SecretTemplate
-	sharedPath      string
 }
 
-func NewConjurFactory(log lager.Logger, client *conjurapi.Client, secretTemplates []*creds.SecretTemplate, sharedPath string) *conjurFactory {
+func NewConjurFactory(log lager.Logger, client *conjurapi.Client, secretTemplates []*creds.SecretTemplate) *conjurFactory {
 	return &conjurFactory{
 		log:             log,
 		client:          client,
 		secretTemplates: secretTemplates,
-		sharedPath:      sharedPath,
 	}
 }
 
 func (factory *conjurFactory) NewSecrets() creds.Secrets {
-	return NewConjur(factory.log, factory.client, factory.secretTemplates, factory.sharedPath)
+	return NewConjur(factory.log, factory.client, factory.secretTemplates)
 }

--- a/atc/creds/conjur/conjur_test.go
+++ b/atc/creds/conjur/conjur_test.go
@@ -36,19 +36,16 @@ var _ = Describe("Conjur", func() {
 	var variables vars.Variables
 	var varRef vars.Reference
 	var mockService MockConjurService
-	var t1 *creds.SecretTemplate
-	var t2 *creds.SecretTemplate
 
 	JustBeforeEach(func() {
 		varRef = vars.Reference{Path: "cheery"}
-		var err error
-		t1, err = creds.BuildSecretTemplate("t1", DefaultPipelineSecretTemplate)
+		t1, err := creds.BuildSecretTemplate("t1", DefaultPipelineSecretTemplate)
 		Expect(t1).NotTo(BeNil())
 		Expect(err).To(BeNil())
-		t2, err = creds.BuildSecretTemplate("t2", DefaultTeamSecretTemplate)
+		t2, err := creds.BuildSecretTemplate("t2", DefaultTeamSecretTemplate)
 		Expect(t2).NotTo(BeNil())
 		Expect(err).To(BeNil())
-		secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{t1, t2}, "")
+		secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{t1, t2})
 		variables = creds.NewVariables(secretAccess, creds.SecretLookupParams{Team: "alpha", Pipeline: "bogus"}, false)
 		Expect(secretAccess).NotTo(BeNil())
 		mockService.stubGetParameter = func(input string) ([]byte, error) {
@@ -101,7 +98,7 @@ var _ = Describe("Conjur", func() {
 		})
 
 		It("should allow full variable path when no templates were configured", func() {
-			secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{}, "")
+			secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{})
 			variables := creds.NewVariables(secretAccess, creds.SecretLookupParams{Team: "", Pipeline: ""}, false)
 			mockService.stubGetParameter = func(input string) ([]byte, error) {
 				Expect(input).To(Equal("cheery"))
@@ -109,21 +106,6 @@ var _ = Describe("Conjur", func() {
 			}
 			value, found, err := variables.Get(varRef)
 			Expect(value).To(BeEquivalentTo("full path secret"))
-			Expect(found).To(BeTrue())
-			Expect(err).To(BeNil())
-		})
-
-		It("should get shared parameter if exists", func() {
-			secretAccess = NewConjur(lager.NewLogger("conjur_test"), &mockService, []*creds.SecretTemplate{t1, t2}, "concourse/shared")
-			variables := creds.NewVariables(secretAccess, creds.SecretLookupParams{Team: "alpha", Pipeline: "bogus"}, false)
-			mockService.stubGetParameter = func(input string) ([]byte, error) {
-				if input != "concourse/shared/cheery" {
-					return nil, errors.New("Variable not found")
-				}
-				return []byte("shared secret"), nil
-			}
-			value, found, err := variables.Get(varRef)
-			Expect(value).To(BeEquivalentTo("shared secret"))
 			Expect(found).To(BeTrue())
 			Expect(err).To(BeNil())
 		})

--- a/atc/creds/conjur/manager.go
+++ b/atc/creds/conjur/manager.go
@@ -26,7 +26,6 @@ type Manager struct {
 	PipelineSecretTemplate string `long:"pipeline-secret-template" description:"Conjur secret identifier template used for pipeline specific parameter" default:"concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"`
 	TeamSecretTemplate     string `long:"team-secret-template" description:"Conjur secret identifier template used for team specific parameter" default:"concourse/{{.Team}}/{{.Secret}}"`
 	SecretTemplate         string `long:"secret-template" description:"Conjur secret identifier template used for full path conjur secrets" default:"vaultName/{{.Secret}}"`
-	SharedPath             string `long:"shared-path" description:"Path under which to lookup shared credentials"`
 	Conjur                 *Conjur
 }
 
@@ -60,9 +59,8 @@ func (manager *Manager) Init(log lager.Logger) error {
 	}
 
 	manager.Conjur = &Conjur{
-		log:        log,
-		client:     conjur,
-		sharedPath: manager.SharedPath,
+		log:    log,
+		client: conjur,
 	}
 
 	return nil
@@ -143,7 +141,7 @@ func (manager *Manager) NewSecretsFactory(log lager.Logger) (creds.SecretsFactor
 		return nil, err
 	}
 
-	return NewConjurFactory(log, client, []*creds.SecretTemplate{pipelineSecretTemplate, teamSecretTemplate, secretTemplate}, manager.SharedPath), nil
+	return NewConjurFactory(log, client, []*creds.SecretTemplate{pipelineSecretTemplate, teamSecretTemplate, secretTemplate}), nil
 }
 
 func (manager Manager) Close(logger lager.Logger) {


### PR DESCRIPTION
Reverts concourse/concourse#9651

Kevin noted here: https://github.com/concourse/docs/pull/616#discussion_r3700257850
That the existing config `CONCOURSE_CONJUR_SECRET_TEMPLATE` appears to be functional as a shared path. The only difference I see is in the default values. Actually it probably shouldn't even have a default value since that could catch an operator by disguise.

@AndrewCopeland You initially added this code https://github.com/concourse/concourse/pull/4693
I know you're probably very far removed from Concourse and potentially Conjur now too, but are you able to recall what the intention of `SecretTemplate` is: https://github.com/concourse/concourse/blob/0ccc29ab5ef3ddd8423609e3e0c3758df7b74b46/atc/creds/conjur/manager.go#L28

**Is `SecretTemplate` meant to be a "shared path" lookup?**