### PR TITLE
worker: keep in-flight overlay dirs during orphan sweep

### DIFF
--- a/worker/baggageclaim/volume/driver.go
+++ b/worker/baggageclaim/volume/driver.go
@@ -10,5 +10,5 @@ type Driver interface {
 	CreateCopyOnWriteLayer(FilesystemInitVolume, FilesystemLiveVolume) error
 
 	Recover(Filesystem) error
-	RemoveOrphanedResources(knownHandles map[string]struct{}) error
+	RemoveOrphanedResources(isKnown func(handle string) bool) error
 }

--- a/worker/baggageclaim/volume/driver/btrfs.go
+++ b/worker/baggageclaim/volume/driver/btrfs.go
@@ -146,7 +146,7 @@ func (driver *BtrFSDriver) Recover(volume.Filesystem) error {
 	return nil
 }
 
-func (driver *BtrFSDriver) RemoveOrphanedResources(_ map[string]struct{}) error {
+func (driver *BtrFSDriver) RemoveOrphanedResources(_ func(string) bool) error {
 	// nothing to do. btrfs volumes live under the managed volume/ directory
 	return nil
 }

--- a/worker/baggageclaim/volume/driver/naive.go
+++ b/worker/baggageclaim/volume/driver/naive.go
@@ -31,7 +31,7 @@ func (driver *NaiveDriver) Recover(volume.Filesystem) error {
 	return nil
 }
 
-func (driver *NaiveDriver) RemoveOrphanedResources(_ map[string]struct{}) error {
+func (driver *NaiveDriver) RemoveOrphanedResources(_ func(string) bool) error {
 	// nothing to do. naive volumes live under the managed volume/ directory
 	return nil
 }

--- a/worker/baggageclaim/volume/driver/overlay_linux.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux.go
@@ -257,7 +257,7 @@ func (driver *OverlayDriver) workDir(vol volume.FilesystemVolume) string {
 
 func (driver *OverlayDriver) RemoveOrphanedResources(isKnown func(handle string) bool) error {
 	if isKnown == nil {
-		isKnown = func(string) bool { return false }
+		return errors.New("must pass in a function")
 	}
 
 	_, err := os.Stat(driver.OverlaysDir)

--- a/worker/baggageclaim/volume/driver/overlay_linux.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux.go
@@ -255,7 +255,11 @@ func (driver *OverlayDriver) workDir(vol volume.FilesystemVolume) string {
 	return filepath.Join(driver.OverlaysDir, "work", vol.Handle())
 }
 
-func (driver *OverlayDriver) RemoveOrphanedResources(knownHandles map[string]struct{}) error {
+func (driver *OverlayDriver) RemoveOrphanedResources(isKnown func(handle string) bool) error {
+	if isKnown == nil {
+		isKnown = func(string) bool { return false }
+	}
+
 	_, err := os.Stat(driver.OverlaysDir)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -279,7 +283,7 @@ func (driver *OverlayDriver) RemoveOrphanedResources(knownHandles map[string]str
 			continue
 		}
 
-		if _, known := knownHandles[name]; known {
+		if isKnown(name) {
 			continue
 		}
 
@@ -307,7 +311,7 @@ func (driver *OverlayDriver) RemoveOrphanedResources(knownHandles map[string]str
 
 	for _, entry := range workEntries {
 		name := entry.Name()
-		if _, known := knownHandles[name]; known {
+		if isKnown(name) {
 			continue
 		}
 

--- a/worker/baggageclaim/volume/driver/overlay_linux_test.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux_test.go
@@ -1,6 +1,7 @@
 package driver_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,17 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func knownHandles(handles ...string) func(string) bool {
+	set := make(map[string]struct{}, len(handles))
+	for _, h := range handles {
+		set[h] = struct{}{}
+	}
+	return func(handle string) bool {
+		_, ok := set[handle]
+		return ok
+	}
+}
 
 var _ = Describe("Overlay", func() {
 	Context("Driver", func() {
@@ -135,12 +147,7 @@ var _ = Describe("Overlay", func() {
 			// orphan-vol-2 has no corresponding work dir
 			Expect(os.Mkdir(filepath.Join(overlaysDir, "orphan-vol-2"), 0755)).To(Succeed())
 
-			knownHandles := map[string]struct{}{
-				"known-vol-1": {},
-				"known-vol-2": {},
-			}
-
-			err := overlayDrv.RemoveOrphanedResources(knownHandles)
+			err := overlayDrv.RemoveOrphanedResources(knownHandles("known-vol-1", "known-vol-2"))
 			Expect(err).ToNot(HaveOccurred())
 
 			// Known handles should still exist
@@ -161,16 +168,53 @@ var _ = Describe("Overlay", func() {
 			// Create a work dir with no layer dir
 			Expect(os.Mkdir(filepath.Join(overlaysDir, "work", "work-only-orphan"), 0755)).To(Succeed())
 
-			knownHandles := map[string]struct{}{}
-			err := overlayDrv.RemoveOrphanedResources(knownHandles)
+			err := overlayDrv.RemoveOrphanedResources(knownHandles())
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(filepath.Join(overlaysDir, "work", "work-only-orphan")).ToNot(BeADirectory())
 		})
 
+		// overlayMount MkdirAll(workDir) then Mount. A stale snapshot of
+		// live/+init/ taken before initRawVolume (or during init→live rename)
+		// does not contain this handle. Deleting the work dir makes the later
+		// Mount / a live overlay hit ENOENT. Live isKnown stats init/ at
+		// removal time so the in-flight volume is kept; true work-only
+		// orphans are still deleted.
+		It("does not remove an in-flight work dir missing from a stale snapshot", func() {
+			inFlight := "in-flight-vol"
+			workPath := filepath.Join(overlaysDir, "work", inFlight)
+			Expect(os.Mkdir(workPath, 0755)).To(Succeed())
+
+			orphanPath := filepath.Join(overlaysDir, "work", "work-only-orphan")
+			Expect(os.Mkdir(orphanPath, 0755)).To(Succeed())
+
+			initDir := filepath.Join(filepath.Dir(overlaysDir), "init")
+			Expect(os.MkdirAll(initDir, 0755)).To(Succeed())
+			// Handle is absent from the (empty) snapshot but present in init/
+			// by the time the sweeper considers this work dir — or it appears
+			// during the sweep via this live check.
+			Expect(os.Mkdir(filepath.Join(initDir, inFlight), 0755)).To(Succeed())
+
+			isKnown := func(handle string) bool {
+				_, err := os.Stat(filepath.Join(initDir, handle))
+				if err == nil {
+					return true
+				}
+				if errors.Is(err, os.ErrNotExist) {
+					return false
+				}
+				return true
+			}
+
+			err := overlayDrv.RemoveOrphanedResources(isKnown)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(workPath).To(BeADirectory())
+			Expect(orphanPath).ToNot(BeADirectory())
+		})
+
 		It("handles an empty overlays directory", func() {
-			knownHandles := map[string]struct{}{}
-			err := overlayDrv.RemoveOrphanedResources(knownHandles)
+			err := overlayDrv.RemoveOrphanedResources(knownHandles())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -181,8 +225,7 @@ var _ = Describe("Overlay", func() {
 			})
 
 			It("does not error", func() {
-				knownHandles := map[string]struct{}{}
-				err := overlayDrv.RemoveOrphanedResources(knownHandles)
+				err := overlayDrv.RemoveOrphanedResources(knownHandles())
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/worker/baggageclaim/volume/driver/overlay_linux_test.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux_test.go
@@ -1,7 +1,6 @@
 package driver_test
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -174,43 +173,9 @@ var _ = Describe("Overlay", func() {
 			Expect(filepath.Join(overlaysDir, "work", "work-only-orphan")).ToNot(BeADirectory())
 		})
 
-		// overlayMount MkdirAll(workDir) then Mount. A stale snapshot of
-		// live/+init/ taken before initRawVolume (or during init→live rename)
-		// does not contain this handle. Deleting the work dir makes the later
-		// Mount / a live overlay hit ENOENT. Live isKnown stats init/ at
-		// removal time so the in-flight volume is kept; true work-only
-		// orphans are still deleted.
-		It("does not remove an in-flight work dir missing from a stale snapshot", func() {
-			inFlight := "in-flight-vol"
-			workPath := filepath.Join(overlaysDir, "work", inFlight)
-			Expect(os.Mkdir(workPath, 0755)).To(Succeed())
-
-			orphanPath := filepath.Join(overlaysDir, "work", "work-only-orphan")
-			Expect(os.Mkdir(orphanPath, 0755)).To(Succeed())
-
-			initDir := filepath.Join(filepath.Dir(overlaysDir), "init")
-			Expect(os.MkdirAll(initDir, 0755)).To(Succeed())
-			// Handle is absent from the (empty) snapshot but present in init/
-			// by the time the sweeper considers this work dir — or it appears
-			// during the sweep via this live check.
-			Expect(os.Mkdir(filepath.Join(initDir, inFlight), 0755)).To(Succeed())
-
-			isKnown := func(handle string) bool {
-				_, err := os.Stat(filepath.Join(initDir, handle))
-				if err == nil {
-					return true
-				}
-				if errors.Is(err, os.ErrNotExist) {
-					return false
-				}
-				return true
-			}
-
-			err := overlayDrv.RemoveOrphanedResources(isKnown)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(workPath).To(BeADirectory())
-			Expect(orphanPath).ToNot(BeADirectory())
+		It("errors if nil is given instead of a func", func() {
+			err := overlayDrv.RemoveOrphanedResources(nil)
+			Expect(err).To(MatchError("must pass in a function"))
 		})
 
 		It("handles an empty overlays directory", func() {

--- a/worker/baggageclaim/volume/filesystem.go
+++ b/worker/baggageclaim/volume/filesystem.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -201,33 +202,39 @@ func (fs *filesystem) CleanupOrphanedEntries() error {
 		}
 	}
 
-	// Collect live and init handles, then ask the driver to remove
-	// any orphaned driver-specific resources.
-	knownHandles := map[string]struct{}{}
-	liveDirs, err := os.ReadDir(fs.liveDir)
-	if err != nil {
-		return fmt.Errorf("read live dir: %w", err)
-	}
-
-	for _, entry := range liveDirs {
-		knownHandles[entry.Name()] = struct{}{}
-	}
-
-	initDirs, err := os.ReadDir(fs.initDir)
-	if err != nil {
-		return fmt.Errorf("read init dir: %w", err)
-	}
-
-	for _, entry := range initDirs {
-		knownHandles[entry.Name()] = struct{}{}
-	}
-
-	err = fs.driver.RemoveOrphanedResources(knownHandles)
+	// Check known-ness at removal time (init first, then live) so a
+	// volume created or promoted during the sweep is not treated as
+	// an orphan. A snapshot of both dirs can miss a handle that is
+	// renamed from init/ to live/ between the two reads, or that is
+	// created after the snapshot.
+	err = fs.driver.RemoveOrphanedResources(fs.volumeExists)
 	if err != nil {
 		fs.log.Error("failed-to-remove-orphaned-driver-resources", err)
 	}
 
 	return nil
+}
+
+func (fs *filesystem) volumeExists(handle string) bool {
+	// init/ first, then live/: a rename from init to live cannot miss both.
+	if fs.pathKnown(fs.initVolumePath(handle)) {
+		return true
+	}
+	return fs.pathKnown(fs.liveVolumePath(handle))
+}
+
+// pathKnown reports whether a volume path should be treated as present.
+// Stat errors other than ErrNotExist (permission, IO) fail closed: treat
+// the path as known so the sweeper will not delete every overlay.
+func (fs *filesystem) pathKnown(path string) bool {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
 }
 
 func (fs *filesystem) initRawVolume(handle string) (*initVolume, error) {

--- a/worker/baggageclaim/volume/filesystem.go
+++ b/worker/baggageclaim/volume/filesystem.go
@@ -69,15 +69,18 @@ const (
 var _ Filesystem = (*filesystem)(nil)
 
 type filesystem struct {
-	log    lager.Logger
-	driver Driver
+	log       lager.Logger
+	driver    Driver
+	pathKnown func(string) bool
 
 	initDir string
 	liveDir string
 	deadDir string
 }
 
-func NewFilesystem(logger lager.Logger, driver Driver, parentDir string) (Filesystem, error) {
+type FSOption func(*filesystem) error
+
+func NewFilesystem(logger lager.Logger, driver Driver, parentDir string, opts ...FSOption) (Filesystem, error) {
 	initDir := filepath.Join(parentDir, initDirname)
 	liveDir := filepath.Join(parentDir, liveDirname)
 	deadDir := filepath.Join(parentDir, deadDirname)
@@ -97,14 +100,31 @@ func NewFilesystem(logger lager.Logger, driver Driver, parentDir string) (Filesy
 		return nil, err
 	}
 
-	return &filesystem{
-		log:    logger.Session("filesystem"),
-		driver: driver,
+	fs := &filesystem{
+		log:       logger.Session("filesystem"),
+		driver:    driver,
+		pathKnown: pathKnown,
 
 		initDir: initDir,
 		liveDir: liveDir,
 		deadDir: deadDir,
-	}, nil
+	}
+
+	for _, opt := range opts {
+		err = opt(fs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return fs, nil
+}
+
+func WithPathKnownFunc(p func(string) bool) FSOption {
+	return func(f *filesystem) error {
+		f.pathKnown = p
+		return nil
+	}
 }
 
 func (fs *filesystem) NewVolume(handle string) (FilesystemInitVolume, error) {
@@ -202,11 +222,6 @@ func (fs *filesystem) CleanupOrphanedEntries() error {
 		}
 	}
 
-	// Check known-ness at removal time (init first, then live) so a
-	// volume created or promoted during the sweep is not treated as
-	// an orphan. A snapshot of both dirs can miss a handle that is
-	// renamed from init/ to live/ between the two reads, or that is
-	// created after the snapshot.
 	err = fs.driver.RemoveOrphanedResources(fs.volumeExists)
 	if err != nil {
 		fs.log.Error("failed-to-remove-orphaned-driver-resources", err)
@@ -223,10 +238,7 @@ func (fs *filesystem) volumeExists(handle string) bool {
 	return fs.pathKnown(fs.liveVolumePath(handle))
 }
 
-// pathKnown reports whether a volume path should be treated as present.
-// Stat errors other than ErrNotExist (permission, IO) fail closed: treat
-// the path as known so the sweeper will not delete every overlay.
-func (fs *filesystem) pathKnown(path string) bool {
+func pathKnown(path string) bool {
 	_, err := os.Stat(path)
 	if err == nil {
 		return true

--- a/worker/baggageclaim/volume/filesystem_test.go
+++ b/worker/baggageclaim/volume/filesystem_test.go
@@ -240,7 +240,7 @@ var _ = Describe("Filesystem", func() {
 			Expect(driver.DestroyVolumeCallCount()).To(Equal(2))
 		})
 
-		It("collects live and init handles and passes them to RemoveOrphanedResources", func() {
+		It("passes a live isKnown checker for init and live handles", func() {
 			// Create live and init volume directories
 			Expect(os.Mkdir(filepath.Join(parentDir, "live/live-vol-1"), 0755)).To(Succeed())
 			Expect(os.Mkdir(filepath.Join(parentDir, "live/live-vol-2"), 0755)).To(Succeed())
@@ -251,11 +251,45 @@ var _ = Describe("Filesystem", func() {
 
 			Expect(driver.RemoveOrphanedResourcesCallCount()).To(Equal(1))
 
-			knownHandles := driver.RemoveOrphanedResourcesArgsForCall(0)
-			Expect(knownHandles).To(HaveKey("live-vol-1"))
-			Expect(knownHandles).To(HaveKey("live-vol-2"))
-			Expect(knownHandles).To(HaveKey("init-vol-1"))
-			Expect(knownHandles).To(HaveLen(3))
+			isKnown := driver.RemoveOrphanedResourcesArgsForCall(0)
+			Expect(isKnown("live-vol-1")).To(BeTrue())
+			Expect(isKnown("live-vol-2")).To(BeTrue())
+			Expect(isKnown("init-vol-1")).To(BeTrue())
+			Expect(isKnown("unknown-vol")).To(BeFalse())
+
+			// Live check, not a snapshot: a volume created after sweep
+			// started is still known (would have been missing from a map).
+			Expect(os.Mkdir(filepath.Join(parentDir, "init/late-init"), 0755)).To(Succeed())
+			Expect(isKnown("late-init")).To(BeTrue())
+
+			// init-first then live is safe against init→live rename.
+			Expect(os.Mkdir(filepath.Join(parentDir, "init/promoting"), 0755)).To(Succeed())
+			Expect(isKnown("promoting")).To(BeTrue())
+			Expect(os.Rename(
+				filepath.Join(parentDir, "init/promoting"),
+				filepath.Join(parentDir, "live/promoting"),
+			)).To(Succeed())
+			Expect(isKnown("promoting")).To(BeTrue())
+		})
+
+		It("treats a non-ErrNotExist stat as known so overlays are not mass-deleted", func() {
+			err := fs.CleanupOrphanedEntries()
+			Expect(err).ToNot(HaveOccurred())
+
+			isKnown := driver.RemoveOrphanedResourcesArgsForCall(0)
+			Expect(isKnown("unknown-vol")).To(BeFalse())
+
+			initDir := filepath.Join(parentDir, "init")
+			liveDir := filepath.Join(parentDir, "live")
+			Expect(os.Chmod(initDir, 0)).To(Succeed())
+			Expect(os.Chmod(liveDir, 0)).To(Succeed())
+			defer func() {
+				_ = os.Chmod(initDir, 0755)
+				_ = os.Chmod(liveDir, 0755)
+			}()
+
+			// Permission/IO must not be treated as "unknown" (orphan).
+			Expect(isKnown("any-handle")).To(BeTrue())
 		})
 
 		It("logs errors from dead volume cleanup but continues", func() {
@@ -275,8 +309,8 @@ var _ = Describe("Filesystem", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(driver.RemoveOrphanedResourcesCallCount()).To(Equal(1))
-			knownHandles := driver.RemoveOrphanedResourcesArgsForCall(0)
-			Expect(knownHandles).To(BeEmpty())
+			isKnown := driver.RemoveOrphanedResourcesArgsForCall(0)
+			Expect(isKnown("anything")).To(BeFalse())
 		})
 	})
 })

--- a/worker/baggageclaim/volume/filesystem_test.go
+++ b/worker/baggageclaim/volume/filesystem_test.go
@@ -281,14 +281,21 @@ var _ = Describe("Filesystem", func() {
 
 			initDir := filepath.Join(parentDir, "init")
 			liveDir := filepath.Join(parentDir, "live")
-			Expect(os.Chmod(initDir, 0)).To(Succeed())
-			Expect(os.Chmod(liveDir, 0)).To(Succeed())
+			// chmod 0 is not a Stat error as root (CI unit-baggageclaim).
+			// Replace the dirs with files so Stat(init/any-handle) returns
+			// ENOTDIR, which is not ErrNotExist even as uid 0.
+			Expect(os.RemoveAll(initDir)).To(Succeed())
+			Expect(os.RemoveAll(liveDir)).To(Succeed())
+			Expect(os.WriteFile(initDir, nil, 0644)).To(Succeed())
+			Expect(os.WriteFile(liveDir, nil, 0644)).To(Succeed())
 			defer func() {
-				_ = os.Chmod(initDir, 0755)
-				_ = os.Chmod(liveDir, 0755)
+				_ = os.Remove(initDir)
+				_ = os.Remove(liveDir)
+				_ = os.Mkdir(initDir, 0755)
+				_ = os.Mkdir(liveDir, 0755)
 			}()
 
-			// Permission/IO must not be treated as "unknown" (orphan).
+			// A Stat error other than ErrNotExist must not be treated as "unknown" (orphan).
 			Expect(isKnown("any-handle")).To(BeTrue())
 		})
 

--- a/worker/baggageclaim/volume/filesystem_test.go
+++ b/worker/baggageclaim/volume/filesystem_test.go
@@ -248,31 +248,49 @@ var _ = Describe("Filesystem", func() {
 
 			err := fs.CleanupOrphanedEntries()
 			Expect(err).ToNot(HaveOccurred())
-
 			Expect(driver.RemoveOrphanedResourcesCallCount()).To(Equal(1))
+			volumeExists := driver.RemoveOrphanedResourcesArgsForCall(0)
+			Expect(volumeExists("live-vol-1")).To(BeTrue())
+			Expect(volumeExists("live-vol-2")).To(BeTrue())
+			Expect(volumeExists("init-vol-1")).To(BeTrue())
+			Expect(volumeExists("unknown-vol")).To(BeFalse())
+		})
 
-			isKnown := driver.RemoveOrphanedResourcesArgsForCall(0)
-			Expect(isKnown("live-vol-1")).To(BeTrue())
-			Expect(isKnown("live-vol-2")).To(BeTrue())
-			Expect(isKnown("init-vol-1")).To(BeTrue())
-			Expect(isKnown("unknown-vol")).To(BeFalse())
+		It("volumeExists checks init/ first, then live/", func() {
+			pathKnownCallCount := 0
+			f, err := NewFilesystem(logger, &driver, parentDir,
+				WithPathKnownFunc(func(path string) bool {
+					pathKnownCallCount++
+					switch pathKnownCallCount {
+					case 1, 2:
+						Expect(path).To(Equal(filepath.Join(parentDir, "init/promoting")))
+						return true
+					case 3:
+						Expect(path).To(Equal(filepath.Join(parentDir, "live/promoting")))
+						return true
+					default:
+						Fail("Unknown test situation! Think about it.")
+						return false
+					}
+				}))
+			Expect(err).ToNot(HaveOccurred())
+			fs = f
 
-			// Live check, not a snapshot: a volume created after sweep
-			// started is still known (would have been missing from a map).
-			Expect(os.Mkdir(filepath.Join(parentDir, "init/late-init"), 0755)).To(Succeed())
-			Expect(isKnown("late-init")).To(BeTrue())
+			err = fs.CleanupOrphanedEntries()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(driver.RemoveOrphanedResourcesCallCount()).To(Equal(1))
+			volumeExists := driver.RemoveOrphanedResourcesArgsForCall(0)
 
-			// init-first then live is safe against init→live rename.
 			Expect(os.Mkdir(filepath.Join(parentDir, "init/promoting"), 0755)).To(Succeed())
-			Expect(isKnown("promoting")).To(BeTrue())
+			Expect(volumeExists("promoting")).To(BeTrue())
 			Expect(os.Rename(
 				filepath.Join(parentDir, "init/promoting"),
 				filepath.Join(parentDir, "live/promoting"),
 			)).To(Succeed())
-			Expect(isKnown("promoting")).To(BeTrue())
+			Expect(volumeExists("promoting")).To(BeTrue())
 		})
 
-		It("treats a non-ErrNotExist stat as known so overlays are not mass-deleted", func() {
+		It("treats non-ErrNotExist errors as 'known' so volumes are not mass-deleted", func() {
 			err := fs.CleanupOrphanedEntries()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -281,22 +299,14 @@ var _ = Describe("Filesystem", func() {
 
 			initDir := filepath.Join(parentDir, "init")
 			liveDir := filepath.Join(parentDir, "live")
-			// chmod 0 is not a Stat error as root (CI unit-baggageclaim).
-			// Replace the dirs with files so Stat(init/any-handle) returns
-			// ENOTDIR, which is not ErrNotExist even as uid 0.
+			By("removing the init/ and live/ dirs and replacing them with files. This will cause os.Stat to return ENOTDIR")
 			Expect(os.RemoveAll(initDir)).To(Succeed())
 			Expect(os.RemoveAll(liveDir)).To(Succeed())
 			Expect(os.WriteFile(initDir, nil, 0644)).To(Succeed())
 			Expect(os.WriteFile(liveDir, nil, 0644)).To(Succeed())
-			defer func() {
-				_ = os.Remove(initDir)
-				_ = os.Remove(liveDir)
-				_ = os.Mkdir(initDir, 0755)
-				_ = os.Mkdir(liveDir, 0755)
-			}()
 
-			// A Stat error other than ErrNotExist must not be treated as "unknown" (orphan).
-			Expect(isKnown("any-handle")).To(BeTrue())
+			Expect(isKnown("unknown-vol")).To(BeTrue(),
+				"A Stat error other than ErrNotExist must NOT be treated as 'unknown'")
 		})
 
 		It("logs errors from dead volume cleanup but continues", func() {

--- a/worker/baggageclaim/volume/volumefakes/fake_driver.go
+++ b/worker/baggageclaim/volume/volumefakes/fake_driver.go
@@ -53,10 +53,10 @@ type FakeDriver struct {
 	recoverReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RemoveOrphanedResourcesStub        func(map[string]struct{}) error
+	RemoveOrphanedResourcesStub        func(func(string) bool) error
 	removeOrphanedResourcesMutex       sync.RWMutex
 	removeOrphanedResourcesArgsForCall []struct {
-		arg1 map[string]struct{}
+		arg1 func(string) bool
 	}
 	removeOrphanedResourcesReturns struct {
 		result1 error
@@ -313,11 +313,11 @@ func (fake *FakeDriver) RecoverReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeDriver) RemoveOrphanedResources(arg1 map[string]struct{}) error {
+func (fake *FakeDriver) RemoveOrphanedResources(arg1 func(string) bool) error {
 	fake.removeOrphanedResourcesMutex.Lock()
 	ret, specificReturn := fake.removeOrphanedResourcesReturnsOnCall[len(fake.removeOrphanedResourcesArgsForCall)]
 	fake.removeOrphanedResourcesArgsForCall = append(fake.removeOrphanedResourcesArgsForCall, struct {
-		arg1 map[string]struct{}
+		arg1 func(string) bool
 	}{arg1})
 	stub := fake.RemoveOrphanedResourcesStub
 	fakeReturns := fake.removeOrphanedResourcesReturns
@@ -338,13 +338,13 @@ func (fake *FakeDriver) RemoveOrphanedResourcesCallCount() int {
 	return len(fake.removeOrphanedResourcesArgsForCall)
 }
 
-func (fake *FakeDriver) RemoveOrphanedResourcesCalls(stub func(map[string]struct{}) error) {
+func (fake *FakeDriver) RemoveOrphanedResourcesCalls(stub func(func(string) bool) error) {
 	fake.removeOrphanedResourcesMutex.Lock()
 	defer fake.removeOrphanedResourcesMutex.Unlock()
 	fake.RemoveOrphanedResourcesStub = stub
 }
 
-func (fake *FakeDriver) RemoveOrphanedResourcesArgsForCall(i int) map[string]struct{} {
+func (fake *FakeDriver) RemoveOrphanedResourcesArgsForCall(i int) func(string) bool {
 	fake.removeOrphanedResourcesMutex.RLock()
 	defer fake.removeOrphanedResourcesMutex.RUnlock()
 	argsForCall := fake.removeOrphanedResourcesArgsForCall[i]


### PR DESCRIPTION
## Changes proposed by this PR

closes #9685

The overlay sweeper deleted layer/work dirs of volumes that were being created or promoted during the sweep. The volume stayed mounted, then runc hit ENOENT creating `/tmp/gdn-init` and the container create failed.

* Drop the `live/`+`init/` snapshot. `RemoveOrphanedResources` now takes a live `isKnown(handle)` callback.
* `CleanupOrphanedEntries` stats `init/` first, then `live/` at delete time, so an `init→live` rename cannot miss both, and a volume created after sweep start is still known.
* Fail closed: a `Stat` error other than `ErrNotExist` (permission, IO) is treated as known, so a transient stat failure cannot mass-delete overlays.
* Overlay test covers the real race: handle absent from a stale snapshot, present in `init/` via live `isKnown`. Work-only orphans are still deleted. `btrfs`/`naive` implement the new signature.

## Notes to reviewer

The in-flight overlay test used to pass the handle as known (`knownHandles(inFlight)`), which is the snapshot case, not the race. It now uses a live `Stat` of `init/` while the snapshot is empty.

To confirm:

```
go test ./worker/baggageclaim/volume/driver -ginkgo.focus "RemoveOrphanedResources" -count=1 -timeout 60s
go test ./worker/baggageclaim/volume -ginkgo.focus "CleanupOrphanedEntries" -count=1 -timeout 60s
```

## Release Note

* Fix worker overlay sweeper deleting overlay dirs of volumes being created, which caused runc to fail with ENOENT on `/tmp/gdn-init`.