### PR TITLE
Widen volumes and containers id columns to bigint

### DIFF
--- a/atc/db/migration/migrations/1786574734_widen_volumes_and_containers_ids_to_bigint.down.sql
+++ b/atc/db/migration/migrations/1786574734_widen_volumes_and_containers_ids_to_bigint.down.sql
@@ -1,0 +1,19 @@
+-- Reverse of the volumes/containers id-widening migration: bigint -> integer.
+-- This can fail if a live sequence value already exceeds the 32-bit integer
+-- range, which is the expected/standard limitation for narrowing back to
+-- integer.
+ALTER TABLE volumes DROP CONSTRAINT volumes_parent_id_fkey;
+
+ALTER TABLE containers
+    ALTER COLUMN id TYPE integer,
+    ALTER COLUMN image_check_container_id TYPE integer,
+    ALTER COLUMN image_get_container_id TYPE integer;
+
+ALTER TABLE volumes
+    ALTER COLUMN id TYPE integer,
+    ALTER COLUMN parent_id TYPE integer,
+    ALTER COLUMN container_id TYPE integer;
+
+ALTER TABLE volumes ADD CONSTRAINT volumes_parent_id_fkey
+    FOREIGN KEY (parent_id, parent_state)
+    REFERENCES volumes (id, state) DEFERRABLE;

--- a/atc/db/migration/migrations/1786574734_widen_volumes_and_containers_ids_to_bigint.up.sql
+++ b/atc/db/migration/migrations/1786574734_widen_volumes_and_containers_ids_to_bigint.up.sql
@@ -1,0 +1,27 @@
+-- Widen the volumes and containers id columns (and the columns that reference
+-- them through a foreign key) from integer to bigint, so their high-churn
+-- sequences cannot overflow the 32-bit integer range and produce
+-- "ERROR: integer out of range (SQLSTATE 22003)". See
+-- https://github.com/concourse/concourse/issues/9672.
+--
+-- Only the volumes and containers tables are rewritten by this migration.
+--
+-- The volumes composite self-foreign-key (parent_id, parent_state) ->
+-- (id, state) is dropped first: altering the id side otherwise fails with
+-- "could not find cast from volume_state to anyenum". The volumes(id, state)
+-- unique constraint it depends on is preserved throughout.
+ALTER TABLE volumes DROP CONSTRAINT volumes_parent_id_fkey;
+
+ALTER TABLE containers
+    ALTER COLUMN id TYPE bigint,
+    ALTER COLUMN image_check_container_id TYPE bigint,
+    ALTER COLUMN image_get_container_id TYPE bigint;
+
+ALTER TABLE volumes
+    ALTER COLUMN id TYPE bigint,
+    ALTER COLUMN parent_id TYPE bigint,
+    ALTER COLUMN container_id TYPE bigint;
+
+ALTER TABLE volumes ADD CONSTRAINT volumes_parent_id_fkey
+    FOREIGN KEY (parent_id, parent_state)
+    REFERENCES volumes (id, state) DEFERRABLE;


### PR DESCRIPTION
Fixes #9672.

`volumes.id` and `containers.id` are backed by ever-incrementing sequences and can exhaust the 32-bit `integer` range (2,147,483,647) on high-churn deployments even though row counts stay small, causing web nodes to fail with `ERROR: integer out of range (SQLSTATE 22003)`.

This migrates `volumes.id` and `containers.id` — and the columns that reference them through a foreign key — from `integer` to `bigint`:

- `containers.id`, `containers.image_check_container_id`, `containers.image_get_container_id`
- `volumes.id`, `volumes.parent_id`, `volumes.container_id`

Only the `volumes` and `containers` tables are rewritten. The `volumes` composite self-FK `(parent_id, parent_state)` → `(id, state)` is dropped and recreated around the `ALTER`s — otherwise altering the `id` side fails with `could not find cast from volume_state to anyenum` — and the `volumes(id, state)` unique constraint is preserved throughout.

### Scope

Following review feedback, this is intentionally limited to the two high-churn tables named in the issue. Other sequence-backed `id` columns can overflow in principle, but widening them rewrites large tables (e.g. `builds`) under an `ACCESS EXCLUSIVE` lock, so they're better discussed and sequenced separately. Happy to open a follow-up issue to work through which additional tables warrant it.

### Notes

- `volumes`/`containers` are themselves large, churny tables, so the `ALTER ... TYPE` rewrites them under an exclusive lock; on very large deployments this can take a while. Let me know if this should ride along with a major version bump / release note.
- The down migration reverts to `integer` and will (expectedly) fail if a live id already exceeds the int range — the standard limitation when narrowing back.

### Testing

Verified an up → down → up round-trip through Concourse's own migrator on PostgreSQL 16: the migration history records every step `passed`, the six columns flip `integer` ↔ `bigint` in both directions, and the `volumes` self-FK and `volumes(id, state)` unique constraint stay intact at each step. `go build ./atc/db/...` and `go vet ./atc/db/...` pass.
