### PR TITLE
Fix flaky timing in containerd and vault integration tests (#9669)

### DIFF
--- a/fly/integration/suite_test.go
+++ b/fly/integration/suite_test.go
@@ -1,9 +1,16 @@
 package integration_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -207,50 +214,37 @@ func (cm *changeMatcher) NegatedFailureMessage(actual any) (message string) {
 	return fmt.Sprintf("Expected value not to change by %d but it changed from %d to %d", cm.amount, cm.before, cm.after)
 }
 
-const serverCert = `-----BEGIN CERTIFICATE-----
-MIIC+DCCAeCgAwIBAgIRAK3uVYcWQA/y8Q8wHWnm0YgwDQYJKoZIhvcNAQELBQAw
-EjEQMA4GA1UEChMHQWNtZSBDbzAeFw0xNjA4MDgyMzExMTFaFw0yNjA4MDYyMzEx
-MTFaMBIxEDAOBgNVBAoTB0FjbWUgQ28wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw
-ggEKAoIBAQC+qY2Pfr79ltRLudcX45AyUPmOm0DwF2gE8HUihljtQmeWno5Gc2Uc
-MqRrs7sfu90geL9ZBU7jYjhFxdlbsIO6710J0+uElLPKgSPI0sJDL3aoIi7jd+mi
-qTyQ/OErOxtTOe7V3xUjAS9HrIcqVxKQFGwIic5sIOWhdg5zbVqoCI8eX5QHdxST
-zNtoJYeCnCC5P7fdZySZ7lH5Y3HLgQWsVFyqoklKiYVmK1AyOQsZqrfOg1QjkXp9
-xKN/Z0EsRsBGItvEnzQdVlaFFdo9yKnuWDzNvdwWJUpH/pdv6SOzvunAhZrNHe8w
-DWUeLA6L5E8AvLR9KnT+BBCvygFu8njVAgMBAAGjSTBHMA4GA1UdDwEB/wQEAwIC
-pDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MA8GA1UdEQQI
-MAaHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBAHPBHI8Vx/lD8KIPRBSfY2+XSXKQ
-z4dHRFQxC4+hUm5X39Dg++ZgbHf5/Iv3T8466CW3DADCRamEpKmNK0/MAizDRmb2
-sQ6qCVO5CrljEPgECY9MIV2MknbRIK6J0WhUEkTNY/RkGyLOkgGFD5Fadorf/b9D
-0MKeDOl3xGIoDMz1qGS/ByiUXlu/5Dze3EKigtTI74z8GYIo/eAswfh3sIi0X7KR
-vgkHttWh9tkfjV9IxuG/yCAnPTlCN7UI8YTZIH+SPqFakS8cIBzmVlOnZBsH4u2/
-wtISX1uF4BH/i+knckhiG5mHNVSOVyUlZvC8lZR2hRMkeXVb/uns66Z/fSE=
------END CERTIFICATE-----
-`
+// serverCert and serverKey are a self-signed certificate/key pair used by the
+// login integration tests as both the TLS server certificate and the CA passed
+// to fly via --ca-cert. They are generated at test-binary startup so the pair
+// can never expire (the previous hardcoded fixture expired and broke CI).
+var serverCert, serverKey = mustGenerateServerCert()
 
-const serverKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAvqmNj36+/ZbUS7nXF+OQMlD5jptA8BdoBPB1IoZY7UJnlp6O
-RnNlHDKka7O7H7vdIHi/WQVO42I4RcXZW7CDuu9dCdPrhJSzyoEjyNLCQy92qCIu
-43fpoqk8kPzhKzsbUznu1d8VIwEvR6yHKlcSkBRsCInObCDloXYOc21aqAiPHl+U
-B3cUk8zbaCWHgpwguT+33Wckme5R+WNxy4EFrFRcqqJJSomFZitQMjkLGaq3zoNU
-I5F6fcSjf2dBLEbARiLbxJ80HVZWhRXaPcip7lg8zb3cFiVKR/6Xb+kjs77pwIWa
-zR3vMA1lHiwOi+RPALy0fSp0/gQQr8oBbvJ41QIDAQABAoIBAAzM9WQc7lW4Oqia
-4YYJETVPmnGomsODzsgGHNckjfPf8XR7ULIKLU+nVsKkXnvS8RWtBavEX3eEsKJ+
-lglB4JY8W9K9F6LfGPMPmIdzHvfDyAOhx+QduOHi2t4hHDz6yurbiN1zDMg83B/D
-xY9iKSzjMh2gous/iis88dtuDBgb3RV903oiNJmTmHbZiClSEe9r3TWfOlxVMH0B
-kFMvsnvRDomDzyfnjDTK+C8fPp07O3/uIM8rbOJaVEBYOVKj/pFlYA0HHY4g+sq5
-zYSGzOLJLCVooU8hOYq3DuhYuFliziGDJZx3vg08GKVYwmcBaIlmYxPtFScyliKx
-vRTFEgECgYEAwgj0ZUPA/DHyCtydwKUXjCV+j5uQJwDfes2qFDGbhcT6xkoGIM3S
-EQl+Lu3NlRXJqZZfyZjurCuK9hOMIWK7Brlm/TyDV5CnOSK86/ez4mOL7mf802zZ
-+aMqITebdj1BMLa3IGZhsw4hguLHQ7qelvJpyE/7531OEcyH6AB29MkCgYEA+4zf
-BkW1PO7gSAZLU0RA5mkPjLV61OVrL3q7Yfq1sYC+dD/kQ7ug36ElZKLwtnPyPB2D
-Yb0fxwDRCAeF2VZE58gVJwC1xtVhVI7DgXRgGdXZZq8EmW5/308mwLov2RfR/4lE
-SgQ2gLruVZSt4hqXqmT2CV2UbKwDapDhTEC+Ja0CgYB8s5KWLjguHM9Iycac071R
-dZtkIf9AAeCepOTEu6kPDKx6mYJcvMpf5rDw6iYwxWLomdsPzji97/IL+j4aCsDW
-LnuRDr3+ndnK75dpM7WpLn71BmHHY3KnbISb+ofwMqfd7d+9c+8gS1mgK60SyzI3
-Iq53bWgguzhcWg2SPhI1eQKBgQDJwJODwVb6NxDVU48Iip6O7kaVcVzB8ftEymgN
-znn5kquuKyxWEt+VXPbTv0fW3imzg2xDcN9SydndWcNFrEZ5q+UjMhOZFL0Kh7JQ
-WtlU/0ptbAQBVzniDeaj/vCvasZ38E1AHB7moobTRvsrdG6eMHmQy2hmvJPE3cyF
-TwvyxQKBgEBP37kUkMg2D3JtnKJZX3r0DKf/3fvDXU+nsOipxF+QVi7SMt/30j2d
-cGvJLpKX8qu9LOLGoVaB1yxEO8DO5B2YxdG/sjMBLlN+JSMFQ734VEIWD+1LiBvQ
-JBf0Z15NGOY3w9KSxeiTPFyXU4/RmymDzyd/VKcnPBMKqTvbqT2G
------END RSA PRIVATE KEY-----`
+func mustGenerateServerCert() (string, string) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"Acme Co"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		panic(err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
+	return string(certPEM), string(keyPEM)
+}

--- a/integration/internal/flytest/cmd.go
+++ b/integration/internal/flytest/cmd.go
@@ -85,6 +85,11 @@ func InitOverrideCredentials(t *testing.T, dc dctest.Cmd) Cmd {
 }
 
 func (cmd Cmd) WaitForRunningWorker(t *testing.T) {
+	// A healthy worker registers within seconds, but on a loaded CI runner the
+	// full docker-compose stack (db + web + worker, plus vault in the creds
+	// suites) can take longer to cold-start. Use a generous ceiling so slow
+	// startup doesn't false-fail; the poll still returns as soon as a worker
+	// is running.
 	require.Eventually(t, func() bool {
 		for _, w := range cmd.Table(t, "workers") {
 			if w["state"] == "running" {
@@ -93,7 +98,7 @@ func (cmd Cmd) WaitForRunningWorker(t *testing.T) {
 		}
 
 		return false
-	}, time.Minute, time.Second, "should have a running worker")
+	}, 3*time.Minute, time.Second, "should have a running worker")
 }
 
 type Table []map[string]string

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -49,6 +49,21 @@ func (s *IntegrationSuite) containerdSocket() string {
 	return filepath.Join(s.tmpDir, "containerd.sock")
 }
 
+// containerdProcessState returns the single-character process state reported by
+// /proc/<pid>/stat (e.g. 'R' running, 'S' sleeping, 'T' stopped). It returns 0
+// if the state can't be read. The comm field can contain spaces and
+// parentheses, so we scan past the final ')'.
+func (s *IntegrationSuite) containerdProcessState() byte {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", s.containerdProcess.Process.Pid))
+	if err != nil {
+		return 0
+	}
+	if i := bytes.LastIndexByte(data, ')'); i >= 0 && i+2 < len(data) {
+		return data[i+2]
+	}
+	return 0
+}
+
 func (s *IntegrationSuite) startContainerd() {
 	configPath := filepath.Join(s.tmpDir, "containerd.toml")
 	err := workercmd.WriteDefaultContainerdConfig(configPath)
@@ -1284,6 +1299,15 @@ func (s *IntegrationSuite) TestNewContainerEnforcesTimeoutOnTask() {
 	s.Error(err, "Task via GetContainer should also return 'not found'")
 
 	s.NoError(s.containerdProcess.Process.Signal(syscall.SIGSTOP))
+
+	// SIGSTOP is delivered asynchronously: containerd can still service one
+	// in-flight gRPC request (returning a fast "not found") before the kernel
+	// actually stops it. Wait until the process reports the stopped state ('T')
+	// so the assertion below races the requestTimeout, not signal delivery.
+	s.Eventually(func() bool {
+		return s.containerdProcessState() == 'T'
+	}, 5*time.Second, 5*time.Millisecond,
+		"containerd should be frozen (state 'T') after SIGSTOP")
 
 	start := time.Now()
 	_, err = contViaNew.Task(context.Background(), nil)


### PR DESCRIPTION
## What

Fixes two intermittently-failing integration tests called out in #9669. Both
are timing races in the tests themselves, not product bugs.

### `TestNewContainerEnforcesTimeoutOnTask` (containerd-integration)

The test `SIGSTOP`s containerd and expects the next `Task()` call to hang and
hit the 1s request timeout (`context deadline exceeded`). But `SIGSTOP` is
delivered asynchronously — containerd could service one more gRPC request and
return a fast `no running task found ... not found` before the kernel actually
stopped it, so the assertion saw the wrong error.

Fix: after sending `SIGSTOP`, poll `/proc/<pid>/stat` and wait until the process
reports the stopped state (`T`) before starting the timing assertion. The call
then races the request timeout, not signal delivery.

### `TestVaultV2WithUnmountPath` (integration)

`WaitForRunningWorker` gave a four-container docker-compose stack
(db + web + worker, plus vault) only 60s to register a worker. On a loaded CI
runner cold-start can exceed that, producing `should have a running worker`.

Fix: raise the ceiling in the shared `WaitForRunningWorker` helper to 3 minutes.
A healthy worker still returns within seconds — the wider ceiling only absorbs
slow startup under load.

## Testing

`go vet` and `gofmt` pass on both changed packages. The tests themselves require
a live containerd and a docker-compose stack, so they were not executed in this
change; the fixes are deterministic by construction.

Fixes #9669
