### PR TITLE
Update Go to 1.27.1 and modernize codebase

### DIFF
--- a/atc/api/accessor/verifier_test.go
+++ b/atc/api/accessor/verifier_test.go
@@ -98,9 +98,7 @@ var _ = Describe("Verifier", func() {
 			BeforeEach(func() {
 				oneHourAgo := jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
 				accessToken.Claims = db.Claims{
-					Claims: jwt.Claims{
-						Expiry: oneHourAgo,
-					},
+					Expiry: oneHourAgo,
 				}
 			})
 
@@ -113,10 +111,8 @@ var _ = Describe("Verifier", func() {
 			BeforeEach(func() {
 				oneHourFromNow := jwt.NewNumericDate(time.Now().Add(1 * time.Hour))
 				accessToken.Claims = db.Claims{
-					Claims: jwt.Claims{
-						Expiry:   oneHourFromNow,
-						Audience: []string{"invalid"},
-					},
+					Expiry:   oneHourFromNow,
+					Audience: []string{"invalid"},
 				}
 			})
 
@@ -129,10 +125,8 @@ var _ = Describe("Verifier", func() {
 			BeforeEach(func() {
 				oneHourFromNow := jwt.NewNumericDate(time.Now().Add(1 * time.Hour))
 				accessToken.Claims = db.Claims{
-					Claims: jwt.Claims{
-						Expiry:   oneHourFromNow,
-						Audience: []string{"some-aud"},
-					},
+					Expiry:   oneHourFromNow,
+					Audience: []string{"some-aud"},
 				}
 			})
 

--- a/atc/api/health_test.go
+++ b/atc/api/health_test.go
@@ -20,11 +20,11 @@ import (
 
 // fakeRowScanner is a minimal squirrel.RowScanner that returns a fixed bool.
 type fakeRowScanner struct {
-	val interface{}
+	val any
 	err error
 }
 
-func (f *fakeRowScanner) Scan(dest ...interface{}) error {
+func (f *fakeRowScanner) Scan(dest ...any) error {
 	if f.err != nil {
 		return f.err
 	}

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1483,27 +1483,23 @@ var _ = Describe("Pipelines API", func() {
 							},
 							BuildOutputs: []atc.DebugBuildOutput{
 								{
-									DebugResourceVersion: atc.DebugResourceVersion{
-										VersionID:  73,
-										ResourceID: 127,
-										CheckOrder: 123,
-										ScopeID:    111,
-									},
-									BuildID: 66,
-									JobID:   13,
+									VersionID:  73,
+									ResourceID: 127,
+									CheckOrder: 123,
+									ScopeID:    111,
+									BuildID:    66,
+									JobID:      13,
 								},
 							},
 							BuildInputs: []atc.DebugBuildInput{
 								{
-									DebugResourceVersion: atc.DebugResourceVersion{
-										VersionID:  66,
-										ResourceID: 77,
-										CheckOrder: 88,
-										ScopeID:    222,
-									},
-									BuildID:   66,
-									JobID:     13,
-									InputName: "some-input-name",
+									VersionID:  66,
+									ResourceID: 77,
+									CheckOrder: 88,
+									ScopeID:    222,
+									BuildID:    66,
+									JobID:      13,
+									InputName:  "some-input-name",
 								},
 							},
 							BuildReruns: []atc.DebugBuildRerun{

--- a/atc/api/pipelineserver/order.go
+++ b/atc/api/pipelineserver/order.go
@@ -26,8 +26,7 @@ func (s *Server) OrderPipelines(team db.Team) http.Handler {
 			logger.Error("failed-to-order-pipelines", err, lager.Data{
 				"pipeline_names": pipelinesNames,
 			})
-			var errNotFound db.ErrPipelineNotFound
-			if errors.As(err, &errNotFound) {
+			if _, ok := errors.AsType[db.ErrPipelineNotFound](err); ok {
 				w.WriteHeader(http.StatusBadRequest)
 				fmt.Fprintln(w, err.Error())
 			} else {

--- a/atc/api/pipelineserver/order_within_group.go
+++ b/atc/api/pipelineserver/order_within_group.go
@@ -31,8 +31,7 @@ func (s *Server) OrderPipelinesWithinGroup(team db.Team) http.Handler {
 				"pipeline_name": groupName,
 				"instance_vars": instanceVars,
 			})
-			var errNotFound db.ErrPipelineNotFound
-			if errors.As(err, &errNotFound) {
+			if _, ok := errors.AsType[db.ErrPipelineNotFound](err); ok {
 				w.WriteHeader(http.StatusBadRequest)
 				fmt.Fprintln(w, err.Error())
 			} else {

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -197,13 +197,13 @@ type RunCommand struct {
 	} `group:"Policy Checking"`
 
 	Server struct {
-		XFrameOptions             string `long:"x-frame-options" default:"deny" description:"The value to set for the X-Frame-Options header."`
-		ContentSecurityPolicy     string `long:"content-security-policy" default:"frame-ancestors 'none'" description:"The value to set for the Content-Security-Policy header."`
-		StrictTransportSecurity   string `long:"strict-transport-security" description:"The value to set for the Strict-Transport-Security header."`
-		CustomHTTPHeaders         flag.CustomHTTPHeaders `long:"custom-http-headers" description:"Path to a YAML or JSON file containing additional HTTP response headers to set on all responses. These headers override any previously set headers."`
-		ClusterName               string `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
-		ClientID                  string `long:"client-id" default:"concourse-web" description:"Client ID to use for login flow"`
-		ClientSecret              string `long:"client-secret" required:"true" description:"Client secret to use for login flow"`
+		XFrameOptions           string                 `long:"x-frame-options" default:"deny" description:"The value to set for the X-Frame-Options header."`
+		ContentSecurityPolicy   string                 `long:"content-security-policy" default:"frame-ancestors 'none'" description:"The value to set for the Content-Security-Policy header."`
+		StrictTransportSecurity string                 `long:"strict-transport-security" description:"The value to set for the Strict-Transport-Security header."`
+		CustomHTTPHeaders       flag.CustomHTTPHeaders `long:"custom-http-headers" description:"Path to a YAML or JSON file containing additional HTTP response headers to set on all responses. These headers override any previously set headers."`
+		ClusterName             string                 `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
+		ClientID                string                 `long:"client-id" default:"concourse-web" description:"Client ID to use for login flow"`
+		ClientSecret            string                 `long:"client-secret" required:"true" description:"Client secret to use for login flow"`
 	} `group:"Web Server"`
 
 	Health struct {
@@ -1202,10 +1202,8 @@ func (cmd *RunCommand) backendComponents(
 
 	components := []RunnableComponent{
 		{
-			Component: atc.Component{
-				Name:     atc.ComponentLidarScanner,
-				Interval: cmd.LidarScannerInterval,
-			},
+			Name:     atc.ComponentLidarScanner,
+			Interval: cmd.LidarScannerInterval,
 			Runnable: lidar.NewScanner(
 				dbCheckFactory,
 				atc.NewPlanFactory(time.Now().Unix()),
@@ -1213,20 +1211,16 @@ func (cmd *RunCommand) backendComponents(
 			),
 		},
 		{
-			Component: atc.Component{
-				Name:     atc.ComponentPipelinePauser,
-				Interval: cmd.PipelinePauserInterval,
-			},
+			Name:     atc.ComponentPipelinePauser,
+			Interval: cmd.PipelinePauserInterval,
 			Runnable: pauser.NewPipelinePauser(
 				dbPipelinePauser,
 				cmd.PausePipelinesAfter,
 			),
 		},
 		{
-			Component: atc.Component{
-				Name:     atc.ComponentScheduler,
-				Interval: 10 * time.Second,
-			},
+			Name:     atc.ComponentScheduler,
+			Interval: 10 * time.Second,
 			Runnable: scheduler.NewRunner(
 				logger.Session("scheduler"),
 				dbJobFactory,
@@ -1241,17 +1235,13 @@ func (cmd *RunCommand) backendComponents(
 			),
 		},
 		{
-			Component: atc.Component{
-				Name:     atc.ComponentBuildTracker,
-				Interval: cmd.BuildTrackerInterval,
-			},
+			Name:     atc.ComponentBuildTracker,
+			Interval: cmd.BuildTrackerInterval,
 			Runnable: builds.NewTracker(logger, dbBuildFactory, engine, checkBuildsChan),
 		},
 		{
-			Component: atc.Component{
-				Name:     atc.ComponentBuildReaper,
-				Interval: 30 * time.Second,
-			},
+			Name:     atc.ComponentBuildReaper,
+			Interval: 30 * time.Second,
 			Runnable: gc.NewBuildLogCollector(
 				dbPipelineFactory,
 				dbPipelineLifecycle,
@@ -1266,17 +1256,13 @@ func (cmd *RunCommand) backendComponents(
 			),
 		},
 		{
-			Component: atc.Component{
-				Name:     atc.ComponentBeingWatchedBuildMarker,
-				Interval: 10 * time.Minute,
-			},
+			Name:     atc.ComponentBeingWatchedBuildMarker,
+			Interval: 10 * time.Minute,
 			Runnable: buildEventWatcher,
 		},
 		{
-			Component: atc.Component{
-				Name:     atc.ComponentSigningKeyLifecycler,
-				Interval: cmd.SigningKey.CheckInterval,
-			},
+			Name:     atc.ComponentSigningKeyLifecycler,
+			Interval: cmd.SigningKey.CheckInterval,
 			Runnable: &idtoken.SigningKeyLifecycler{
 				Logger:              logger.Session(atc.ComponentSigningKeyLifecycler),
 				DBSigningKeyFactory: dbSigningKeyFactory,
@@ -1292,10 +1278,8 @@ func (cmd *RunCommand) backendComponents(
 
 	if syslogDrainConfigured {
 		components = append(components, RunnableComponent{
-			Component: atc.Component{
-				Name:     atc.ComponentSyslogDrainer,
-				Interval: cmd.Syslog.DrainInterval,
-			},
+			Name:     atc.ComponentSyslogDrainer,
+			Interval: cmd.Syslog.DrainInterval,
 			Runnable: syslog.NewDrainer(
 				cmd.Syslog.Transport,
 				cmd.Syslog.Address,
@@ -1418,10 +1402,8 @@ func (cmd *RunCommand) gcComponents(
 	var components []RunnableComponent
 	for collectorName, collector := range collectors {
 		components = append(components, RunnableComponent{
-			Component: atc.Component{
-				Name:     collectorName,
-				Interval: cmd.GC.Interval,
-			},
+			Name:     collectorName,
+			Interval: cmd.GC.Interval,
 			Runnable: collector,
 		})
 	}

--- a/atc/creds/kubernetes/kubernetes_test.go
+++ b/atc/creds/kubernetes/kubernetes_test.go
@@ -79,9 +79,7 @@ var _ = Describe("Kubernetes", func() {
 		Entry("team-scoped vars with a value field", Example{
 			Setup: func() {
 				fakeClientset.CoreV1().Secrets("prefix-some-team").Create(context.TODO(), &v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: secretName,
-					},
+					Name: secretName,
 					Data: map[string][]byte{
 						"value": []byte("some-value"),
 					},
@@ -95,9 +93,7 @@ var _ = Describe("Kubernetes", func() {
 		Entry("pipeline-scoped vars with a value field", Example{
 			Setup: func() {
 				fakeClientset.CoreV1().Secrets("prefix-some-team").Create(context.TODO(), &v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "some-pipeline." + secretName,
-					},
+					Name: "some-pipeline." + secretName,
 					Data: map[string][]byte{
 						"value": []byte("some-value"),
 					},
@@ -111,9 +107,7 @@ var _ = Describe("Kubernetes", func() {
 		Entry("pipeline-scoped vars with arbitrary fields", Example{
 			Setup: func() {
 				fakeClientset.CoreV1().Secrets("prefix-some-team").Create(context.TODO(), &v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "some-pipeline." + secretName,
-					},
+					Name: "some-pipeline." + secretName,
 					Data: map[string][]byte{
 						"some-field": []byte("some-field-value"),
 					},
@@ -133,9 +127,7 @@ var _ = Describe("Kubernetes", func() {
 		Entry("pipeline-scoped vars with arbitrary fields accessed via template", Example{
 			Setup: func() {
 				fakeClientset.CoreV1().Secrets("prefix-some-team").Create(context.TODO(), &v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "some-pipeline." + secretName,
-					},
+					Name: "some-pipeline." + secretName,
 					Data: map[string][]byte{
 						"some-field": []byte("some-field-value"),
 					},
@@ -167,9 +159,7 @@ var _ = Describe("Kubernetes", func() {
 			Entry("shared-namespace-suffix scoped vars with a value field", Example{
 				Setup: func() {
 					fakeClientset.CoreV1().Secrets("prefix-shared").Create(context.TODO(), &v1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: secretName,
-						},
+						Name: secretName,
 						Data: map[string][]byte{
 							"value": []byte("some-shared-value"),
 						},

--- a/atc/creds/ssm/ssm.go
+++ b/atc/creds/ssm/ssm.go
@@ -89,8 +89,7 @@ func (s *Ssm) getParameterByName(name string) (any, *time.Time, bool, error) {
 	if err == nil {
 		return *param.Parameter.Value, nil, true, nil
 	} else {
-		var notFound *types.ParameterNotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*types.ParameterNotFound](err); ok {
 			return nil, nil, false, nil
 		}
 	}

--- a/atc/db/access_token_factory_test.go
+++ b/atc/db/access_token_factory_test.go
@@ -44,19 +44,15 @@ var _ = Describe("Access Token Factory", func() {
 		Expect(ok).To(BeTrue())
 		Expect(token.Token).To(Equal("my-awesome-token"))
 		Expect(token.Claims).To(Equal(db.Claims{
-			Claims: jwt.Claims{
-				Issuer:    "issuer",
-				Subject:   "subject",
-				Audience:  []string{"audience"},
-				Expiry:    &date,
-				NotBefore: &date,
-				IssuedAt:  &date,
-				ID:        "id",
-			},
-			FederatedClaims: db.FederatedClaims{
-				UserID:    "userid",
-				Connector: "github",
-			},
+			Issuer:    "issuer",
+			Subject:   "subject",
+			Audience:  []string{"audience"},
+			Expiry:    &date,
+			NotBefore: &date,
+			IssuedAt:  &date,
+			ID:        "id",
+			UserID:    "userid",
+			Connector: "github",
 			RawClaims: map[string]any{
 				"iss": "issuer",
 				"sub": "subject",

--- a/atc/db/access_token_lifecycle_test.go
+++ b/atc/db/access_token_lifecycle_test.go
@@ -26,13 +26,13 @@ var _ = Describe("Access Token Lifecycle", func() {
 		tomorrow := jwt.NewNumericDate(now().Add(24 * time.Hour))
 		yesterday := jwt.NewNumericDate(now().Add(-24 * time.Hour))
 		factory.CreateAccessToken("expiredToken1", db.Claims{
-			Claims: jwt.Claims{Expiry: yesterday},
+			Expiry: yesterday,
 		})
 		factory.CreateAccessToken("expiredToken2", db.Claims{
-			Claims: jwt.Claims{Expiry: yesterday},
+			Expiry: yesterday,
 		})
 		factory.CreateAccessToken("activeToken", db.Claims{
-			Claims: jwt.Claims{Expiry: tomorrow},
+			Expiry: tomorrow,
 		})
 
 		By("removing expired tokens")
@@ -49,7 +49,7 @@ var _ = Describe("Access Token Lifecycle", func() {
 		By("having a token that is 24 hours old")
 		yesterday := jwt.NewNumericDate(now().Add(-24 * time.Hour))
 		factory.CreateAccessToken("expiredToken", db.Claims{
-			Claims: jwt.Claims{Expiry: yesterday},
+			Expiry: yesterday,
 		})
 
 		By("removing expired tokens with leeway of 25 hours")

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -285,7 +285,7 @@ type build struct {
 }
 
 func newEmptyBuild(conn DbConn, lockFactory lock.LockFactory) *build {
-	return &build{pipelineRef: pipelineRef{conn: conn, lockFactory: lockFactory}}
+	return &build{conn: conn, lockFactory: lockFactory}
 }
 
 var ErrBuildDisappeared = errors.New("build disappeared from db")
@@ -1451,10 +1451,8 @@ func (b *build) AdoptInputsAndPipes() ([]BuildInput, bool, error) {
 
 		inputs[inputName] = InputResult{
 			Input: &AlgorithmInput{
-				AlgorithmVersion: AlgorithmVersion{
-					ResourceID: resourceID,
-					Version:    ResourceVersion(versionSHA256),
-				},
+				ResourceID:      resourceID,
+				Version:         ResourceVersion(versionSHA256),
 				FirstOccurrence: firstOccurrence,
 			},
 		}
@@ -1614,10 +1612,8 @@ func (b *build) AdoptRerunInputsAndPipes() ([]BuildInput, bool, error) {
 
 		inputs[inputName] = InputResult{
 			Input: &AlgorithmInput{
-				AlgorithmVersion: AlgorithmVersion{
-					ResourceID: resourceID,
-					Version:    ResourceVersion(versionSHA256),
-				},
+				ResourceID:      resourceID,
+				Version:         ResourceVersion(versionSHA256),
 				FirstOccurrence: firstOccurrence,
 			},
 		}

--- a/atc/db/build_in_memory_check.go
+++ b/atc/db/build_in_memory_check.go
@@ -277,14 +277,12 @@ func newRunningInMemoryCheckBuild(conn DbConn, lockFactory lock.LockFactory, che
 	timeNow := time.Now()
 
 	build := &inMemoryCheckBuild{
-		inMemoryCheckBuildForApi: inMemoryCheckBuildForApi{
-			id:        0,
-			conn:      conn,
-			checkable: checkable,
-			plan:      plan,
-			startTime: timeNow,
-			status:    BuildStatusPending,
-		},
+		id:          0,
+		conn:        conn,
+		checkable:   checkable,
+		plan:        plan,
+		startTime:   timeNow,
+		status:      BuildStatusPending,
 		lockFactory: lockFactory,
 		createTime:  timeNow,
 		spanContext: spanContext,

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -699,10 +699,8 @@ func (builder Builder) WithNextInputMapping(jobName string, inputs JobInputs) Se
 
 			mapping[input.Name] = db.InputResult{
 				Input: &db.AlgorithmInput{
-					AlgorithmVersion: db.AlgorithmVersion{
-						Version:    db.ResourceVersion(sha256Version(i.Version)),
-						ResourceID: input.ResourceID,
-					},
+					Version:         db.ResourceVersion(sha256Version(i.Version)),
+					ResourceID:      input.ResourceID,
 					FirstOccurrence: i.FirstOccurrence,
 				},
 				PassedBuildIDs: buildIDs,

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -182,7 +182,7 @@ type job struct {
 }
 
 func newEmptyJob(conn DbConn, lockFactory lock.LockFactory) *job {
-	return &job{pipelineRef: pipelineRef{conn: conn, lockFactory: lockFactory}}
+	return &job{conn: conn, lockFactory: lockFactory}
 }
 
 func (j *job) SetHasNewInputs(hasNewInputs bool) error {

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -1493,30 +1493,24 @@ var _ = Describe("Job", func() {
 				inputVersions := db.InputMapping{
 					"some-input-1": db.InputResult{
 						Input: &db.AlgorithmInput{
-							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToSHA256(versions[0].Version)),
-								ResourceID: scenario.Resource("some-resource").ID(),
-							},
+							Version:         db.ResourceVersion(convertToSHA256(versions[0].Version)),
+							ResourceID:      scenario.Resource("some-resource").ID(),
 							FirstOccurrence: false,
 						},
 						PassedBuildIDs: []int{},
 					},
 					"some-input-2": db.InputResult{
 						Input: &db.AlgorithmInput{
-							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToSHA256(versions[1].Version)),
-								ResourceID: scenario.Resource("some-resource").ID(),
-							},
+							Version:         db.ResourceVersion(convertToSHA256(versions[1].Version)),
+							ResourceID:      scenario.Resource("some-resource").ID(),
 							FirstOccurrence: false,
 						},
 						PassedBuildIDs: []int{},
 					},
 					"some-input-3": db.InputResult{
 						Input: &db.AlgorithmInput{
-							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToSHA256(versions[2].Version)),
-								ResourceID: scenario.Resource("some-resource").ID(),
-							},
+							Version:         db.ResourceVersion(convertToSHA256(versions[2].Version)),
+							ResourceID:      scenario.Resource("some-resource").ID(),
 							FirstOccurrence: false,
 						},
 						PassedBuildIDs: []int{},
@@ -1633,20 +1627,16 @@ var _ = Describe("Job", func() {
 			inputVersions := db.InputMapping{
 				"some-input-1": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(versions[0].Version)),
-							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(versions[0].Version)),
+						ResourceID:      scenarioPipeline1.Resource("some-resource").ID(),
 						FirstOccurrence: false,
 					},
 					PassedBuildIDs: []int{},
 				},
 				"some-input-2": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(versions[1].Version)),
-							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(versions[1].Version)),
+						ResourceID:      scenarioPipeline1.Resource("some-resource").ID(),
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
@@ -1658,10 +1648,8 @@ var _ = Describe("Job", func() {
 			pipeline2InputVersions := db.InputMapping{
 				"some-input-3": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(versions[2].Version)),
-							ResourceID: scenarioPipeline2.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(versions[2].Version)),
+						ResourceID:      scenarioPipeline2.Resource("some-resource").ID(),
 						FirstOccurrence: false,
 					},
 					PassedBuildIDs: []int{},
@@ -1695,20 +1683,16 @@ var _ = Describe("Job", func() {
 			inputVersions2 := db.InputMapping{
 				"some-input-2": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(versions[2].Version)),
-							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(versions[2].Version)),
+						ResourceID:      scenarioPipeline1.Resource("some-resource").ID(),
 						FirstOccurrence: false,
 					},
 					PassedBuildIDs: []int{},
 				},
 				"some-input-3": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(versions[2].Version)),
-							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(versions[2].Version)),
+						ResourceID:      scenarioPipeline1.Resource("some-resource").ID(),
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},

--- a/atc/db/migration/migration.go
+++ b/atc/db/migration/migration.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"slices"
 	"sort"
 	"time"
 
@@ -315,9 +316,9 @@ func (helper *migrator) Migrate(newKey, oldKey *encryption.Key, toVersion int) e
 			}
 		}
 	} else {
-		for i := len(migrations) - 1; i >= 0; i-- {
-			if currentVersion >= migrations[i].Version && migrations[i].Version > toVersion && migrations[i].Direction == "down" {
-				err = helper.runMigration(migrations[i], strategy)
+		for _, migration := range slices.Backward(migrations) {
+			if currentVersion >= migration.Version && migration.Version > toVersion && migration.Direction == "down" {
+				err = helper.runMigration(migration, strategy)
 				if err != nil {
 					return err
 				}

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -833,14 +833,12 @@ var _ = Describe("Pipeline", func() {
 				}))
 
 				explicitOutput := atc.DebugBuildOutput{
-					DebugResourceVersion: atc.DebugResourceVersion{
-						VersionID:  savedVR1.ID(),
-						ResourceID: resource.ID(),
-						ScopeID:    resource.ResourceConfigScopeID(),
-						CheckOrder: savedVR1.CheckOrder(),
-					},
-					JobID:   scenarioPipeline1.Job("a-job").ID(),
-					BuildID: build1DB.ID(),
+					VersionID:  savedVR1.ID(),
+					ResourceID: resource.ID(),
+					ScopeID:    resource.ResourceConfigScopeID(),
+					CheckOrder: savedVR1.CheckOrder(),
+					JobID:      scenarioPipeline1.Job("a-job").ID(),
+					BuildID:    build1DB.ID(),
 				}
 
 				Expect(versions.BuildOutputs).To(ConsistOf([]atc.DebugBuildOutput{
@@ -885,14 +883,12 @@ var _ = Describe("Pipeline", func() {
 
 				Expect(versions.BuildOutputs).To(ConsistOf([]atc.DebugBuildOutput{
 					{
-						DebugResourceVersion: atc.DebugResourceVersion{
-							VersionID:  savedVR1.ID(),
-							ResourceID: resource.ID(),
-							ScopeID:    resource.ResourceConfigScopeID(),
-							CheckOrder: savedVR1.CheckOrder(),
-						},
-						JobID:   scenarioPipeline1.Job("a-job").ID(),
-						BuildID: build1DB.ID(),
+						VersionID:  savedVR1.ID(),
+						ResourceID: resource.ID(),
+						ScopeID:    resource.ResourceConfigScopeID(),
+						CheckOrder: savedVR1.CheckOrder(),
+						JobID:      scenarioPipeline1.Job("a-job").ID(),
+						BuildID:    build1DB.ID(),
 					},
 				}))
 
@@ -944,24 +940,20 @@ var _ = Describe("Pipeline", func() {
 
 				Expect(versions.BuildOutputs).To(ConsistOf([]atc.DebugBuildOutput{
 					{
-						DebugResourceVersion: atc.DebugResourceVersion{
-							VersionID:  savedVR3.ID(),
-							ResourceID: otherResource.ID(),
-							ScopeID:    otherResource.ResourceConfigScopeID(),
-							CheckOrder: savedVR3.CheckOrder(),
-						},
-						JobID:   scenarioPipeline1.Job("a-job").ID(),
-						BuildID: otherPipelineBuild.ID(),
+						VersionID:  savedVR3.ID(),
+						ResourceID: otherResource.ID(),
+						ScopeID:    otherResource.ResourceConfigScopeID(),
+						CheckOrder: savedVR3.CheckOrder(),
+						JobID:      scenarioPipeline1.Job("a-job").ID(),
+						BuildID:    otherPipelineBuild.ID(),
 					},
 					{
-						DebugResourceVersion: atc.DebugResourceVersion{
-							VersionID:  savedVR1.ID(),
-							ResourceID: resource.ID(),
-							ScopeID:    resource.ResourceConfigScopeID(),
-							CheckOrder: savedVR1.CheckOrder(),
-						},
-						JobID:   scenarioPipeline1.Job("a-job").ID(),
-						BuildID: build1DB.ID(),
+						VersionID:  savedVR1.ID(),
+						ResourceID: resource.ID(),
+						ScopeID:    resource.ResourceConfigScopeID(),
+						CheckOrder: savedVR1.CheckOrder(),
+						JobID:      scenarioPipeline1.Job("a-job").ID(),
+						BuildID:    build1DB.ID(),
 					},
 				}))
 
@@ -987,10 +979,8 @@ var _ = Describe("Pipeline", func() {
 				err = scenarioPipeline1.Job("a-job").SaveNextInputMapping(db.InputMapping{
 					"some-input-name": db.InputResult{
 						Input: &db.AlgorithmInput{
-							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToSHA256(atc.Version{"version": "1"})),
-								ResourceID: resource.ID(),
-							},
+							Version:         db.ResourceVersion(convertToSHA256(atc.Version{"version": "1"})),
+							ResourceID:      resource.ID(),
 							FirstOccurrence: true,
 						},
 						PassedBuildIDs: []int{},
@@ -1012,40 +1002,34 @@ var _ = Describe("Pipeline", func() {
 
 				Expect(versions.BuildInputs).To(ConsistOf([]atc.DebugBuildInput{
 					{
-						DebugResourceVersion: atc.DebugResourceVersion{
-							VersionID:  savedVR1.ID(),
-							ResourceID: resource.ID(),
-							ScopeID:    resource.ResourceConfigScopeID(),
-							CheckOrder: savedVR1.CheckOrder(),
-						},
-						JobID:     scenarioPipeline1.Job("a-job").ID(),
-						BuildID:   build1DB.ID(),
-						InputName: "some-input-name",
+						VersionID:  savedVR1.ID(),
+						ResourceID: resource.ID(),
+						ScopeID:    resource.ResourceConfigScopeID(),
+						CheckOrder: savedVR1.CheckOrder(),
+						JobID:      scenarioPipeline1.Job("a-job").ID(),
+						BuildID:    build1DB.ID(),
+						InputName:  "some-input-name",
 					},
 				}))
 
 				By("including implicit outputs of successful builds")
 				implicitOutput := atc.DebugBuildOutput{
-					DebugResourceVersion: atc.DebugResourceVersion{
-						VersionID:  savedVR1.ID(),
-						ResourceID: resource.ID(),
-						ScopeID:    resource.ResourceConfigScopeID(),
-						CheckOrder: savedVR1.CheckOrder(),
-					},
-					JobID:   scenarioPipeline1.Job("a-job").ID(),
-					BuildID: build1DB.ID(),
+					VersionID:  savedVR1.ID(),
+					ResourceID: resource.ID(),
+					ScopeID:    resource.ResourceConfigScopeID(),
+					CheckOrder: savedVR1.CheckOrder(),
+					JobID:      scenarioPipeline1.Job("a-job").ID(),
+					BuildID:    build1DB.ID(),
 				}
 
 				By("including put-only resource's outputs of successful builds")
 				otherExplicitOutput := atc.DebugBuildOutput{
-					DebugResourceVersion: atc.DebugResourceVersion{
-						VersionID:  savedVR3.ID(),
-						ResourceID: otherResource.ID(),
-						ScopeID:    otherResource.ResourceConfigScopeID(),
-						CheckOrder: savedVR3.CheckOrder(),
-					},
-					JobID:   scenarioPipeline1.Job("a-job").ID(),
-					BuildID: otherPipelineBuild.ID(),
+					VersionID:  savedVR3.ID(),
+					ResourceID: otherResource.ID(),
+					ScopeID:    otherResource.ResourceConfigScopeID(),
+					CheckOrder: savedVR3.CheckOrder(),
+					JobID:      scenarioPipeline1.Job("a-job").ID(),
+					BuildID:    otherPipelineBuild.ID(),
 				}
 
 				Expect(versions.BuildOutputs).To(ConsistOf([]atc.DebugBuildOutput{
@@ -1162,10 +1146,8 @@ var _ = Describe("Pipeline", func() {
 			err = scenario.Job("some-job").SaveNextInputMapping(db.InputMapping{
 				"build-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(atc.Version{"key": "value"})),
-							ResourceID: scenario.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(atc.Version{"key": "value"})),
+						ResourceID:      scenario.Resource("some-resource").ID(),
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
@@ -1588,10 +1570,8 @@ var _ = Describe("Pipeline", func() {
 			err = scenario.Job("job-name").SaveNextInputMapping(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(atc.Version{"version": "v1"})),
-							ResourceID: scenario.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(atc.Version{"version": "v1"})),
+						ResourceID:      scenario.Resource("some-resource").ID(),
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
@@ -1617,20 +1597,16 @@ var _ = Describe("Pipeline", func() {
 			err = scenario.Job("job-name").SaveNextInputMapping(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(atc.Version{"version": "v1"})),
-							ResourceID: scenario.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(atc.Version{"version": "v1"})),
+						ResourceID:      scenario.Resource("some-resource").ID(),
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
 				},
 				"some-other-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256(atc.Version{"version": "v3"})),
-							ResourceID: scenario.Resource("some-resource").ID(),
-						},
+						Version:         db.ResourceVersion(convertToSHA256(atc.Version{"version": "v3"})),
+						ResourceID:      scenario.Resource("some-resource").ID(),
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},

--- a/atc/db/prototype.go
+++ b/atc/db/prototype.go
@@ -154,7 +154,7 @@ func (p *prototype) CurrentPinnedVersion() atc.Version { return nil }
 func (p *prototype) HasWebhook() bool { return false }
 
 func newEmptyPrototype(conn DbConn, lockFactory lock.LockFactory) *prototype {
-	return &prototype{pipelineRef: pipelineRef{conn: conn, lockFactory: lockFactory}}
+	return &prototype{conn: conn, lockFactory: lockFactory}
 }
 
 func (p *prototype) Reload() (bool, error) {

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -190,7 +190,7 @@ type resource struct {
 }
 
 func newEmptyResource(conn DbConn, lockFactory lock.LockFactory) *resource {
-	return &resource{pipelineRef: pipelineRef{conn: conn, lockFactory: lockFactory}}
+	return &resource{conn: conn, lockFactory: lockFactory}
 }
 
 type ResourceNotFoundError struct {

--- a/atc/db/resource_cache_lifecycle_test.go
+++ b/atc/db/resource_cache_lifecycle_test.go
@@ -348,10 +348,8 @@ var _ = Describe("ResourceCacheLifecycle", func() {
 				err = defaultJob.SaveNextInputMapping(db.InputMapping{
 					"some-resource": db.InputResult{
 						Input: &db.AlgorithmInput{
-							AlgorithmVersion: db.AlgorithmVersion{
-								Version:    db.ResourceVersion(convertToSHA256(atc.Version(resourceConfigVersion.Version()))),
-								ResourceID: scenario.Resource("some-resource").ID(),
-							},
+							Version:    db.ResourceVersion(convertToSHA256(atc.Version(resourceConfigVersion.Version()))),
+							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						PassedBuildIDs: []int{},
 					},

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -217,7 +217,7 @@ func (t *resourceType) CurrentPinnedVersion() atc.Version { return nil }
 func (t *resourceType) HasWebhook() bool                  { return false }
 
 func newEmptyResourceType(conn DbConn, lockFactory lock.LockFactory) *resourceType {
-	return &resourceType{pipelineRef: pipelineRef{conn: conn, lockFactory: lockFactory}}
+	return &resourceType{conn: conn, lockFactory: lockFactory}
 }
 
 func (t *resourceType) Reload() (bool, error) {

--- a/atc/db/versions_db_test.go
+++ b/atc/db/versions_db_test.go
@@ -3,6 +3,7 @@ package db_test
 import (
 	"context"
 	"database/sql"
+	"slices"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -150,11 +151,11 @@ var _ = Describe("VersionsDB", func() {
 			})
 
 			It("returns all of the builds, newest first, with reruns relative to original build's order, and then finishes", func() {
-				for i := len(fillerBuilds) - 1; i >= 0; i-- {
+				for _, fillerBuild := range slices.Backward(fillerBuilds) {
 					buildID, ok, err := paginatedBuilds.Next(ctx)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(ok).To(BeTrue())
-					Expect(buildID).To(Equal(fillerBuilds[i].ID()))
+					Expect(buildID).To(Equal(fillerBuild.ID()))
 				}
 
 				buildID, ok, err := paginatedBuilds.Next(ctx)
@@ -294,11 +295,11 @@ var _ = Describe("VersionsDB", func() {
 			})
 
 			It("finishes after the rerun", func() {
-				for i := len(fillerBuilds) - 1; i >= 0; i-- {
+				for _, fillerBuild := range slices.Backward(fillerBuilds) {
 					buildID, ok, err := paginatedBuilds.Next(ctx)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(ok).To(BeTrue())
-					Expect(buildID).To(Equal(fillerBuilds[i].ID()))
+					Expect(buildID).To(Equal(fillerBuild.ID()))
 				}
 
 				buildID, ok, err := paginatedBuilds.Next(ctx)
@@ -344,11 +345,11 @@ var _ = Describe("VersionsDB", func() {
 			})
 
 			It("returns the original build after the rerun", func() {
-				for i := len(fillerBuilds) - 1; i >= 0; i-- {
+				for _, fillerBuild := range slices.Backward(fillerBuilds) {
 					buildID, ok, err := paginatedBuilds.Next(ctx)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(ok).To(BeTrue())
-					Expect(buildID).To(Equal(fillerBuilds[i].ID()))
+					Expect(buildID).To(Equal(fillerBuild.ID()))
 				}
 
 				buildID, ok, err := paginatedBuilds.Next(ctx)
@@ -411,11 +412,11 @@ var _ = Describe("VersionsDB", func() {
 			})
 
 			It("returns all builds, and then all three reruns, and finishes", func() {
-				for i := len(fillerBuilds) - 1; i >= 0; i-- {
+				for _, fillerBuild := range slices.Backward(fillerBuilds) {
 					buildID, ok, err := paginatedBuilds.Next(ctx)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(ok).To(BeTrue())
-					Expect(buildID).To(Equal(fillerBuilds[i].ID()))
+					Expect(buildID).To(Equal(fillerBuild.ID()))
 				}
 
 				buildID, ok, err := paginatedBuilds.Next(ctx)
@@ -537,11 +538,11 @@ var _ = Describe("VersionsDB", func() {
 				Expect(ok).To(BeTrue())
 				Expect(buildID).To(Equal(cursorBuild.ID()))
 
-				for i := len(olderBuilds) - 1; i >= 0; i-- {
+				for _, olderBuild := range slices.Backward(olderBuilds) {
 					buildID, ok, err := paginatedBuilds.Next(ctx)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(ok).To(BeTrue())
-					Expect(buildID).To(Equal(olderBuilds[i].ID()))
+					Expect(buildID).To(Equal(olderBuild.ID()))
 				}
 
 				buildID, ok, err = paginatedBuilds.Next(ctx)
@@ -616,11 +617,11 @@ var _ = Describe("VersionsDB", func() {
 				Expect(ok).To(BeTrue())
 				Expect(buildID).To(Equal(cursorBuild.ID()))
 
-				for i := len(olderBuilds) - 1; i >= 0; i-- {
+				for _, olderBuild := range slices.Backward(olderBuilds) {
 					buildID, ok, err := paginatedBuilds.Next(ctx)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(ok).To(BeTrue())
-					Expect(buildID).To(Equal(olderBuilds[i].ID()))
+					Expect(buildID).To(Equal(olderBuild.ID()))
 				}
 
 				buildID, ok, err = paginatedBuilds.Next(ctx)

--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"encoding/json"
 	"errors"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -204,7 +205,7 @@ func (pb *planBuilder) buildAcrossStep(plan atc.Plan) exec.Step {
 func (pb *planBuilder) buildDoStep(plan atc.Plan) exec.Step {
 	var step exec.Step = exec.IdentityStep{}
 
-	for i := len(*plan.Do) - 1; i >= 0; i-- {
+	for i := range slices.Backward(*plan.Do) {
 		innerPlan := (*plan.Do)[i]
 		innerPlan.Attempts = plan.Attempts
 		previous := pb.buildStep(innerPlan)

--- a/atc/gc/resource_cache_collector_test.go
+++ b/atc/gc/resource_cache_collector_test.go
@@ -137,10 +137,8 @@ var _ = Describe("ResourceCacheCollector", func() {
 						Expect(scenario.Job("some-job").SaveNextInputMapping(db.InputMapping{
 							"whatever": db.InputResult{
 								Input: &db.AlgorithmInput{
-									AlgorithmVersion: db.AlgorithmVersion{
-										Version:    db.ResourceVersion(versionSHA256),
-										ResourceID: scenario.Resource("some-resource").ID(),
-									},
+									Version:    db.ResourceVersion(versionSHA256),
+									ResourceID: scenario.Resource("some-resource").ID(),
 								},
 							},
 						}, true)).To(Succeed())

--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -98,15 +98,13 @@ func (config JobConfig) Inputs() []JobInputParams {
 	_ = config.StepConfig().Visit(StepRecursor{
 		OnGet: func(step *GetStep) error {
 			inputs = append(inputs, JobInputParams{
-				JobInput: JobInput{
-					Name:     step.Name,
-					Resource: step.ResourceName(),
-					Passed:   step.Passed,
-					Version:  step.Version,
-					Trigger:  step.Trigger,
-				},
-				Params: step.Params,
-				Tags:   step.Tags,
+				Name:     step.Name,
+				Resource: step.ResourceName(),
+				Passed:   step.Passed,
+				Version:  step.Version,
+				Trigger:  step.Trigger,
+				Params:   step.Params,
+				Tags:     step.Tags,
 			})
 
 			return nil

--- a/atc/job_config_test.go
+++ b/atc/job_config_test.go
@@ -109,19 +109,15 @@ var _ = Describe("JobConfig", func() {
 				It("uses both for inputs", func() {
 					Expect(inputs).To(Equal([]atc.JobInputParams{
 						{
-							JobInput: atc.JobInput{
-								Name:     "some-get-plan",
-								Resource: "some-get-plan",
-								Passed:   []string{"a", "b"},
-								Trigger:  true,
-							},
+							Name:     "some-get-plan",
+							Resource: "some-get-plan",
+							Passed:   []string{"a", "b"},
+							Trigger:  true,
 						},
 						{
-							JobInput: atc.JobInput{
-								Name:     "some-other-get-plan",
-								Resource: "some-other-get-plan",
-								Trigger:  false,
-							},
+							Name:     "some-other-get-plan",
+							Resource: "some-other-get-plan",
+							Trigger:  false,
 						},
 					}))
 
@@ -146,12 +142,10 @@ var _ = Describe("JobConfig", func() {
 					Expect(inputs).To(Equal(
 						[]atc.JobInputParams{
 							{
-								JobInput: atc.JobInput{
-									Name:     "a",
-									Resource: "a",
-									Version: &atc.VersionConfig{
-										Every: true,
-									},
+								Name:     "a",
+								Resource: "a",
+								Version: &atc.VersionConfig{
+									Every: true,
 								},
 							},
 						},
@@ -179,16 +173,12 @@ var _ = Describe("JobConfig", func() {
 				It("returns an input config for all get plans", func() {
 					Expect(inputs).To(ConsistOf(
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "a",
-								Resource: "a",
-							},
+							Name:     "a",
+							Resource: "a",
 						},
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "b",
-								Resource: "b",
-							},
+							Name:     "b",
+							Resource: "b",
 						},
 					))
 				})
@@ -214,16 +204,12 @@ var _ = Describe("JobConfig", func() {
 				It("returns an input config for all get plans", func() {
 					Expect(inputs).To(ConsistOf(
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "a",
-								Resource: "a",
-							},
+							Name:     "a",
+							Resource: "a",
 						},
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "b",
-								Resource: "b",
-							},
+							Name:     "b",
+							Resource: "b",
 						},
 					))
 
@@ -250,16 +236,12 @@ var _ = Describe("JobConfig", func() {
 				It("returns an input config for all get plans", func() {
 					Expect(inputs).To(ConsistOf(
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "a",
-								Resource: "a",
-							},
+							Name:     "a",
+							Resource: "a",
 						},
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "b",
-								Resource: "b",
-							},
+							Name:     "b",
+							Resource: "b",
 						},
 					))
 
@@ -286,16 +268,12 @@ var _ = Describe("JobConfig", func() {
 				It("returns an input config for all get plans", func() {
 					Expect(inputs).To(ConsistOf(
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "a",
-								Resource: "a",
-							},
+							Name:     "a",
+							Resource: "a",
 						},
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "b",
-								Resource: "b",
-							},
+							Name:     "b",
+							Resource: "b",
 						},
 					))
 
@@ -322,16 +300,12 @@ var _ = Describe("JobConfig", func() {
 				It("returns an input config for all get plans", func() {
 					Expect(inputs).To(ConsistOf(
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "a",
-								Resource: "a",
-							},
+							Name:     "a",
+							Resource: "a",
 						},
 						atc.JobInputParams{
-							JobInput: atc.JobInput{
-								Name:     "b",
-								Resource: "b",
-							},
+							Name:     "b",
+							Resource: "b",
 						},
 					))
 
@@ -353,11 +327,9 @@ var _ = Describe("JobConfig", func() {
 				It("uses it as resource in the input config", func() {
 					Expect(inputs).To(Equal([]atc.JobInputParams{
 						{
-							JobInput: atc.JobInput{
-								Name:     "some-get-plan",
-								Resource: "some-get-resource",
-								Trigger:  false,
-							},
+							Name:     "some-get-plan",
+							Resource: "some-get-resource",
+							Trigger:  false,
 						},
 					}))
 
@@ -402,26 +374,20 @@ var _ = Describe("JobConfig", func() {
 				It("returns an input config for all get plans", func() {
 					Expect(inputs).To(Equal([]atc.JobInputParams{
 						{
-							JobInput: atc.JobInput{
-								Name:     "a",
-								Resource: "a",
-								Trigger:  false,
-							},
+							Name:     "a",
+							Resource: "a",
+							Trigger:  false,
 						},
 						{
-							JobInput: atc.JobInput{
-								Name:     "b",
-								Resource: "some-resource",
-								Passed:   []string{"x"},
-								Trigger:  false,
-							},
+							Name:     "b",
+							Resource: "some-resource",
+							Passed:   []string{"x"},
+							Trigger:  false,
 						},
 						{
-							JobInput: atc.JobInput{
-								Name:     "c",
-								Resource: "c",
-								Trigger:  true,
-							},
+							Name:     "c",
+							Resource: "c",
+							Trigger:  true,
 						},
 					}))
 

--- a/atc/scheduler/algorithm/compute.go
+++ b/atc/scheduler/algorithm/compute.go
@@ -100,10 +100,8 @@ func (a *Algorithm) candidatesToInputMapping(ctx context.Context, mapping db.Inp
 
 			mapping[input.Name] = db.InputResult{
 				Input: &db.AlgorithmInput{
-					AlgorithmVersion: db.AlgorithmVersion{
-						ResourceID: input.ResourceID,
-						Version:    candidates[input.Name].Version,
-					},
+					ResourceID:      input.ResourceID,
+					Version:         candidates[input.Name].Version,
 					FirstOccurrence: firstOcc,
 				},
 				PassedBuildIDs: candidates[input.Name].SourceBuildIds,

--- a/atc/scheduler/algorithm/firstoccurrence_test.go
+++ b/atc/scheduler/algorithm/firstoccurrence_test.go
@@ -283,10 +283,8 @@ var _ = Describe("Resolve", func() {
 			Expect(inputMapping).To(Equal(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256("v2")),
-							ResourceID: 1,
-						},
+						Version:         db.ResourceVersion(convertToSHA256("v2")),
+						ResourceID:      1,
 						FirstOccurrence: false,
 					},
 					PassedBuildIDs: []int{},
@@ -313,9 +311,8 @@ var _ = Describe("Resolve", func() {
 			Expect(inputMapping).To(Equal(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256("v2")),
-							ResourceID: 1},
+						Version:         db.ResourceVersion(convertToSHA256("v2")),
+						ResourceID:      1,
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
@@ -342,9 +339,8 @@ var _ = Describe("Resolve", func() {
 			Expect(inputMapping).To(Equal(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256("v2")),
-							ResourceID: 1},
+						Version:         db.ResourceVersion(convertToSHA256("v2")),
+						ResourceID:      1,
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
@@ -371,9 +367,8 @@ var _ = Describe("Resolve", func() {
 			Expect(inputMapping).To(Equal(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256("v2")),
-							ResourceID: 1},
+						Version:         db.ResourceVersion(convertToSHA256("v2")),
+						ResourceID:      1,
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
@@ -399,9 +394,8 @@ var _ = Describe("Resolve", func() {
 			Expect(inputMapping).To(Equal(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256("v2")),
-							ResourceID: 1},
+						Version:         db.ResourceVersion(convertToSHA256("v2")),
+						ResourceID:      1,
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
@@ -445,9 +439,8 @@ var _ = Describe("Resolve", func() {
 			Expect(inputMapping).To(Equal(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256("v2")),
-							ResourceID: 1},
+						Version:         db.ResourceVersion(convertToSHA256("v2")),
+						ResourceID:      1,
 						FirstOccurrence: false,
 					},
 					PassedBuildIDs: []int{},
@@ -490,10 +483,8 @@ var _ = Describe("Resolve", func() {
 			Expect(inputMapping).To(Equal(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
-						AlgorithmVersion: db.AlgorithmVersion{
-							Version:    db.ResourceVersion(convertToSHA256("v3")),
-							ResourceID: 1,
-						},
+						Version:         db.ResourceVersion(convertToSHA256("v3")),
+						ResourceID:      1,
 						FirstOccurrence: false,
 					},
 					PassedBuildIDs: []int{},

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -420,10 +420,8 @@ var _ = Describe("BuildStarter", func() {
 								expectedInputMapping = map[string]db.InputResult{
 									"input-1": db.InputResult{
 										Input: &db.AlgorithmInput{
-											AlgorithmVersion: db.AlgorithmVersion{
-												ResourceID: 1,
-												Version:    db.ResourceVersion("1"),
-											},
+											ResourceID:      1,
+											Version:         db.ResourceVersion("1"),
 											FirstOccurrence: true,
 										},
 									},

--- a/atc/scheduler/scheduler_test.go
+++ b/atc/scheduler/scheduler_test.go
@@ -99,10 +99,8 @@ var _ = Describe("Scheduler", func() {
 					expectedInputMapping = map[string]db.InputResult{
 						"input-1": db.InputResult{
 							Input: &db.AlgorithmInput{
-								AlgorithmVersion: db.AlgorithmVersion{
-									ResourceID: 1,
-									Version:    db.ResourceVersion("1"),
-								},
+								ResourceID:      1,
+								Version:         db.ResourceVersion("1"),
 								FirstOccurrence: true,
 							},
 						},

--- a/atc/worker/gardenruntime/container.go
+++ b/atc/worker/gardenruntime/container.go
@@ -68,8 +68,7 @@ func (c Container) Run(_ context.Context, spec runtime.ProcessSpec, io runtime.P
 	process, err := c.GardenContainer.Run(streamCtx, toGardenProcessSpec(spec, properties), toGardenProcessIO(io))
 	if err != nil {
 		cancelStream()
-		var exeNotFound garden.ExecutableNotFoundError
-		if errors.As(err, &exeNotFound) {
+		if exeNotFound, ok := errors.AsType[garden.ExecutableNotFoundError](err); ok {
 			return nil, runtime.ExecutableNotFoundError{Message: exeNotFound.Message}
 		}
 		return nil, fmt.Errorf("start process: %w", err)

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"sort"
 	"strings"
 
@@ -126,9 +127,9 @@ func (strategy PlacementStrategy) Order(logger lager.Logger, pool Pool, workers 
 	// they should expect candidates to be sorted by those with the fewest build containers,
 	// and ties with the number of build containers are broken by the number of volumes
 	// which already exists on the worker.
-	for i := len(strategy) - 1; i >= 0; i-- {
+	for _, s := range slices.Backward(strategy) {
 		var err error
-		candidates, err = strategy[i].Order(logger, pool, candidates, spec)
+		candidates, err = s.Order(logger, pool, candidates, spec)
 		if err != nil {
 			return nil, err
 		}
@@ -153,8 +154,8 @@ func (strategy PlacementStrategy) Approve(logger lager.Logger, worker db.Worker,
 }
 
 func (strategy PlacementStrategy) Release(logger lager.Logger, worker db.Worker, spec runtime.ContainerSpec) {
-	for i := len(strategy) - 1; i >= 0; i-- {
-		strategy[i].Release(logger, worker, spec)
+	for _, s := range slices.Backward(strategy) {
+		s.Release(logger, worker, spec)
 	}
 }
 

--- a/atc/worker/pool_test.go
+++ b/atc/worker/pool_test.go
@@ -293,9 +293,9 @@ var _ = Describe("Pool", func() {
 
 			workerCh := make(chan runtime.Worker)
 
-			var callbackInvocations int32
+			var callbackInvocations atomic.Int32
 			callback := PoolCallback{
-				waitingForWorker: func() { atomic.AddInt32(&callbackInvocations, 1) },
+				waitingForWorker: func() { callbackInvocations.Add(1) },
 			}
 
 			By("selecting a worker when there are no satisfiable workers", func() {
@@ -319,7 +319,7 @@ var _ = Describe("Pool", func() {
 			})
 
 			By("validating that the step is marked as waiting", func() {
-				callbackCount := func() int32 { return atomic.LoadInt32(&callbackInvocations) }
+				callbackCount := func() int32 { return callbackInvocations.Load() }
 				metricCount := func() float64 {
 					labels := metric.StepsWaitingLabels{
 						TeamId: "123",

--- a/fly/commands/internal/templatehelpers/yaml_template.go
+++ b/fly/commands/internal/templatehelpers/yaml_template.go
@@ -3,6 +3,7 @@ package templatehelpers
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
@@ -70,8 +71,8 @@ func (yamlTemplate YamlTemplateWithParams) Evaluate(strict bool) ([]byte, error)
 
 	// second, we take all files. with values in the files specified later on command line taking precedence over the
 	// same values in the files specified earlier on command line
-	for i := len(yamlTemplate.templateVariablesFiles) - 1; i >= 0; i-- {
-		path := yamlTemplate.templateVariablesFiles[i]
+	for _, path := range slices.Backward(yamlTemplate.templateVariablesFiles) {
+
 		templateVars, err := os.ReadFile(string(path))
 		if err != nil {
 			return nil, fmt.Errorf("could not read template variables file (%s): %s", string(path), err.Error())

--- a/fly/integration/suite_test.go
+++ b/fly/integration/suite_test.go
@@ -126,7 +126,7 @@ func userInfoHandler() http.HandlerFunc {
 func validAccessToken(expiry time.Time) string {
 	GinkgoHelper()
 	accessToken, err := token.Factory{}.GenerateAccessToken(db.Claims{
-		Claims: jwt.Claims{Expiry: jwt.NewNumericDate(expiry)}},
+		Expiry: jwt.NewNumericDate(expiry)},
 	)
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/concourse/concourse
 
-go 1.26.3
+go 1.27.1
 
 require (
 	charm.land/bubbles/v2 v2.1.1
@@ -33,6 +33,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/go-cni v1.1.13
 	github.com/containerd/typeurl/v2 v2.3.0
+	github.com/containernetworking/cni v1.3.0
 	github.com/coreos/go-iptables v0.8.0
 	github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4
 	github.com/creack/pty v1.1.24
@@ -46,6 +47,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/google/jsonapi v1.0.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.8
@@ -93,9 +95,11 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.54.0
+	golang.org/x/net v0.57.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
+	golang.org/x/term v0.45.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.83.1
 	k8s.io/api v0.36.2
@@ -105,83 +109,10 @@ require (
 )
 
 require (
-	cloud.google.com/go/trace v1.16.0 // indirect
-	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // indirect
-	github.com/Microsoft/hcsshim v0.15.0-rc.1 // indirect
-	github.com/VividCortex/ewma v1.2.0 // indirect
-	github.com/beevik/etree v1.6.0 // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charlievieth/fs v0.0.3 // indirect
-	github.com/cloudfoundry/go-socks5 v0.0.0-20250423223041-4ad5fea42851 // indirect
-	github.com/cloudfoundry/socks5-proxy v0.2.182 // indirect
-	github.com/containerd/continuity v0.5.0 // indirect
-	github.com/containerd/fifo v1.1.0 // indirect
-	github.com/containerd/ttrpc v1.2.8 // indirect
-	github.com/containernetworking/cni v1.3.0
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dexidp/dex/api/v2 v2.4.0 // indirect
-	github.com/go-logr/logr v1.4.4 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-sql-driver/mysql v1.10.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0
-	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
-	github.com/gorilla/handlers v1.5.2 // indirect
-	github.com/gorilla/mux v1.8.1 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect
-	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
-	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
-	github.com/hashicorp/go-version v1.9.0 // indirect
-	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
-	github.com/jonboulle/clockwork v0.5.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
-	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.44 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/sys/mountinfo v0.7.2 // indirect
-	github.com/moby/sys/signal v0.7.1 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.70.0 // indirect
-	github.com/prometheus/procfs v0.21.1 // indirect
-	github.com/russellhaering/goxmldsig v1.6.0 // indirect
-	github.com/ryanuber/go-glob v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
-	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	golang.org/x/mod v0.38.0 // indirect
-	golang.org/x/net v0.57.0
-	golang.org/x/term v0.45.0
-	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/tools v0.48.0 // indirect
-	google.golang.org/api v0.280.0 // indirect
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/klog/v2 v2.140.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20260501160325-927ab1f70cd6 // indirect
-	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
-	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-)
-
-require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/trace v1.16.0 // indirect
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/AppsFlyer/go-sundheit v0.6.0 // indirect
 	github.com/Azure/go-ntlmssp v0.1.1 // indirect
@@ -189,6 +120,9 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/Microsoft/go-winio v0.6.3-0.20251027160822-ad3df93bed29 // indirect
+	github.com/Microsoft/hcsshim v0.15.0-rc.1 // indirect
+	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.31 // indirect
@@ -201,6 +135,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.0 // indirect
+	github.com/beevik/etree v1.6.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charlievieth/fs v0.0.3 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
@@ -209,21 +150,30 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/cloudfoundry/go-socks5 v0.0.0-20250423223041-4ad5fea42851 // indirect
+	github.com/cloudfoundry/socks5-proxy v0.2.182 // indirect
 	github.com/concourse/go-archive v1.0.1 // indirect
 	github.com/containerd/cgroups/v3 v3.1.3 // indirect
+	github.com/containerd/continuity v0.5.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.4 // indirect
 	github.com/containerd/plugin v1.1.0 // indirect
+	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/coreos/go-oidc/v3 v3.18.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dexidp/dex/api/v2 v2.4.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.13 // indirect
+	github.com/go-logr/logr v1.4.4 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.23.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.5 // indirect
 	github.com/go-openapi/swag v0.26.0 // indirect
@@ -238,47 +188,94 @@ require (
 	github.com/go-openapi/swag/stringutils v0.26.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
+	github.com/go-sql-driver/mysql v1.10.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260709232956-b9395ee17fa0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
+	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
+	github.com/gorilla/handlers v1.5.2 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
+	github.com/hashicorp/go-version v1.9.0 // indirect
+	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.12.3 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
+	github.com/mattn/go-sqlite3 v1.14.44 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
+	github.com/moby/sys/signal v0.7.1 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openbao/openbao/api/v2 v2.5.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/openzipkin/zipkin-go v0.4.3 // indirect
 	github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.70.0 // indirect
+	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russellhaering/goxmldsig v1.6.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sahilm/fuzzy v0.1.3 // indirect
 	github.com/sasha-s/go-deadlock v0.3.9 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/zalando/go-keyring v0.2.8 // indirect
+	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.step.sm/crypto v0.67.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
+	golang.org/x/mod v0.38.0 // indirect
+	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/tools v0.48.0 // indirect
+	google.golang.org/api v0.280.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/klog/v2 v2.140.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20260501160325-927ab1f70cd6 // indirect
+	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
+	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )

--- a/integration/internal/cmdtest/cmd.go
+++ b/integration/internal/cmdtest/cmd.go
@@ -80,8 +80,7 @@ func (cmd Cmd) Start(t *testing.T, args ...string) *exec.Cmd {
 func (cmd Cmd) Run(t *testing.T, args ...string) {
 	err := cmd.Try(args...)
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			if exitErr.ExitCode() != cmd.ExpectExitCode {
 				t.Fatalf("ExitCode %d != %d", exitErr.ExitCode(), cmd.ExpectExitCode)
 			}

--- a/skymarshal/storage/storage.go
+++ b/skymarshal/storage/storage.go
@@ -23,14 +23,12 @@ func NewPostgresStorage(log lager.Logger, postgres flag.PostgresConfig) (Storage
 	}
 
 	store := sql.Postgres{
-		NetworkDB: sql.NetworkDB{
-			Database:          postgres.Database,
-			User:              postgres.User,
-			Password:          postgres.Password,
-			Host:              host,
-			Port:              postgres.Port,
-			ConnectionTimeout: int(postgres.ConnectTimeout.Seconds()),
-		},
+		Database:          postgres.Database,
+		User:              postgres.User,
+		Password:          postgres.Password,
+		Host:              host,
+		Port:              postgres.Port,
+		ConnectionTimeout: int(postgres.ConnectTimeout.Seconds()),
 		SSL: sql.SSL{
 			Mode:     postgres.SSLMode,
 			CAFile:   string(postgres.CACert),

--- a/skymarshal/token/access_token_test.go
+++ b/skymarshal/token/access_token_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Access Tokens", func() {
 			factory := token.Factory{}
 			expectExpiry := jwt.NewNumericDate(time.Now())
 			rawToken, err := factory.GenerateAccessToken(db.Claims{
-				Claims: jwt.Claims{Expiry: expectExpiry},
+				Expiry: expectExpiry,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			expiry, err := factory.ParseExpiry(rawToken)

--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -129,7 +129,7 @@ func deployWithDriverAndSelectors(driver string, selectorFlags ...string) {
 func createPVC(name string, scName string) {
 	_, err := kubeClient.CoreV1().PersistentVolumeClaims(namespace).
 		Create(context.TODO(), &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Name: name, Namespace: namespace,
 			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: &scName,
 				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -337,7 +337,7 @@ func getPods(namespace string, listOptions metav1.ListOptions) []corev1.Pod {
 }
 
 func getNotRunningPodLogs() {
-	events, _ := kubeClient.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Running", TypeMeta: metav1.TypeMeta{Kind: "Pod"}})
+	events, _ := kubeClient.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Running", Kind: "Pod"})
 	for _, item := range events.Items {
 		fmt.Println(item)
 	}

--- a/worker/baggageclaim/client/client_resiliency_test.go
+++ b/worker/baggageclaim/client/client_resiliency_test.go
@@ -46,12 +46,10 @@ var _ = Describe("baggageclaim http client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-volume"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle: "some-volume",
-							Path:   "/some/path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: map[string]string{},
-								Privileged: false,
-							},
+							Handle:     "some-volume",
+							Path:       "/some/path",
+							Properties: map[string]string{},
+							Privileged: false,
 						}),
 					),
 					ghttp.CombineHandlers(

--- a/worker/baggageclaim/client_test.go
+++ b/worker/baggageclaim/client_test.go
@@ -206,11 +206,9 @@ var _ = Describe("Baggage Claim Client", func() {
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-								Handle: "some-handle",
-								Path:   "some-path",
-								VolumeOpts: volume.VolumeOpts{
-									Properties: volume.Properties{},
-								},
+								Handle:     "some-handle",
+								Path:       "some-path",
+								Properties: volume.Properties{},
 							}),
 						),
 						ghttp.CombineHandlers(
@@ -246,11 +244,9 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle: "some-handle",
-							Path:   "some-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{},
-							},
+							Handle:     "some-handle",
+							Path:       "some-path",
+							Properties: volume.Properties{},
 						}),
 					),
 					ghttp.CombineHandlers(
@@ -308,11 +304,9 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle: "some-handle",
-							Path:   "some-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{},
-							},
+							Handle:     "some-handle",
+							Path:       "some-path",
+							Properties: volume.Properties{},
 						}),
 					),
 					ghttp.CombineHandlers(
@@ -380,11 +374,9 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle: "some-handle",
-							Path:   "some-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{},
-							},
+							Handle:     "some-handle",
+							Path:       "some-path",
+							Properties: volume.Properties{},
 						}),
 					),
 					ghttp.CombineHandlers(
@@ -427,11 +419,9 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle: "some-handle",
-							Path:   "some-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{},
-							},
+							Handle:     "some-handle",
+							Path:       "some-path",
+							Properties: volume.Properties{},
 						}),
 					),
 					ghttp.CombineHandlers(
@@ -486,11 +476,9 @@ var _ = Describe("Baggage Claim Client", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/volumes-async/some-handle"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, volume.Volume{
-							Handle: "some-handle",
-							Path:   "some-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{},
-							},
+							Handle:     "some-handle",
+							Path:       "some-path",
+							Properties: volume.Properties{},
 						}),
 					),
 					ghttp.CombineHandlers(

--- a/worker/baggageclaim/fs/btrfs.go
+++ b/worker/baggageclaim/fs/btrfs.go
@@ -86,7 +86,7 @@ func (fs *BtrfsFilesystem) Delete() error {
 		return err
 	}
 
-	loopbackDevice := strings.Split(loopbackOutput, ":")[0]
+	loopbackDevice, _, _ := strings.Cut(loopbackOutput, ":")
 
 	_, err = fs.run(exec.Command(
 		"losetup",

--- a/worker/baggageclaim/volume/driver/btrfs.go
+++ b/worker/baggageclaim/volume/driver/btrfs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -76,8 +77,8 @@ func (driver *BtrFSDriver) DestroyVolume(vol volume.FilesystemVolume) error {
 		return fmt.Errorf("recursively walking subvolumes for %s failed: %v", vol.DataPath(), err)
 	}
 
-	for i := len(volumePathsToDelete) - 1; i >= 0; i-- {
-		_, _, err := driver.run(driver.btrfsBin, "subvolume", "delete", volumePathsToDelete[i])
+	for _, v := range slices.Backward(volumePathsToDelete) {
+		_, _, err := driver.run(driver.btrfsBin, "subvolume", "delete", v)
 		if err != nil {
 			return err
 		}

--- a/worker/baggageclaim/volume/filesystem.go
+++ b/worker/baggageclaim/volume/filesystem.go
@@ -142,12 +142,10 @@ func (fs *filesystem) LookupVolume(handle string) (FilesystemLiveVolume, bool, e
 	}
 
 	return &liveVolume{
-		baseVolume: baseVolume{
-			fs: fs,
+		fs: fs,
 
-			handle: handle,
-			dir:    volumePath,
-		},
+		handle: handle,
+		dir:    volumePath,
 	}, true, nil
 }
 
@@ -163,12 +161,10 @@ func (fs *filesystem) ListVolumes() ([]FilesystemLiveVolume, error) {
 		handle := liveDir.Name()
 
 		response = append(response, &liveVolume{
-			baseVolume: baseVolume{
-				fs: fs,
+			fs: fs,
 
-				handle: handle,
-				dir:    fs.liveVolumePath(handle),
-			},
+			handle: handle,
+			dir:    fs.liveVolumePath(handle),
 		})
 	}
 
@@ -189,11 +185,9 @@ func (fs *filesystem) CleanupOrphanedEntries() error {
 		fs.log.Debug("cleaning-up-dead-volume", lager.Data{"handle": handle})
 
 		deadVol := &deadVolume{
-			baseVolume: baseVolume{
-				fs:     fs,
-				handle: handle,
-				dir:    fs.deadVolumePath(handle),
-			},
+			fs:     fs,
+			handle: handle,
+			dir:    fs.deadVolumePath(handle),
 		}
 
 		if err := deadVol.Destroy(); err != nil {
@@ -239,12 +233,10 @@ func (fs *filesystem) initRawVolume(handle string) (*initVolume, error) {
 	}
 
 	volume := &initVolume{
-		baseVolume: baseVolume{
-			fs: fs,
+		fs: fs,
 
-			handle: handle,
-			dir:    volumePath,
-		},
+		handle: handle,
+		dir:    volumePath,
 	}
 
 	err = volume.StoreProperties(Properties{})
@@ -311,12 +303,10 @@ func (base *baseVolume) Parent() (FilesystemLiveVolume, bool, error) {
 	}
 
 	return &liveVolume{
-		baseVolume: baseVolume{
-			fs: base.fs,
+		fs: base.fs,
 
-			handle: filepath.Base(parentDir),
-			dir:    parentDir,
-		},
+		handle: filepath.Base(parentDir),
+		dir:    parentDir,
 	}, true, nil
 }
 
@@ -330,12 +320,10 @@ func (base *baseVolume) Destroy() error {
 	}
 
 	deadVol := &deadVolume{
-		baseVolume: baseVolume{
-			fs: base.fs,
+		fs: base.fs,
 
-			handle: base.handle,
-			dir:    deadDir,
-		},
+		handle: base.handle,
+		dir:    deadDir,
 	}
 
 	return deadVol.Destroy()
@@ -373,12 +361,10 @@ func (vol *initVolume) Initialize() (FilesystemLiveVolume, error) {
 	}
 
 	return &liveVolume{
-		baseVolume: baseVolume{
-			fs: vol.fs,
+		fs: vol.fs,
 
-			handle: vol.handle,
-			dir:    liveDir,
-		},
+		handle: vol.handle,
+		dir:    liveDir,
 	}, nil
 }
 

--- a/worker/baggageclaim/volume/promise_test.go
+++ b/worker/baggageclaim/volume/promise_test.go
@@ -12,11 +12,9 @@ var _ = Describe("Volume Promise", func() {
 		promise    Promise
 		testErr    = errors.New("some-error")
 		testVolume = Volume{
-			Handle: "some-handle",
-			Path:   "some-path",
-			VolumeOpts: VolumeOpts{
-				Properties: make(Properties),
-			},
+			Handle:     "some-handle",
+			Path:       "some-path",
+			Properties: make(Properties),
 		}
 	)
 

--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -681,12 +681,10 @@ func (repo *repository) volumeFrom(liveVolume FilesystemLiveVolume) (Volume, err
 	}
 
 	return Volume{
-		Handle: liveVolume.Handle(),
-		Path:   liveVolume.DataPath(),
-		VolumeOpts: VolumeOpts{
-			Properties: properties,
-			Privileged: isPrivileged,
-		},
+		Handle:     liveVolume.Handle(),
+		Path:       liveVolume.DataPath(),
+		Properties: properties,
+		Privileged: isPrivileged,
 	}, nil
 }
 

--- a/worker/baggageclaim/volume/repository_test.go
+++ b/worker/baggageclaim/volume/repository_test.go
@@ -543,36 +543,28 @@ var _ = Describe("Repository", func() {
 				It("returns all volumes", func() {
 					Expect(volumes).To(Equal(volume.Volumes{
 						{
-							Handle: "handle-1",
-							Path:   "handle-1-data-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{"a": "a", "b": "b"},
-								Privileged: true,
-							},
+							Handle:     "handle-1",
+							Path:       "handle-1-data-path",
+							Properties: volume.Properties{"a": "a", "b": "b"},
+							Privileged: true,
 						},
 						{
-							Handle: "handle-2",
-							Path:   "handle-2-data-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{"a": "a"},
-								Privileged: false,
-							},
+							Handle:     "handle-2",
+							Path:       "handle-2-data-path",
+							Properties: volume.Properties{"a": "a"},
+							Privileged: false,
 						},
 						{
-							Handle: "handle-3",
-							Path:   "handle-3-data-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{"b": "b"},
-								Privileged: true,
-							},
+							Handle:     "handle-3",
+							Path:       "handle-3-data-path",
+							Properties: volume.Properties{"b": "b"},
+							Privileged: true,
 						},
 						{
-							Handle: "handle-4",
-							Path:   "handle-4-data-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{},
-								Privileged: false,
-							},
+							Handle:     "handle-4",
+							Path:       "handle-4-data-path",
+							Properties: volume.Properties{},
+							Privileged: false,
 						},
 					}))
 				})
@@ -586,28 +578,22 @@ var _ = Describe("Repository", func() {
 						It("is not included in the response", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
-									Handle: "handle-1",
-									Path:   "handle-1-data-path",
-									VolumeOpts: volume.VolumeOpts{
-										Properties: volume.Properties{"a": "a", "b": "b"},
-										Privileged: true,
-									},
+									Handle:     "handle-1",
+									Path:       "handle-1-data-path",
+									Properties: volume.Properties{"a": "a", "b": "b"},
+									Privileged: true,
 								},
 								{
-									Handle: "handle-3",
-									Path:   "handle-3-data-path",
-									VolumeOpts: volume.VolumeOpts{
-										Properties: volume.Properties{"b": "b"},
-										Privileged: true,
-									},
+									Handle:     "handle-3",
+									Path:       "handle-3-data-path",
+									Properties: volume.Properties{"b": "b"},
+									Privileged: true,
 								},
 								{
-									Handle: "handle-4",
-									Path:   "handle-4-data-path",
-									VolumeOpts: volume.VolumeOpts{
-										Properties: volume.Properties{},
-										Privileged: false,
-									},
+									Handle:     "handle-4",
+									Path:       "handle-4-data-path",
+									Properties: volume.Properties{},
+									Privileged: false,
 								},
 							}))
 						})
@@ -621,28 +607,22 @@ var _ = Describe("Repository", func() {
 						It("returns only working volumes", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
-									Handle: "handle-1",
-									Path:   "handle-1-data-path",
-									VolumeOpts: volume.VolumeOpts{
-										Properties: volume.Properties{"a": "a", "b": "b"},
-										Privileged: true,
-									},
+									Handle:     "handle-1",
+									Path:       "handle-1-data-path",
+									Properties: volume.Properties{"a": "a", "b": "b"},
+									Privileged: true,
 								},
 								{
-									Handle: "handle-3",
-									Path:   "handle-3-data-path",
-									VolumeOpts: volume.VolumeOpts{
-										Properties: volume.Properties{"b": "b"},
-										Privileged: true,
-									},
+									Handle:     "handle-3",
+									Path:       "handle-3-data-path",
+									Properties: volume.Properties{"b": "b"},
+									Privileged: true,
 								},
 								{
-									Handle: "handle-4",
-									Path:   "handle-4-data-path",
-									VolumeOpts: volume.VolumeOpts{
-										Properties: volume.Properties{},
-										Privileged: false,
-									},
+									Handle:     "handle-4",
+									Path:       "handle-4-data-path",
+									Properties: volume.Properties{},
+									Privileged: false,
 								},
 							}))
 						})
@@ -658,20 +638,16 @@ var _ = Describe("Repository", func() {
 				It("returns only volumes whose properties match", func() {
 					Expect(volumes).To(Equal(volume.Volumes{
 						{
-							Handle: "handle-1",
-							Path:   "handle-1-data-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{"a": "a", "b": "b"},
-								Privileged: true,
-							},
+							Handle:     "handle-1",
+							Path:       "handle-1-data-path",
+							Properties: volume.Properties{"a": "a", "b": "b"},
+							Privileged: true,
 						},
 						{
-							Handle: "handle-2",
-							Path:   "handle-2-data-path",
-							VolumeOpts: volume.VolumeOpts{
-								Properties: volume.Properties{"a": "a"},
-								Privileged: false,
-							},
+							Handle:     "handle-2",
+							Path:       "handle-2-data-path",
+							Properties: volume.Properties{"a": "a"},
+							Privileged: false,
 						},
 					}))
 				})
@@ -685,12 +661,10 @@ var _ = Describe("Repository", func() {
 						It("is not included in the response", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
-									Handle: "handle-1",
-									Path:   "handle-1-data-path",
-									VolumeOpts: volume.VolumeOpts{
-										Properties: volume.Properties{"a": "a", "b": "b"},
-										Privileged: true,
-									},
+									Handle:     "handle-1",
+									Path:       "handle-1-data-path",
+									Properties: volume.Properties{"a": "a", "b": "b"},
+									Privileged: true,
 								},
 							}))
 						})
@@ -704,12 +678,10 @@ var _ = Describe("Repository", func() {
 						It("returns only working volumes", func() {
 							Expect(volumes).To(Equal(volume.Volumes{
 								{
-									Handle: "handle-1",
-									Path:   "handle-1-data-path",
-									VolumeOpts: volume.VolumeOpts{
-										Properties: volume.Properties{"a": "a", "b": "b"},
-										Privileged: true,
-									},
+									Handle:     "handle-1",
+									Path:       "handle-1-data-path",
+									Properties: volume.Properties{"a": "a", "b": "b"},
+									Privileged: true,
 								},
 							}))
 						})
@@ -767,12 +739,10 @@ var _ = Describe("Repository", func() {
 			It("returns the volume and true", func() {
 				Expect(found).To(BeTrue())
 				Expect(foundVolume).To(Equal(volume.Volume{
-					Handle: "some-volume",
-					Path:   "some-data-path",
-					VolumeOpts: volume.VolumeOpts{
-						Properties: volume.Properties{"a": "a", "b": "b"},
-						Privileged: true,
-					},
+					Handle:     "some-volume",
+					Path:       "some-data-path",
+					Properties: volume.Properties{"a": "a", "b": "b"},
+					Privileged: true,
 				}))
 			})
 
@@ -1108,12 +1078,10 @@ var _ = Describe("Repository", func() {
 				It("returns the parent volume and true", func() {
 					Expect(found).To(BeTrue())
 					Expect(parent).To(Equal(volume.Volume{
-						Handle: "parent-volume",
-						Path:   "parent-data-path",
-						VolumeOpts: volume.VolumeOpts{
-							Properties: volume.Properties{"parent": "property"},
-							Privileged: true,
-						},
+						Handle:     "parent-volume",
+						Path:       "parent-data-path",
+						Properties: volume.Properties{"parent": "property"},
+						Privileged: true,
 					}))
 				})
 

--- a/worker/network/mtu_test.go
+++ b/worker/network/mtu_test.go
@@ -30,7 +30,7 @@ func TestMTU(t *testing.T) {
 
 	addrs, err := iface.Addrs()
 	require.NoError(t, err)
-	ipAddr := strings.Split(addrs[0].String(), "/")[0]
+	ipAddr, _, _ := strings.Cut(addrs[0].String(), "/")
 
 	mtu, err := network.MTU(ipAddr)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Upgrades the Go toolchain to Go 1.27.1 and modernizes the codebase by running `go fix ./...` for Go 1.26 and Go 1.27 language features.

**End goal:** remove workarounds we put in place due to the Go bugs that are now resolved:
1. https://github.com/concourse/concourse/blob/7c5c7ca8d9737335cf8e8b10ca4f389ba4848f22/go-archive/tarfs/extract.go#L134
2. https://github.com/concourse/concourse/blob/7c5c7ca8d9737335cf8e8b10ca4f389ba4848f22/go-archive/tarfs/extract.go#L236 

## Changes

- **Toolchain & Dependencies**: Upgraded Go directive and toolchain to `1.27.1` in `go.mod` (`go get go@1.27.1 && go mod tidy`).
- **Go 1.26 Modernization**: Applied automatic fixes via `go fix ./...`.
- **Go 1.27 Modernization**: Applied Go 1.27 fixes, notably adopting struct literal field selectors to initialize nested and embedded struct fields directly across ATC, worker, Baggageclaim, and test suites.

## References
- [Go 1.27 Release Notes](https://go.dev/blog/go1.27)
- Struct literal field selectors for nested/embedded structs

Thanks to @marco-m-pix4d for teaching me about go fix :)