### PR TITLE
Emit audit logs when pipelines are auto-archived internally

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1184,6 +1184,7 @@ func (cmd *RunCommand) backendComponents(
 		lockFactory,
 		rateLimiter,
 		policyChecker,
+		aud,
 	)
 
 	buildEventWatcher, err := db.NewBuildBeingWatchedMarker(logger, dbConn, db.DefaultBuildBeingWatchedMarkDuration, clock.NewClock())
@@ -1900,6 +1901,7 @@ func (cmd *RunCommand) constructEngine(
 	lockFactory lock.LockFactory,
 	rateLimiter engine.RateLimiter,
 	policyChecker policy.Checker,
+	aud auditor.Auditor,
 ) engine.Engine {
 	return engine.NewEngine(
 		engine.NewStepperFactory(
@@ -1929,6 +1931,7 @@ func (cmd *RunCommand) constructEngine(
 		),
 		secretManager,
 		cmd.varSourcePool,
+		aud,
 	)
 }
 

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1123,7 +1123,21 @@ func (cmd *RunCommand) backendComponents(
 	dbCheckFactory := db.NewCheckFactory(dbConn, lockFactory, secretManager, cmd.varSourcePool, checkBuildsChan, util.NewSequenceGenerator(1))
 	dbPipelineFactory := db.NewPipelineFactory(dbConn, lockFactory)
 	dbJobFactory := db.NewJobFactory(dbConn, lockFactory)
-	dbPipelineLifecycle := db.NewPipelineLifecycle(dbConn, lockFactory)
+
+	aud := auditor.NewAuditor(
+		cmd.Auditor.EnableBuildAuditLog,
+		cmd.Auditor.EnableContainerAuditLog,
+		cmd.Auditor.EnableJobAuditLog,
+		cmd.Auditor.EnablePipelineAuditLog,
+		cmd.Auditor.EnableResourceAuditLog,
+		cmd.Auditor.EnableSystemAuditLog,
+		cmd.Auditor.EnableTeamAuditLog,
+		cmd.Auditor.EnableWorkerAuditLog,
+		cmd.Auditor.EnableVolumeAuditLog,
+		logger,
+	)
+
+	dbPipelineLifecycle := db.NewPipelineLifecycle(dbConn, lockFactory, aud)
 	dbPipelinePauser := db.NewPipelinePauser(dbConn, lockFactory)
 	dbSigningKeyFactory := db.NewSigningKeyFactory(dbConn)
 
@@ -1385,7 +1399,21 @@ func (cmd *RunCommand) gcComponents(
 	resourceConfigCheckSessionLifecycle := db.NewResourceConfigCheckSessionLifecycle(gcConn)
 	dbBuildFactory := db.NewBuildFactory(gcConn, lockFactory, cmd.GC.OneOffBuildGracePeriod, cmd.GC.FailedGracePeriod)
 	dbResourceConfigFactory := db.NewResourceConfigFactory(gcConn, lockFactory)
-	dbPipelineLifecycle := db.NewPipelineLifecycle(gcConn, lockFactory)
+
+	aud := auditor.NewAuditor(
+		cmd.Auditor.EnableBuildAuditLog,
+		cmd.Auditor.EnableContainerAuditLog,
+		cmd.Auditor.EnableJobAuditLog,
+		cmd.Auditor.EnablePipelineAuditLog,
+		cmd.Auditor.EnableResourceAuditLog,
+		cmd.Auditor.EnableSystemAuditLog,
+		cmd.Auditor.EnableTeamAuditLog,
+		cmd.Auditor.EnableWorkerAuditLog,
+		cmd.Auditor.EnableVolumeAuditLog,
+		logger,
+	)
+
+	dbPipelineLifecycle := db.NewPipelineLifecycle(gcConn, lockFactory, aud)
 	dbCheckLifecycle := db.NewCheckLifecycle(gcConn)
 
 	dbVolumeRepository := db.NewVolumeRepository(gcConn)

--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -39,6 +39,7 @@ func NewAuditor(
 
 type Auditor interface {
 	Audit(action string, userName string, r *http.Request)
+	AuditInternal(action string, params map[string][]string)
 }
 
 type auditor struct {
@@ -183,5 +184,11 @@ func (a *auditor) Audit(action string, userName string, r *http.Request) {
 	err := r.ParseForm()
 	if err == nil && a.ValidateAction(action) {
 		a.logger.Info("audit", lager.Data{"action": action, "user": userName, "parameters": r.Form})
+	}
+}
+
+func (a *auditor) AuditInternal(action string, params map[string][]string) {
+	if a.ValidateAction(action) {
+		a.logger.Info("audit", lager.Data{"action": action, "user": "system", "parameters": params})
 	}
 }

--- a/atc/auditor/auditor_test.go
+++ b/atc/auditor/auditor_test.go
@@ -590,4 +590,45 @@ var _ = Describe("Audit", func() {
 			})
 		})
 	})
+
+	Describe("AuditInternal", func() {
+		var params map[string][]string
+
+		BeforeEach(func() {
+			params = map[string][]string{
+				":pipeline_name": {"my-pipeline"},
+				":team_name":     {"my-team"},
+			}
+		})
+
+		Context("When EnablePipelineAuditLog is true with ArchivePipeline action", func() {
+			BeforeEach(func() {
+				EnablePipelineAuditLog = true
+			})
+
+			It("creates an audit log with user 'system'", func() {
+				aud.AuditInternal(atc.ArchivePipeline, params)
+				logs := logger.Logs()
+				Expect(len(logs)).To(Equal(1))
+				Expect(logs[0].Data["action"]).To(Equal(atc.ArchivePipeline))
+				Expect(logs[0].Data["user"]).To(Equal("system"))
+				Expect(logs[0].Data["parameters"]).To(Equal(map[string]interface{}{
+					":pipeline_name": []interface{}{"my-pipeline"},
+					":team_name":     []interface{}{"my-team"},
+				}))
+			})
+		})
+
+		Context("When EnablePipelineAuditLog is false with ArchivePipeline action", func() {
+			BeforeEach(func() {
+				EnablePipelineAuditLog = false
+			})
+
+			It("does not create a log", func() {
+				aud.AuditInternal(atc.ArchivePipeline, params)
+				logs := logger.Logs()
+				Expect(len(logs)).To(Equal(0))
+			})
+		})
+	})
 })

--- a/atc/auditor/auditorfakes/fake_auditor.go
+++ b/atc/auditor/auditorfakes/fake_auditor.go
@@ -16,6 +16,12 @@ type FakeAuditor struct {
 		arg2 string
 		arg3 *http.Request
 	}
+	AuditInternalStub        func(string, map[string][]string)
+	auditInternalMutex       sync.RWMutex
+	auditInternalArgsForCall []struct {
+		arg1 string
+		arg2 map[string][]string
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -52,6 +58,39 @@ func (fake *FakeAuditor) AuditArgsForCall(i int) (string, string, *http.Request)
 	defer fake.auditMutex.RUnlock()
 	argsForCall := fake.auditArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeAuditor) AuditInternal(arg1 string, arg2 map[string][]string) {
+	fake.auditInternalMutex.Lock()
+	fake.auditInternalArgsForCall = append(fake.auditInternalArgsForCall, struct {
+		arg1 string
+		arg2 map[string][]string
+	}{arg1, arg2})
+	stub := fake.AuditInternalStub
+	fake.recordInvocation("AuditInternal", []interface{}{arg1, arg2})
+	fake.auditInternalMutex.Unlock()
+	if stub != nil {
+		fake.AuditInternalStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeAuditor) AuditInternalCallCount() int {
+	fake.auditInternalMutex.RLock()
+	defer fake.auditInternalMutex.RUnlock()
+	return len(fake.auditInternalArgsForCall)
+}
+
+func (fake *FakeAuditor) AuditInternalCalls(stub func(string, map[string][]string)) {
+	fake.auditInternalMutex.Lock()
+	defer fake.auditInternalMutex.Unlock()
+	fake.AuditInternalStub = stub
+}
+
+func (fake *FakeAuditor) AuditInternalArgsForCall(i int) (string, map[string][]string) {
+	fake.auditInternalMutex.RLock()
+	defer fake.auditInternalMutex.RUnlock()
+	argsForCall := fake.auditInternalArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeAuditor) Invocations() map[string][][]interface{} {

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -34,6 +34,14 @@ const schema = "exec.v2"
 var ErrAdoptRerunBuildHasNoInputs = errors.New("inputs not ready for build to rerun")
 var ErrSetByNewerBuild = errors.New("pipeline set by a newer build")
 
+// ArchivedPipelineInfo holds metadata about a pipeline that was automatically
+// archived during a build's completion.
+type ArchivedPipelineInfo struct {
+	Name         string
+	TeamName     string
+	InstanceVars atc.InstanceVars
+}
+
 type BuildInput struct {
 	Name       string
 	Version    atc.Version
@@ -192,6 +200,7 @@ type Build interface {
 
 	Start(atc.Plan) (bool, error)
 	Finish(BuildStatus) error
+	ArchivedPipelines() []ArchivedPipelineInfo
 
 	Variables(lager.Logger, creds.Secrets, creds.VarSourcePool) (vars.Variables, error)
 
@@ -281,7 +290,8 @@ type build struct {
 
 	spanContext SpanContext
 
-	eventIdSeq util.SequenceGenerator
+	eventIdSeq       util.SequenceGenerator
+	archivedChildren []ArchivedPipelineInfo
 }
 
 func newEmptyBuild(conn DbConn, lockFactory lock.LockFactory) *build {
@@ -404,6 +414,7 @@ func (b *build) RerunOf() int                     { return b.rerunOf }
 func (b *build) RerunOfName() string              { return b.rerunOfName }
 func (b *build) RerunNumber() int                 { return b.rerunNumber }
 func (b *build) CreatedBy() *string               { return b.createdBy }
+func (b *build) ArchivedPipelines() []ArchivedPipelineInfo { return b.archivedChildren }
 
 func (b *build) isNewerThanLastCheckOf(input Resource) bool {
 	return b.createTime.After(input.LastCheckEndTime())
@@ -806,9 +817,17 @@ WITH RECURSIVE pipelines_to_archive AS (
 		}
 		defer pipelineRows.Close()
 
-		err = archivePipelines(tx, b.conn, b.lockFactory, pipelineRows)
+		archived, err := archivePipelines(tx, b.conn, b.lockFactory, pipelineRows)
 		if err != nil {
 			return err
+		}
+
+		for _, p := range archived {
+			b.archivedChildren = append(b.archivedChildren, ArchivedPipelineInfo{
+				Name:         p.name,
+				TeamName:     p.teamName,
+				InstanceVars: p.instanceVars,
+			})
 		}
 	}
 

--- a/atc/db/build_in_memory_check.go
+++ b/atc/db/build_in_memory_check.go
@@ -314,6 +314,7 @@ func (b *inMemoryCheckBuild) RunStateID() string {
 func (b *inMemoryCheckBuild) IsRunning() bool           { return b.endTime.IsZero() }
 func (b *inMemoryCheckBuild) IsManuallyTriggered() bool { return false }
 func (b *inMemoryCheckBuild) CreateTime() time.Time     { return b.createTime }
+func (b *inMemoryCheckBuild) ArchivedPipelines() []ArchivedPipelineInfo { return nil }
 
 func (b *inMemoryCheckBuild) SpanContext() propagation.TextMapCarrier { return b.spanContext }
 

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -872,6 +872,49 @@ var _ = Describe("Build", func() {
 					childPipeline.Reload()
 					Expect(childPipeline.Archived()).To(BeFalse())
 				})
+
+				It("returns no archived pipelines", func() {
+					build2, _ := defaultJob.CreateBuild(defaultBuildCreatedBy)
+					build2.Finish(db.BuildStatusFailed)
+
+					Expect(build2.ArchivedPipelines()).To(BeEmpty())
+				})
+			})
+
+			It("populates ArchivedPipelines after archiving", func() {
+				build2, _ := defaultJob.CreateBuild(defaultBuildCreatedBy)
+				build2.Finish(db.BuildStatusSucceeded)
+
+				archived := build2.ArchivedPipelines()
+				Expect(archived).To(HaveLen(1))
+				Expect(archived[0].Name).To(Equal("child1-pipeline"))
+				Expect(archived[0].TeamName).To(Equal(defaultTeam.Name()))
+			})
+
+			It("populates ArchivedPipelines for chain of pipelines", func() {
+				childPipelines := []db.Pipeline{childPipeline}
+
+				for i := range 5 {
+					job, _, _ := childPipeline.Job("some-job")
+					build, _ := job.CreateBuild(defaultBuildCreatedBy)
+					childPipeline, _, _ = build.SavePipeline(atc.PipelineRef{Name: "child-pipeline-" + strconv.Itoa(i)}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false)
+					build.Finish(db.BuildStatusSucceeded)
+					childPipelines = append(childPipelines, childPipeline)
+				}
+
+				build, _ := defaultJob.CreateBuild(defaultBuildCreatedBy)
+				build.Finish(db.BuildStatusSucceeded)
+
+				archived := build.ArchivedPipelines()
+				Expect(archived).To(HaveLen(len(childPipelines)))
+			})
+
+			It("returns empty ArchivedPipelines when no pipelines are archived", func() {
+				build2, _ := defaultJob.CreateBuild(defaultBuildCreatedBy)
+				_, _, _ = build2.SavePipeline(atc.PipelineRef{Name: "child1-pipeline"}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(1), false)
+				build2.Finish(db.BuildStatusSucceeded)
+
+				Expect(build2.ArchivedPipelines()).To(BeEmpty())
 			})
 		})
 	})

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -911,7 +911,8 @@ var _ = Describe("Build", func() {
 
 			It("returns empty ArchivedPipelines when no pipelines are archived", func() {
 				build2, _ := defaultJob.CreateBuild(defaultBuildCreatedBy)
-				_, _, _ = build2.SavePipeline(atc.PipelineRef{Name: "child1-pipeline"}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(1), false)
+				_, _, err := build2.SavePipeline(atc.PipelineRef{Name: "child1-pipeline"}, defaultTeam.ID(), defaultPipelineConfig, childPipeline.ConfigVersion(), false)
+				Expect(err).ToNot(HaveOccurred())
 				build2.Finish(db.BuildStatusSucceeded)
 
 				Expect(build2.ArchivedPipelines()).To(BeEmpty())

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -84,6 +84,16 @@ type FakeBuild struct {
 	allAssociatedTeamNamesReturnsOnCall map[int]struct {
 		result1 []string
 	}
+	ArchivedPipelinesStub        func() []db.ArchivedPipelineInfo
+	archivedPipelinesMutex       sync.RWMutex
+	archivedPipelinesArgsForCall []struct {
+	}
+	archivedPipelinesReturns struct {
+		result1 []db.ArchivedPipelineInfo
+	}
+	archivedPipelinesReturnsOnCall map[int]struct {
+		result1 []db.ArchivedPipelineInfo
+	}
 	ArtifactStub        func(int) (db.WorkerArtifact, error)
 	artifactMutex       sync.RWMutex
 	artifactArgsForCall []struct {
@@ -1096,6 +1106,59 @@ func (fake *FakeBuild) AllAssociatedTeamNamesReturnsOnCall(i int, result1 []stri
 	}
 	fake.allAssociatedTeamNamesReturnsOnCall[i] = struct {
 		result1 []string
+	}{result1}
+}
+
+func (fake *FakeBuild) ArchivedPipelines() []db.ArchivedPipelineInfo {
+	fake.archivedPipelinesMutex.Lock()
+	ret, specificReturn := fake.archivedPipelinesReturnsOnCall[len(fake.archivedPipelinesArgsForCall)]
+	fake.archivedPipelinesArgsForCall = append(fake.archivedPipelinesArgsForCall, struct {
+	}{})
+	stub := fake.ArchivedPipelinesStub
+	fakeReturns := fake.archivedPipelinesReturns
+	fake.recordInvocation("ArchivedPipelines", []interface{}{})
+	fake.archivedPipelinesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuild) ArchivedPipelinesCallCount() int {
+	fake.archivedPipelinesMutex.RLock()
+	defer fake.archivedPipelinesMutex.RUnlock()
+	return len(fake.archivedPipelinesArgsForCall)
+}
+
+func (fake *FakeBuild) ArchivedPipelinesCalls(stub func() []db.ArchivedPipelineInfo) {
+	fake.archivedPipelinesMutex.Lock()
+	defer fake.archivedPipelinesMutex.Unlock()
+	fake.ArchivedPipelinesStub = stub
+}
+
+func (fake *FakeBuild) ArchivedPipelinesReturns(result1 []db.ArchivedPipelineInfo) {
+	fake.archivedPipelinesMutex.Lock()
+	defer fake.archivedPipelinesMutex.Unlock()
+	fake.ArchivedPipelinesStub = nil
+	fake.archivedPipelinesReturns = struct {
+		result1 []db.ArchivedPipelineInfo
+	}{result1}
+}
+
+func (fake *FakeBuild) ArchivedPipelinesReturnsOnCall(i int, result1 []db.ArchivedPipelineInfo) {
+	fake.archivedPipelinesMutex.Lock()
+	defer fake.archivedPipelinesMutex.Unlock()
+	fake.ArchivedPipelinesStub = nil
+	if fake.archivedPipelinesReturnsOnCall == nil {
+		fake.archivedPipelinesReturnsOnCall = make(map[int]struct {
+			result1 []db.ArchivedPipelineInfo
+		})
+	}
+	fake.archivedPipelinesReturnsOnCall[i] = struct {
+		result1 []db.ArchivedPipelineInfo
 	}{result1}
 }
 

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -82,7 +82,7 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 	}
 	defer pipelinesToArchive.Close()
 
-	err = archivePipelines(tx, pl.conn, pl.lockFactory, pipelinesToArchive)
+	_, err = archivePipelines(tx, pl.conn, pl.lockFactory, pipelinesToArchive)
 	if err != nil {
 		return err
 	}
@@ -95,12 +95,12 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 	return nil
 }
 
-func archivePipelines(tx Tx, conn DbConn, lockFactory lock.LockFactory, rows *sql.Rows) error {
+func archivePipelines(tx Tx, conn DbConn, lockFactory lock.LockFactory, rows *sql.Rows) ([]pipeline, error) {
 	var toArchive []pipeline
 	for rows.Next() {
 		p := newPipeline(conn, lockFactory)
 		if err := scanPipeline(p, rows); err != nil {
-			return err
+			return nil, err
 		}
 
 		toArchive = append(toArchive, *p)
@@ -109,11 +109,11 @@ func archivePipelines(tx Tx, conn DbConn, lockFactory lock.LockFactory, rows *sq
 	for _, pipeline := range toArchive {
 		err := pipeline.archive(tx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return toArchive, nil
 }
 
 func (p *pipelineLifecycle) RemoveBuildEventsForDeletedPipelines() error {

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/auditor"
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
@@ -20,10 +22,11 @@ type PipelineLifecycle interface {
 	DestroyArchivedPipelines(time.Duration) error
 }
 
-func NewPipelineLifecycle(conn DbConn, lockFactory lock.LockFactory) PipelineLifecycle {
+func NewPipelineLifecycle(conn DbConn, lockFactory lock.LockFactory, aud auditor.Auditor) PipelineLifecycle {
 	return &pipelineLifecycle{
 		conn:        conn,
 		lockFactory: lockFactory,
+		auditor:     aud,
 	}
 }
 
@@ -32,6 +35,7 @@ var _ PipelineLifecycle = (*pipelineLifecycle)(nil)
 type pipelineLifecycle struct {
 	conn        DbConn
 	lockFactory lock.LockFactory
+	auditor     auditor.Auditor
 }
 
 func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
@@ -82,7 +86,7 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 	}
 	defer pipelinesToArchive.Close()
 
-	_, err = archivePipelines(tx, pl.conn, pl.lockFactory, pipelinesToArchive)
+	archived, err := archivePipelines(tx, pl.conn, pl.lockFactory, pipelinesToArchive)
 	if err != nil {
 		return err
 	}
@@ -90,6 +94,14 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 	err = tx.Commit()
 	if err != nil {
 		return err
+	}
+
+	for _, p := range archived {
+		pl.auditor.AuditInternal(atc.ArchivePipeline, map[string][]string{
+			":pipeline_name": {p.name},
+			":team_name":     {p.teamName},
+			":triggered_by":  {"abandoned-pipeline-gc"},
+		})
 	}
 
 	return nil

--- a/atc/db/pipeline_lifecycle_test.go
+++ b/atc/db/pipeline_lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/auditor/auditorfakes"
 	"github.com/concourse/concourse/atc/db"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,12 +14,14 @@ import (
 
 var _ = Describe("PipelineLifecycle", func() {
 	var (
-		pl  db.PipelineLifecycle
-		err error
+		pl           db.PipelineLifecycle
+		err          error
+		fakeAuditor  *auditorfakes.FakeAuditor
 	)
 
 	BeforeEach(func() {
-		pl = db.NewPipelineLifecycle(dbConn, lockFactory)
+		fakeAuditor = new(auditorfakes.FakeAuditor)
+		pl = db.NewPipelineLifecycle(dbConn, lockFactory, fakeAuditor)
 	})
 
 	Describe("ArchiveAbandonedPipelines", func() {
@@ -46,6 +49,10 @@ var _ = Describe("PipelineLifecycle", func() {
 					Expect(childPipeline.Archived()).To(BeFalse())
 					Expect(defaultPipeline.Archived()).To(BeFalse())
 				})
+
+				It("should not emit any audit logs", func() {
+					Expect(fakeAuditor.AuditInternalCallCount()).To(Equal(0))
+				})
 			})
 
 			Context("parent pipeline is destroyed", func() {
@@ -57,6 +64,15 @@ var _ = Describe("PipelineLifecycle", func() {
 				It("should archive all child pipelines", func() {
 					childPipeline.Reload()
 					Expect(childPipeline.Archived()).To(BeTrue())
+				})
+
+				It("should emit an audit log for the archived pipeline", func() {
+					Expect(fakeAuditor.AuditInternalCallCount()).To(Equal(1))
+					action, params := fakeAuditor.AuditInternalArgsForCall(0)
+					Expect(action).To(Equal(atc.ArchivePipeline))
+					Expect(params[":pipeline_name"]).To(Equal([]string{"child-pipeline"}))
+					Expect(params[":team_name"]).To(Equal([]string{defaultTeam.Name()}))
+					Expect(params[":triggered_by"]).To(Equal([]string{"abandoned-pipeline-gc"}))
 				})
 			})
 

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -6,9 +6,12 @@ import (
 	"sync"
 	"time"
 
+	"strconv"
+
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagerctx"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/auditor"
 	"github.com/concourse/concourse/atc/builds"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
@@ -25,6 +28,7 @@ func NewEngine(
 	stepperFactory StepperFactory,
 	secrets creds.Secrets,
 	varSourcePool creds.VarSourcePool,
+	aud auditor.Auditor,
 ) Engine {
 	return Engine{
 		stepperFactory: stepperFactory,
@@ -34,6 +38,7 @@ func NewEngine(
 
 		globalSecrets: secrets,
 		varSourcePool: varSourcePool,
+		auditor:       aud,
 	}
 }
 
@@ -45,6 +50,7 @@ type Engine struct {
 
 	globalSecrets creds.Secrets
 	varSourcePool creds.VarSourcePool
+	auditor       auditor.Auditor
 }
 
 func (engine Engine) Drain(ctx context.Context) {
@@ -66,6 +72,7 @@ func (engine Engine) NewBuild(build db.Build) builds.Runnable {
 		engine.stepperFactory,
 		engine.globalSecrets,
 		engine.varSourcePool,
+		engine.auditor,
 		engine.release,
 		engine.trackedStates,
 		engine.waitGroup,
@@ -77,6 +84,7 @@ func NewBuild(
 	builder StepperFactory,
 	globalSecrets creds.Secrets,
 	varSourcePool creds.VarSourcePool,
+	aud auditor.Auditor,
 	release chan bool,
 	trackedStates *sync.Map,
 	waitGroup *sync.WaitGroup,
@@ -87,6 +95,7 @@ func NewBuild(
 
 		globalSecrets: globalSecrets,
 		varSourcePool: varSourcePool,
+		auditor:       aud,
 
 		release:       release,
 		trackedStates: trackedStates,
@@ -100,6 +109,7 @@ type engineBuild struct {
 
 	globalSecrets creds.Secrets
 	varSourcePool creds.VarSourcePool
+	auditor       auditor.Auditor
 
 	release       chan bool
 	trackedStates *sync.Map
@@ -268,6 +278,16 @@ func (b *engineBuild) saveStatus(logger lager.Logger, status atc.BuildStatus) {
 	if err := b.build.Finish(db.BuildStatus(status)); err != nil {
 		logger.Error("failed-to-finish-build", err)
 		return
+	}
+
+	for _, p := range b.build.ArchivedPipelines() {
+		b.auditor.AuditInternal(atc.ArchivePipeline, map[string][]string{
+			":pipeline_name":         {p.Name},
+			":team_name":             {p.TeamName},
+			":triggered_by_pipeline": {b.build.PipelineName()},
+			":triggered_by_job":      {b.build.JobName()},
+			":triggered_by_build_id": {strconv.Itoa(b.build.ID())},
+		})
 	}
 
 	if b.build.JobID() == 0 {

--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/lager/v3/lagerctx"
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/auditor/auditorfakes"
 	"github.com/concourse/concourse/atc/builds"
 	"github.com/concourse/concourse/atc/creds/credsfakes"
 	"github.com/concourse/concourse/atc/db"
@@ -34,6 +35,7 @@ var _ = Describe("Engine", func() {
 
 		fakeGlobalCreds   *credsfakes.FakeSecrets
 		fakeVarSourcePool *credsfakes.FakeVarSourcePool
+		fakeAuditor       *auditorfakes.FakeAuditor
 	)
 
 	BeforeEach(func() {
@@ -44,6 +46,7 @@ var _ = Describe("Engine", func() {
 
 		fakeGlobalCreds = new(credsfakes.FakeSecrets)
 		fakeVarSourcePool = new(credsfakes.FakeVarSourcePool)
+		fakeAuditor = new(auditorfakes.FakeAuditor)
 	})
 
 	Describe("NewBuild", func() {
@@ -53,7 +56,7 @@ var _ = Describe("Engine", func() {
 		)
 
 		BeforeEach(func() {
-			engine = NewEngine(fakeStepperFactory, fakeGlobalCreds, fakeVarSourcePool)
+			engine = NewEngine(fakeStepperFactory, fakeGlobalCreds, fakeVarSourcePool, fakeAuditor)
 		})
 
 		JustBeforeEach(func() {
@@ -83,6 +86,7 @@ var _ = Describe("Engine", func() {
 				fakeStepperFactory,
 				fakeGlobalCreds,
 				fakeVarSourcePool,
+				fakeAuditor,
 				release,
 				trackedStates,
 				waitGroup,
@@ -245,6 +249,39 @@ var _ = Describe("Engine", func() {
 										waitGroup.Wait()
 										Expect(fakeBuild.FinishCallCount()).To(Equal(1))
 										Expect(fakeBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusSucceeded))
+									})
+
+									Context("when the build archived pipelines", func() {
+										BeforeEach(func() {
+											fakeBuild.ArchivedPipelinesReturns([]db.ArchivedPipelineInfo{
+												{Name: "child-pipeline", TeamName: "main"},
+											})
+											fakeBuild.PipelineNameReturns("parent-pipeline")
+											fakeBuild.JobNameReturns("some-job")
+										})
+
+										It("emits an audit log for each archived pipeline", func() {
+											waitGroup.Wait()
+											Expect(fakeAuditor.AuditInternalCallCount()).To(Equal(1))
+											action, params := fakeAuditor.AuditInternalArgsForCall(0)
+											Expect(action).To(Equal(atc.ArchivePipeline))
+											Expect(params[":pipeline_name"]).To(Equal([]string{"child-pipeline"}))
+											Expect(params[":team_name"]).To(Equal([]string{"main"}))
+											Expect(params[":triggered_by_pipeline"]).To(Equal([]string{"parent-pipeline"}))
+											Expect(params[":triggered_by_job"]).To(Equal([]string{"some-job"}))
+											Expect(params[":triggered_by_build_id"]).To(Equal([]string{"128"}))
+										})
+									})
+
+									Context("when no pipelines were archived", func() {
+										BeforeEach(func() {
+											fakeBuild.ArchivedPipelinesReturns(nil)
+										})
+
+										It("does not emit any audit logs", func() {
+											waitGroup.Wait()
+											Expect(fakeAuditor.AuditInternalCallCount()).To(Equal(0))
+										})
 									})
 								})
 


### PR DESCRIPTION
Fixes #9699

## Summary

When pipelines are automatically archived internally by Concourse (via `build.Finish()` or the abandoned-pipeline GC), no audit trail is produced - unlike when `fly archive-pipeline` is used. This PR adds structured audit log lines for both internal archive paths, gated behind the existing `--enable-pipeline-auditing` flag.

## Changes

### New `AuditInternal` method on the Auditor interface

Added `AuditInternal(action string, params map[string][]string)` to complement the existing HTTP-coupled `Audit()` method. It reuses `ValidateAction()` for flag gating and logs with `"user": "system"` since no human initiated the action. The log format matches the existing auditor output:

```json
{"timestamp":"...","level":"info","source":"atc","message":"atc.audit","data":{"action":"ArchivePipeline","user":"system","parameters":{":pipeline_name":["child-pipeline"],":team_name":["core"],":triggered_by":["..."]}}}
```

### GC path (`ArchiveAbandonedPipelines`)

The `PipelineLifecycle` now accepts an `Auditor` and emits an audit log for each pipeline archived by the periodic GC. The log includes `:triggered_by` = `"abandoned-pipeline-gc"`.

### Build path (`build.Finish`)

- Changed `archivePipelines()` to return the list of archived pipelines
- Added `ArchivedPipelines()` to the `Build` interface so the engine layer can read what `Finish()` archived
- The engine emits an audit log for each archived pipeline after a successful build, including `:triggered_by_pipeline`, `:triggered_by_job`, and `:triggered_by_build_id` for full traceability

### Wiring

The auditor is passed to `NewPipelineLifecycle` (in both `backendComponents` and `gcComponents`) and to `NewEngine` via `constructEngine` in `command.go`.

## Tests

- **Auditor**: `AuditInternal` emits when flag enabled, silent when disabled
- **DB build**: `ArchivedPipelines()` populated after successful archive, empty on failure or no-op
- **Pipeline lifecycle**: audit emitted on GC archive, silent when nothing archived
- **Engine**: audit emitted with correct parameters after build archives pipelines

Note: `atc/db` and `atc/gc` integration tests require PostgreSQL and were verified via compilation (`go vet`) only.

## Files changed

| File | Change |
|------|--------|
| `atc/auditor/auditor.go` | Added `AuditInternal` to interface + implementation |
| `atc/auditor/auditor_test.go` | Tests for `AuditInternal` |
| `atc/db/build.go` | Added `ArchivedPipelineInfo`, `ArchivedPipelines()` on Build interface |
| `atc/db/build_in_memory_check.go` | Nil implementation of `ArchivedPipelines()` |
| `atc/db/build_test.go` | Tests for `ArchivedPipelines()` |
| `atc/db/pipeline_lifecycle.go` | Auditor field, emit audit in GC path |
| `atc/db/pipeline_lifecycle_test.go` | Tests for GC audit emission |
| `atc/engine/engine.go` | Auditor field, emit audit after build.Finish |
| `atc/engine/engine_test.go` | Tests for build-path audit emission |
| `atc/atccmd/command.go` | Wire auditor into PipelineLifecycle and Engine |
| Generated fakes | Regenerated for Auditor and Build interfaces |