### PR TITLE
web: instance groups: add list view favorites

### DIFF
--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1441,8 +1441,61 @@ cardsView session params teamCards =
             params.highDensity && not noPipelines
 
         ( headerView, offsetHeight ) =
-            if (highDensity && not viewingInstanceGroups) || (params.groupListView && viewingInstanceGroups) then
+            if highDensity && not viewingInstanceGroups then
                 ( [], 0 )
+
+            else if params.groupListView && viewingInstanceGroups then
+                let
+                    favoritedSections =
+                        teamCards
+                            |> List.map
+                                (\section ->
+                                    { section
+                                        | cards =
+                                            List.filter
+                                                (\c ->
+                                                    case c of
+                                                        PipelineCard p ->
+                                                            Favorites.isPipelineFavorited session p
+
+                                                        InstancedPipelineCard p ->
+                                                            Favorites.isPipelineFavorited session p
+
+                                                        InstanceGroupCard p _ ->
+                                                            Favorites.isInstanceGroupFavorited session (Concourse.toInstanceGroupId p)
+                                                )
+                                                section.cards
+                                    }
+                                )
+                            |> List.filter (\s -> not (List.isEmpty s.cards))
+
+                    allPipelinesHeader =
+                        Html.div Styles.pipelineSectionHeader [ Html.text "all pipelines" ]
+                in
+                if List.isEmpty teamCards then
+                    ( [], 0 )
+
+                else if List.isEmpty favoritedSections then
+                    ( [ allPipelinesHeader ], 0 )
+
+                else
+                    ( Html.div Styles.pipelineSectionHeader [ Html.text "favorite pipelines" ]
+                        :: Group.listViewFavoritePipelines
+                            { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
+                            , pipelineJobs = params.pipelineJobs
+                            , jobs = jobs
+                            , dashboardView = params.dashboardView
+                            , query = params.query
+                            , now = params.now
+                            }
+                            session
+                            session.hovered
+                            favoritedSections
+                        ++ [ Views.Styles.separator 0
+                           , allPipelinesHeader
+                           ]
+                    , 0
+                    )
 
             else
                 let

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1440,8 +1440,61 @@ cardsView session params teamCards =
             params.highDensity && not noPipelines
 
         ( headerView, offsetHeight ) =
-            if (highDensity && not viewingInstanceGroups) || (params.groupListView && viewingInstanceGroups) then
+            if highDensity && not viewingInstanceGroups then
                 ( [], 0 )
+
+            else if params.groupListView && viewingInstanceGroups then
+                let
+                    favoritedSections =
+                        teamCards
+                            |> List.map
+                                (\section ->
+                                    { section
+                                        | cards =
+                                            List.filter
+                                                (\c ->
+                                                    case c of
+                                                        PipelineCard p ->
+                                                            Favorites.isPipelineFavorited session p
+
+                                                        InstancedPipelineCard p ->
+                                                            Favorites.isPipelineFavorited session p
+
+                                                        InstanceGroupCard p _ ->
+                                                            Favorites.isInstanceGroupFavorited session (Concourse.toInstanceGroupId p)
+                                                )
+                                                section.cards
+                                    }
+                                )
+                            |> List.filter (\s -> not (List.isEmpty s.cards))
+
+                    allPipelinesHeader =
+                        Html.div Styles.pipelineSectionHeader [ Html.text "all pipelines" ]
+                in
+                if List.isEmpty teamCards then
+                    ( [], 0 )
+
+                else if List.isEmpty favoritedSections then
+                    ( [ allPipelinesHeader ], 0 )
+
+                else
+                    ( Html.div Styles.pipelineSectionHeader [ Html.text "favorite pipelines" ]
+                        :: Group.listViewFavoritePipelines
+                            { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
+                            , pipelineJobs = params.pipelineJobs
+                            , jobs = jobs
+                            , dashboardView = params.dashboardView
+                            , query = params.query
+                            , now = params.now
+                            }
+                            session
+                            session.hovered
+                            favoritedSections
+                        ++ [ Views.Styles.separator 0
+                           , allPipelinesHeader
+                           ]
+                    , 0
+                    )
 
             else
                 let

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -3,6 +3,7 @@ module Dashboard.Group exposing
     , Section
     , hdView
     , listView
+    , listViewFavoritePipelines
     , ordering
     , pipelineNotSetView
     , view
@@ -426,6 +427,8 @@ listView params session hovered sections =
                                         , query = params.query
                                         , now = params.now
                                         , dragState = params.dragState
+                                        , isDraggable = True
+                                        , section = AllPipelinesSection
                                         }
                                         session
                                         hovered
@@ -433,6 +436,56 @@ listView params session hovered sections =
                                     ]
                                 )
                             |> (\rows -> rows ++ [ endDropZoneView params.dragState params.dropState section.teamName ])
+                    )
+                ]
+        )
+        sections
+
+
+listViewFavoritePipelines :
+    { pipelinesWithResourceErrors : Set Concourse.DatabaseID
+    , pipelineJobs : Dict Concourse.DatabaseID (List Concourse.JobName)
+    , jobs : Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
+    , dashboardView : Routes.DashboardView
+    , query : String
+    , now : Maybe Time.Posix
+    }
+    -> Session
+    -> HoverState.HoverState
+    -> List (Section Card)
+    -> List (Html Message)
+listViewFavoritePipelines params session hovered sections =
+    List.map
+        (\section ->
+            Html.div Styles.listViewTeamGroup
+                [ Html.div Styles.listViewTeamHeader
+                    [ Html.div Styles.listViewTeamName
+                        [ Html.text section.header ]
+                    ]
+                , Html.div
+                    (Styles.listView
+                        ++ [ style "display" "flex"
+                           , style "flex-direction" "column"
+                           , style "gap" "3px"
+                           ]
+                    )
+                    (section.cards
+                        |> sortPipelinesForListView
+                        |> List.map
+                            (renderPipelineRow
+                                { pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
+                                , pipelineJobs = params.pipelineJobs
+                                , jobs = params.jobs
+                                , dashboardView = params.dashboardView
+                                , query = params.query
+                                , now = params.now
+                                , dragState = NotDragging
+                                , isDraggable = False
+                                , section = FavoritesSection
+                                }
+                                session
+                                hovered
+                            )
                     )
                 ]
         )
@@ -471,6 +524,8 @@ renderPipelineRow :
     , query : String
     , now : Maybe Time.Posix
     , dragState : DragState
+    , isDraggable : Bool
+    , section : PipelinesSection
     }
     -> Session
     -> HoverState.HoverState
@@ -502,19 +557,23 @@ renderPipelineRow params session hovered card =
 
                 NotDragging ->
                     False
+
+        dragAttrs =
+            if params.isDraggable then
+                [ attribute "ondragstart" "event.dataTransfer.setData('text/plain', '');"
+                , draggable "true"
+                , on "dragstart" (Json.Decode.succeed (DragStart <| card))
+                , on "dragend" (Json.Decode.succeed DragEnd)
+                ]
+
+            else
+                []
     in
     case card of
         InstanceGroupCard pipeline _ ->
             Html.div
                 (Styles.listViewRowContainer isBeingDragged
-                    ++ [ attribute
-                            "ondragstart"
-                            "event.dataTransfer.setData('text/plain', '');"
-                       , draggable "true"
-                       , on "dragstart"
-                            (Json.Decode.succeed (DragStart <| card))
-                       , on "dragend" (Json.Decode.succeed DragEnd)
-                       ]
+                    ++ dragAttrs
                 )
                 [ Html.div
                     (Styles.listViewRowOverlay anyDragHappening
@@ -552,15 +611,7 @@ renderPipelineRow params session hovered card =
             in
             Html.div
                 (Styles.listViewRowContainer isBeingDragged
-                    ++ [ style "align-items" "stretch"
-                       , attribute
-                            "ondragstart"
-                            "event.dataTransfer.setData('text/plain', '');"
-                       , draggable "true"
-                       , on "dragstart"
-                            (Json.Decode.succeed (DragStart <| card))
-                       , on "dragend" (Json.Decode.succeed DragEnd)
-                       ]
+                    ++ (style "align-items" "stretch" :: dragAttrs)
                 )
                 [ Html.div
                     (Styles.listViewRowOverlay anyDragHappening
@@ -586,7 +637,7 @@ renderPipelineRow params session hovered card =
                         ]
                     ]
                 , Html.div Styles.listViewInstancedPipelineButtons
-                    (renderPipelineButtons pipeline AllPipelinesSection session hovered)
+                    (renderPipelineButtons pipeline params.section session hovered)
                 ]
 
         PipelineCard pipeline ->
@@ -596,14 +647,7 @@ renderPipelineRow params session hovered card =
             in
             Html.div
                 (Styles.listViewRowContainer isBeingDragged
-                    ++ [ attribute
-                            "ondragstart"
-                            "event.dataTransfer.setData('text/plain', '');"
-                       , draggable "true"
-                       , on "dragstart"
-                            (Json.Decode.succeed (DragStart <| card))
-                       , on "dragend" (Json.Decode.succeed DragEnd)
-                       ]
+                    ++ dragAttrs
                 )
                 [ Html.div
                     (Styles.listViewRowOverlay anyDragHappening
@@ -626,7 +670,7 @@ renderPipelineRow params session hovered card =
                             , Html.div Styles.listViewPipelineStatus
                                 [ Html.text (getPipelineStatusText pipelineJobs pipeline params.now) ]
                             , Html.div Styles.listViewPipelineButtonsContainer
-                                (renderStepStatusBlocks pipeline.id pipelineJobs ++ renderPipelineButtons pipeline AllPipelinesSection session hovered)
+                                (renderStepStatusBlocks pipeline.id pipelineJobs ++ renderPipelineButtons pipeline params.section session hovered)
                             ]
                         ]
                     ]

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -18,9 +18,7 @@ module Dashboard.Styles exposing
     , infoBar
     , inlineInstanceVar
     , instanceGroupCard
-    , instanceGroupCardBadge
     , instanceGroupCardBanner
-    , instanceGroupCardBannerHd
     , instanceGroupCardBody
     , instanceGroupCardBodyHd
     , instanceGroupCardFooter
@@ -325,22 +323,6 @@ pipelineCardBody =
     ]
 
 
-instanceGroupCardBadge : List (Html.Attribute msg)
-instanceGroupCardBadge =
-    [ style "background" "#f2f2f2"
-    , style "border-radius" "4px"
-    , style "color" "#222"
-    , style "display" "flex"
-    , style "letter-spacing" "0"
-    , style "margin-right" "8px"
-    , style "width" "20px"
-    , style "height" "20px"
-    , style "flex-shrink" "0"
-    , style "align-items" "center"
-    , style "justify-content" "center"
-    ]
-
-
 instanceGroupCardBody : List (Html.Attribute msg)
 instanceGroupCardBody =
     [ style "background-color" Colors.card
@@ -457,13 +439,6 @@ instanceGroupCardHd =
     , style "background-color" Colors.card
     , style "font-size" "19px"
     , style "letter-spacing" "1px"
-    ]
-
-
-instanceGroupCardBannerHd : List (Html.Attribute msg)
-instanceGroupCardBannerHd =
-    [ style "width" "8px"
-    , style "background-color" Colors.card
     ]
 
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -152,7 +152,7 @@ groupPageContent isListView =
     , style "flex-flow" "column wrap"
     , style "padding" <|
         if isListView then
-            "30px"
+            "0"
 
         else
             "30px 0"
@@ -1134,7 +1134,7 @@ endDropZone { active, anyDragHappening } =
 
 listViewTeamGroup : List (Html.Attribute msg)
 listViewTeamGroup =
-    [ style "margin-bottom" "32px"
+    [ style "margin-bottom" "12px"
     ]
 
 
@@ -1142,7 +1142,7 @@ listViewTeamHeader : List (Html.Attribute msg)
 listViewTeamHeader =
     [ style "display" "flex"
     , style "align-items" "center"
-    , style "margin-bottom" "32px"
+    , style "margin-bottom" "12px"
     , style "background" ColorValues.grey80
     , style "z-index" "2"
     , style "opacity" "0.9"
@@ -1165,6 +1165,7 @@ listView : List (Html.Attribute msg)
 listView =
     [ style "width" "100%"
     , style "box-sizing" "border-box"
+    , style "padding" "0 30px"
     ]
 
 

--- a/web/elm/tests/DashboardInstanceGroupTests.elm
+++ b/web/elm/tests/DashboardInstanceGroupTests.elm
@@ -400,6 +400,61 @@ all =
                         |> Tuple.first
                         |> Common.queryView
                         |> Query.has [ style "margin-bottom" "12px" ]
+            , test "favorites section is not rendered when no pipelines are favorited" <|
+                \_ ->
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines [ pipelineInstance BuildStatusSucceeded False 1 ]
+                        |> Application.handleDelivery (GroupListViewReceived (Ok True))
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.hasNot [ text "favorite pipelines" ]
+            , test "favorites section is rendered when a pipeline is favorited" <|
+                \_ ->
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines [ pipelineInstance BuildStatusSucceeded False 1 ]
+                        |> Application.handleDelivery (GroupListViewReceived (Ok True))
+                        |> Tuple.first
+                        |> Application.handleDelivery
+                            (FavoritedPipelinesReceived <| Ok <| Set.singleton 1)
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.has [ text "favorite pipelines" ]
+            , test "favorited pipeline is rendered in both sections, with distinct dom ids" <|
+                \_ ->
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines [ pipelineInstance BuildStatusSucceeded False 1 ]
+                        |> Application.handleDelivery (GroupListViewReceived (Ok True))
+                        |> Tuple.first
+                        |> Application.handleDelivery
+                            (FavoritedPipelinesReceived <| Ok <| Set.singleton 1)
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Expect.all
+                            [ Query.has
+                                [ id <|
+                                    Effects.toHtmlID <|
+                                        Msgs.PipelineCardFavoritedIcon Msgs.FavoritesSection 1
+                                ]
+                            , Query.has
+                                [ id <|
+                                    Effects.toHtmlID <|
+                                        Msgs.PipelineCardFavoritedIcon Msgs.AllPipelinesSection 1
+                                ]
+                            ]
+            , test "rows in the favorites section are not draggable" <|
+                \_ ->
+                    -- the row in the all pipelines section is draggable, the
+                    -- one in the favorites section is not
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines [ pipelineInstance BuildStatusSucceeded False 1 ]
+                        |> Application.handleDelivery (GroupListViewReceived (Ok True))
+                        |> Tuple.first
+                        |> Application.handleDelivery
+                            (FavoritedPipelinesReceived <| Ok <| Set.singleton 1)
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.findAll [ attribute <| Attr.draggable "true" ]
+                        |> Query.count (Expect.equal 1)
             , test "list view toggle is on when flag is set" <|
                 \_ ->
                     whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }

--- a/web/elm/tests/DashboardInstanceGroupTests.elm
+++ b/web/elm/tests/DashboardInstanceGroupTests.elm
@@ -399,7 +399,7 @@ all =
                         |> Application.handleDelivery (GroupListViewReceived (Ok True))
                         |> Tuple.first
                         |> Common.queryView
-                        |> Query.has [ style "margin-bottom" "32px" ]
+                        |> Query.has [ style "margin-bottom" "12px" ]
             , test "list view toggle is on when flag is set" <|
                 \_ ->
                     whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }


### PR DESCRIPTION
Extend the list view function with a favorites list similar to the grid view.

## Changes proposed by this PR

Added a favorites list similar to the grid view's.

Follow-up to https://github.com/concourse/concourse/pull/9626 and as discussed in https://github.com/orgs/concourse/discussions/9608#discussioncomment-17895632.

<img width="1885" height="884" alt="image" src="https://github.com/user-attachments/assets/dba1de5a-5b2f-4928-8d6c-084f08701203" />


