### PR TITLE
document workaround for running unsigned fly on latest macOS

### DIFF
--- a/web/elm/src/DownloadFly/DownloadFly.elm
+++ b/web/elm/src/DownloadFly/DownloadFly.elm
@@ -212,7 +212,10 @@ macosSteps baseUrl arch =
                         ++ url
                         ++ """' -o fly
 chmod +x ./fly
-mv ./fly /usr/local/bin/"""
+mv ./fly /usr/local/bin/
+# Latest versions of macOS may prevent you from running unsigned binaries.
+# You can run the following as a workaround:
+xattr -d com.apple.quarantine /usr/local/bin/fly"""
                 ]
             ]
         , directDownloadLink url


### PR DESCRIPTION
## Changes proposed by this PR

Related to #9682

We have no timeline/plan to have the fly or concourse binaries signed by Apple. This PR simply documents the workaround for getting fly to run.

<img width="895" height="468" alt="image" src="https://github.com/user-attachments/assets/436a2b30-b532-4072-a3c0-e74bba73b14d" />

