### PR TITLE
Updates Running Concourse section in Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,7 @@ repo:
 ```sh
 $ yarn install
 $ yarn build
+$ docker build -t concourse/concourse:local .
 $ docker compose up -d
 ```
 


### PR DESCRIPTION
## Changes proposed by this PR

* Update CONTRIBUTING.md to instruct contributors to build the image before running docker compose up.

## Notes to reviewer

This avoids a race condition where the web and worker services build and tag the same image simultaneously, causing the build to fail.
