### PR TITLE
 idtoken: emit a jti claim

### DIFF
--- a/atc/api/idtokenserver/openid_discovery.go
+++ b/atc/api/idtokenserver/openid_discovery.go
@@ -20,7 +20,7 @@ func (s *Server) OpenIDConfiguration(w http.ResponseWriter, r *http.Request) {
 	}{
 		Issuer:                           s.oidcIssuer,
 		JWKSUri:                          s.oidcIssuer + "/.well-known/jwks.json",
-		ClaimsSupported:                  []string{"aud", "iat", "iss", "sub"},
+		ClaimsSupported:                  []string{"aud", "iat", "iss", "jti", "sub"},
 		ResponseTypesSupported:           []string{"idtoken"},
 		IDTokenSigningAlgValuesSupported: []string{string(jose.RS256), string(jose.ES256)},
 		SubjectTypesSupported:            []string{"public"},

--- a/atc/creds/idtoken/token_generator.go
+++ b/atc/creds/idtoken/token_generator.go
@@ -57,8 +57,13 @@ func (g TokenGenerator) GenerateToken(params creds.SecretLookupParams) (token st
 		return "", time.Time{}, err
 	}
 
+	jti, err := uuid.NewRandom()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("error generating UUID: %w", err)
+	}
+
 	claims := jwt.Claims{
-		ID:       g.generateId(),
+		ID:       jti.String(),
 		Issuer:   g.Issuer,
 		IssuedAt: jwt.NewNumericDate(now),
 		Audience: jwt.Audience(g.Audience),
@@ -109,17 +114,6 @@ func (g TokenGenerator) getSigningKey() (*jose.SigningKey, error) {
 		Algorithm: alg,
 		Key:       latestKey.JWK(),
 	}, nil
-}
-
-// generateId returns a new value for a token's jti claim.
-//
-// The only requirement on it is uniqueness. The format is free to change, and
-// Concourse does not need to remember the values it issues.
-//
-// RFC 7519 section 4.1.7 (uniqueness)
-// RFC 7523 section 3 (replay prevention)
-func (g TokenGenerator) generateId() string {
-	return uuid.NewString()
 }
 
 func (g TokenGenerator) generateSubject(params creds.SecretLookupParams) string {

--- a/atc/creds/idtoken/token_generator.go
+++ b/atc/creds/idtoken/token_generator.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/uuid"
 )
 
 type SubjectScope string
@@ -57,6 +58,7 @@ func (g TokenGenerator) GenerateToken(params creds.SecretLookupParams) (token st
 	}
 
 	claims := jwt.Claims{
+		ID:       g.generateId(),
 		Issuer:   g.Issuer,
 		IssuedAt: jwt.NewNumericDate(now),
 		Audience: jwt.Audience(g.Audience),
@@ -107,6 +109,17 @@ func (g TokenGenerator) getSigningKey() (*jose.SigningKey, error) {
 		Algorithm: alg,
 		Key:       latestKey.JWK(),
 	}, nil
+}
+
+// generateId returns a new value for a token's jti claim.
+//
+// The only requirement on it is uniqueness. The format is free to change, and
+// Concourse does not need to remember the values it issues.
+//
+// RFC 7519 section 4.1.7 (uniqueness)
+// RFC 7523 section 3 (replay prevention)
+func (g TokenGenerator) generateId() string {
+	return uuid.NewString()
 }
 
 func (g TokenGenerator) generateSubject(params creds.SecretLookupParams) string {

--- a/atc/creds/idtoken/token_generator_test.go
+++ b/atc/creds/idtoken/token_generator_test.go
@@ -79,7 +79,7 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		claims := jwt.Claims{}
 		err = parsed.Claims(rsaVerificationKey, &claims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(claims.Subject).To(Equal(params.Team + "/" + params.Pipeline))
 	})
 
@@ -92,11 +92,9 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		claims := jwt.Claims{}
 		err = parsed.Claims(rsaVerificationKey, &claims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(claims.ID).ToNot(BeEmpty())
 
-		// relying parties doing replay prevention key their single-use caches on
-		// the jti, so it has to differ per generated token
 		otherToken, _, err := tokenGenerator.GenerateToken(params)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -105,7 +103,9 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		otherClaims := jwt.Claims{}
 		err = otherParsed.Claims(rsaVerificationKey, &otherClaims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(otherClaims.ID).ToNot(BeEmpty())
+
 		Expect(otherClaims.ID).ToNot(Equal(claims.ID))
 	})
 
@@ -119,7 +119,7 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		claims := jwt.Claims{}
 		err = parsed.Claims(rsaVerificationKey, &claims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(claims.Subject).To(Equal(params.Team))
 	})
@@ -134,7 +134,7 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		claims := jwt.Claims{}
 		err = parsed.Claims(rsaVerificationKey, &claims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(claims.Subject).To(Equal(params.Team + "/" + params.Pipeline + "/" + params.InstanceVars.String()))
 	})
@@ -149,7 +149,7 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		claims := jwt.Claims{}
 		err = parsed.Claims(rsaVerificationKey, &claims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(claims.Subject).To(Equal(params.Team + "/" + params.Pipeline + "/" + params.InstanceVars.String() + "/" + params.Job))
 	})
@@ -172,7 +172,7 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		claims := jwt.Claims{}
 		err = parsed.Claims(rsaVerificationKey, &claims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(claims.Subject).To(Equal("fake%2Fteam/fake%2Fpipeline/\"fake%2Ffoo\":\"fake%2Fbar\"/fake%2Fjob"))
 	})
@@ -187,7 +187,7 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		claims := jwt.Claims{}
 		err = parsed.Claims(rsaVerificationKey, &claims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(claims.Audience).To(ContainElement("testaud"))
 	})
@@ -202,7 +202,7 @@ var _ = Describe("IDToken TokenGenerator", func() {
 
 		claims := jwt.Claims{}
 		err = parsed.Claims(ecVerificationKey, &claims)
-		Expect(err).To(Succeed())
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(parsed.Headers[0].Algorithm).To(Equal("ES256"))
 	})
@@ -231,7 +231,7 @@ var _ = Describe("IDToken TokenGenerator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			err = parsed.Claims(rsaVerificationKey, &claims)
-			Expect(err).To(Succeed())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("contains the correct subject", func() {

--- a/atc/creds/idtoken/token_generator_test.go
+++ b/atc/creds/idtoken/token_generator_test.go
@@ -83,6 +83,32 @@ var _ = Describe("IDToken TokenGenerator", func() {
 		Expect(claims.Subject).To(Equal(params.Team + "/" + params.Pipeline))
 	})
 
+	It("sets a unique jti on every token", func() {
+		token, _, err := tokenGenerator.GenerateToken(params)
+		Expect(err).ToNot(HaveOccurred())
+
+		parsed, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{idtoken.DefaultAlgorithm})
+		Expect(err).ToNot(HaveOccurred())
+
+		claims := jwt.Claims{}
+		err = parsed.Claims(rsaVerificationKey, &claims)
+		Expect(err).To(Succeed())
+		Expect(claims.ID).ToNot(BeEmpty())
+
+		// relying parties doing replay prevention key their single-use caches on
+		// the jti, so it has to differ per generated token
+		otherToken, _, err := tokenGenerator.GenerateToken(params)
+		Expect(err).ToNot(HaveOccurred())
+
+		otherParsed, err := jwt.ParseSigned(otherToken, []jose.SignatureAlgorithm{idtoken.DefaultAlgorithm})
+		Expect(err).ToNot(HaveOccurred())
+
+		otherClaims := jwt.Claims{}
+		err = otherParsed.Claims(rsaVerificationKey, &otherClaims)
+		Expect(err).To(Succeed())
+		Expect(otherClaims.ID).ToNot(Equal(claims.ID))
+	})
+
 	It("respects subject scope team", func() {
 		tokenGenerator.SubjectScope = idtoken.SubjectScopeTeam
 		token, _, err := tokenGenerator.GenerateToken(params)

--- a/testflight/idtoken_test.go
+++ b/testflight/idtoken_test.go
@@ -87,6 +87,10 @@ var _ = Describe("A pipeline containing idtoken var sources", Ordered, func() {
 		jwksURI, ok := cfg["jwks_uri"].(string)
 		Expect(ok).To(BeTrue())
 		Expect(jwksURI).To(Equal(issuer + "/.well-known/jwks.json"))
+
+		// relying parties read this to decide what a token carries, so assert
+		// the whole advertised set rather than any single claim
+		Expect(cfg["claims_supported"]).To(ConsistOf("aud", "iat", "iss", "jti", "sub"))
 	}, DefaultSpecTimeout)
 })
 

--- a/testflight/idtoken_test.go
+++ b/testflight/idtoken_test.go
@@ -53,6 +53,7 @@ var _ = Describe("A pipeline containing idtoken var sources", Ordered, func() {
 		Expect(claims.Team).To(Equal(teamName))
 		Expect(claims.Pipeline).To(Equal(testPipelineName))
 		Expect(claims.Subject).To(Equal(teamName + "/" + testPipelineName))
+		Expect(claims.ID).ToNot(BeEmpty())
 	}, DefaultSpecTimeout)
 
 	It("creates valid custom idtoken", func(ctx SpecContext) {


### PR DESCRIPTION
## Changes proposed by this PR

Closes #9692 

* idtoken: emit a `jti` claim
* idtoken: advertise `jti` in the OpenID discovery document

## Notes to reviewer

Discussion: https://github.com/orgs/concourse/discussions/9690

A config knob is deliberately not implemented. This was discussed in the above discussion but rejected.
