### PR TITLE
Migrate high read/write table's id column to bigint

### DIFF
--- a/atc/db/migration/migrations/1787860582_volumes_containers_bigint.down.sql
+++ b/atc/db/migration/migrations/1787860582_volumes_containers_bigint.down.sql
@@ -1,0 +1,39 @@
+ALTER TABLE containers
+    ALTER COLUMN id TYPE int,
+    ALTER COLUMN image_check_container_id TYPE int,
+    ALTER COLUMN image_get_container_id TYPE int,
+    ALTER COLUMN resource_config_check_session_id TYPE int;
+
+ALTER TABLE volumes
+    ALTER COLUMN id TYPE int,
+    ALTER COLUMN parent_id TYPE int,
+    ALTER COLUMN container_id TYPE int,
+    ALTER COLUMN worker_task_cache_id TYPE int,
+    ALTER COLUMN worker_resource_cache_id TYPE int;
+
+ALTER TABLE resource_caches
+    ALTER COLUMN id TYPE int;
+
+ALTER TABLE resource_configs
+    ALTER COLUMN resource_cache_id TYPE int;
+
+ALTER TABLE build_image_resource_caches
+    ALTER COLUMN resource_cache_id TYPE int;
+
+ALTER TABLE resource_cache_uses
+    ALTER COLUMN resource_cache_id TYPE int;
+
+ALTER TABLE resource_config_check_sessions
+    ALTER COLUMN id TYPE int;
+
+ALTER TABLE task_caches
+    ALTER COLUMN id TYPE int;
+ALTER SEQUENCE task_caches_id_seq AS int;
+
+ALTER TABLE worker_task_caches
+    ALTER COLUMN id TYPE int,
+    ALTER COLUMN task_cache_id TYPE int;
+
+ALTER TABLE worker_resource_caches
+    ALTER COLUMN id TYPE int,
+    ALTER COLUMN resource_cache_id TYPE int;

--- a/atc/db/migration/migrations/1787860582_volumes_containers_bigint.up.sql
+++ b/atc/db/migration/migrations/1787860582_volumes_containers_bigint.up.sql
@@ -1,0 +1,43 @@
+ALTER TABLE containers
+    ALTER COLUMN id TYPE bigint,
+    ALTER COLUMN image_check_container_id TYPE bigint,
+    ALTER COLUMN image_get_container_id TYPE bigint,
+    ALTER COLUMN resource_config_check_session_id TYPE bigint;
+
+ALTER TABLE volumes
+    ALTER COLUMN id TYPE bigint,
+    ALTER COLUMN parent_id TYPE bigint,
+    ALTER COLUMN container_id TYPE bigint,
+    ALTER COLUMN worker_task_cache_id TYPE bigint,
+    ALTER COLUMN worker_resource_cache_id TYPE bigint;
+
+ALTER TABLE resource_caches
+    ALTER COLUMN id TYPE bigint;
+
+ALTER TABLE resource_configs
+    ALTER COLUMN resource_cache_id TYPE bigint;
+
+ALTER TABLE build_image_resource_caches
+    ALTER COLUMN resource_cache_id TYPE bigint;
+
+ALTER TABLE resource_cache_uses
+    ALTER COLUMN resource_cache_id TYPE bigint;
+
+ALTER TABLE resource_config_check_sessions
+    ALTER COLUMN id TYPE bigint;
+
+ALTER TABLE task_caches
+    ALTER COLUMN id TYPE bigint;
+-- The task_caches.id column was made with 'id serial' which results in the
+-- sequence having a max value set to the int4 max.
+-- Other tables did 'id integer' during creation so the sequence backing their
+-- id columns don't have a max value defined
+ALTER SEQUENCE task_caches_id_seq AS bigint;
+
+ALTER TABLE worker_task_caches
+    ALTER COLUMN id TYPE bigint,
+    ALTER COLUMN task_cache_id TYPE bigint;
+
+ALTER TABLE worker_resource_caches
+    ALTER COLUMN id TYPE bigint,
+    ALTER COLUMN resource_cache_id TYPE bigint;

--- a/atc/db/migration/migrations/1787865309_fix_resource_config_scopes_sequence.down.sql
+++ b/atc/db/migration/migrations/1787865309_fix_resource_config_scopes_sequence.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resource_config_scopes ALTER COLUMN id TYPE int;

--- a/atc/db/migration/migrations/1787865309_fix_resource_config_scopes_sequence.up.sql
+++ b/atc/db/migration/migrations/1787865309_fix_resource_config_scopes_sequence.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resource_config_scopes ALTER COLUMN id TYPE bigint;


### PR DESCRIPTION
## Changes proposed by this PR

closes #9672

This PR adds a migration for the following tables from `int` to `bigint` for their id columns:

- volumes
- containers
- resource_caches
- resource_configs
- build_image_resource_caches
- resource_cache_uses
- resource_config_check_sessions
- task_caches
- worker_task_caches
- worker_resource_caches

All these tables have the following characteristics:
- Frequent reads and writes
- Low number of records at any given time, usually 10's to single-digit thousands number of records depending on cluster size

`volumes` and `containers` are the largest at probably a few thousand records. The others are just us doing "extra homework" and getting ahead of future problems instead of kicking the can down the road. We're in this problem space so might as well think about it thoroughly!

Most clusters are probably still very far off from hitting the `int` limit at all. We've only had one report of a cluster from 2018 hitting the `int` limit on their `volumes` table.

FYI: The down migration won't work if you're past the `int` max value of 2147483647 for any of these tables. Not likely for most users, just a technical warning.

There is a second migration that I added that updates a sequence whose column was previously migrated to `bigint`. The sequence didn't automatically migrate because of the way the table was made. I verified this on a production Concourse.

## Notes to reviewer

I used Claude to review this before submitting. As a warning to anyone else that does the same, your AI will probably think the volumes and containers tables are the largest tables in Concourse, that messes up its review.
