### PR TITLE
improve type casting and checking in vault client

### DIFF
--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -89,7 +89,11 @@ func (ac *APIClient) Read(path string) (*vaultapi.Secret, error) {
 	// Need to discard the metadata object and pull the v2 data field up to match kv1
 	if kv2 {
 		if data, ok := secret.Data["data"]; ok && data != nil {
-			secret.Data = data.(map[string]any)
+			dataMap, ok := data.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("unexpected data type %T in vault response for path %q", data, path)
+			}
+			secret.Data = dataMap
 			secret.LeaseDuration = -1
 		} else {
 			// Return a nil secret object if the secret was deleted, but not destroyed
@@ -243,6 +247,12 @@ func (ac *APIClient) Login() (time.Duration, error) {
 		return time.Second, err
 	}
 
+	if secret == nil || secret.Auth == nil {
+		err := fmt.Errorf("unexpected vault login response")
+		logger.Error("vault-login-auth-missing", err)
+		return time.Second, err
+	}
+
 	logger.Info("succeeded", lager.Data{
 		"token-accessor": secret.Auth.Accessor,
 		"lease-duration": secret.Auth.LeaseDuration,
@@ -306,6 +316,12 @@ func (ac *APIClient) Renew() (time.Duration, error) {
 			return time.Second, nil
 		}
 		logger.Error("failed", err)
+		return time.Second, err
+	}
+
+	if secret == nil || secret.Auth == nil {
+		err := fmt.Errorf("unexpected vault renew response")
+		logger.Error("vault-renew-auth-missing", err)
 		return time.Second, err
 	}
 

--- a/atc/creds/vault/vault_kvhelpers.go
+++ b/atc/creds/vault/vault_kvhelpers.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"errors"
+	"fmt"
 	"path"
 	"strings"
 
@@ -42,17 +43,27 @@ func kvPreflightVersionRequest(client *api.Client, path string) (string, int, er
 	}
 	var mountPath string
 	if mountPathRaw, ok := secret.Data["path"]; ok {
-		mountPath = mountPathRaw.(string)
+		mountPath, ok = mountPathRaw.(string)
+		if !ok {
+			return "", 0, fmt.Errorf("unexpected type %T for mount path in vault pre-flight response", mountPathRaw)
+		}
 	}
 	options := secret.Data["options"]
 	if options == nil {
 		return mountPath, 1, nil
 	}
-	versionRaw := options.(map[string]any)["version"]
+	optionsMap, ok := options.(map[string]any)
+	if !ok {
+		return "", 0, fmt.Errorf("unexpected type %T for options in vault pre-flight response", options)
+	}
+	versionRaw := optionsMap["version"]
 	if versionRaw == nil {
 		return mountPath, 1, nil
 	}
-	version := versionRaw.(string)
+	version, ok := versionRaw.(string)
+	if !ok {
+		return "", 0, fmt.Errorf("unexpected type %T for version in vault pre-flight response", versionRaw)
+	}
 	switch version {
 	case "", "1":
 		return mountPath, 1, nil


### PR DESCRIPTION
## Changes proposed by this PR

The vault client package has a few places where it does type cast and we weren't checking if these conversions were successful for not. This could result in panics if we got some malformed response from the Vault server.