### PR TITLE
fix regression in HD view when there are multiple columns of pipelines

### DIFF
--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -1076,8 +1076,7 @@ hdCardWrapper : Bool -> List (Html.Attribute msg)
 hdCardWrapper isBeingDragged =
     [ style "display" "flex"
     , style "flex-direction" "column"
-    , style "width" "100%"
-    , style "min-width" "800px"
+    , style "width" "auto"
     , style "margin-bottom" "3px"
     ]
         ++ (if isBeingDragged then
@@ -1100,7 +1099,7 @@ cardDropZone active =
          else
             "3px"
         )
-    , style "width" "100%"
+    , style "width" "auto"
     , style "background-color"
         (if active then
             Colors.dropTargetHighlight

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -520,6 +520,43 @@ all =
                         [ style "display" "flex"
                         , style "flex-flow" "column wrap"
                         ]
+        , test "high density card wrapper sizes to its contents" <|
+            \_ ->
+                whenOnDashboard { highDensity = True }
+                    |> givenDataAndUser
+                        (apiData [ ( "team", [] ) ])
+                        (userWithRoles [])
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ style "margin-bottom" "3px" ]
+                    |> Query.has [ style "width" "auto" ]
+        , test "high density drop zone sizes to its contents" <|
+            \_ ->
+                whenOnDashboard { highDensity = True }
+                    |> givenDataAndUser
+                        (apiData [ ( "team", [] ) ])
+                        (userWithRoles [])
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                                , Data.pipeline "team" 1 |> Data.withName "other-pipeline"
+                                ]
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find
+                        [ style "transition"
+                            "height 0.1s ease, background-color 0.1s ease"
+                        ]
+                    |> Query.has [ style "width" "auto" ]
         , test "normal density pipelines view has default layout" <|
             \_ ->
                 whenOnDashboard { highDensity = False }


### PR DESCRIPTION
## Changes proposed by this PR

Regression introduced in #9626.

When there are multiple columns of pipeline cards in HD view, after #9626, there would be a massive gap between each column of cards:

<img width="3024" height="1752" alt="hd-view-8 3" src="https://github.com/user-attachments/assets/0dce7598-4069-47da-9da0-c6ed90bf401d" />

This PR fixes the HD view so the columns don't have massive gaps between them:

<img width="3024" height="1752" alt="hd-view-fixed" src="https://github.com/user-attachments/assets/7c07d205-9d25-4c07-9deb-f223488c8593" />
