### PR TITLE
Revert workarounds for Go bugs

### DIFF
--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -79,7 +79,7 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 	fileInfo := header.FileInfo()
 	fileMode := fileInfo.Mode()
 
-	err := RootMkdirAll(root, filepath.Dir(filePath), 0755)
+	err := root.MkdirAll(filepath.Dir(filePath), 0755)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 		}
 
 	case tar.TypeDir:
-		err := RootMkdirAll(root, filePath, fileMode.Perm())
+		err := root.MkdirAll(filePath, fileMode.Perm())
 		if err != nil {
 			return err
 		}
@@ -231,9 +231,4 @@ func stripRoot(p string) string {
 	// Removes all leading forward and backwards slashes
 	p = strings.TrimLeft(p, `/\`)
 	return p
-}
-
-// Workaround for https://github.com/golang/go/issues/80308
-func RootMkdirAll(r *os.Root, path string, perm os.FileMode) error {
-	return r.MkdirAll(strings.TrimSuffix(path, "/"), perm)
 }

--- a/go-archive/tarfs/extract.go
+++ b/go-archive/tarfs/extract.go
@@ -128,10 +128,7 @@ func extractEntry(root *os.Root, header *tar.Header, input io.Reader, chown bool
 			}
 		}
 
-		// TODO: the filepath.FromSlash() is a workaround until the same fix
-		// lands in Go 1.27. It can be removed once we're on Go 1.27
-		// https://github.com/golang/go/issues/80073
-		err = root.Symlink(filepath.FromSlash(header.Linkname), filePath)
+		err = root.Symlink(header.Linkname, filePath)
 		if err != nil {
 			return err
 		}

--- a/go-archive/tarfs/extract_test.go
+++ b/go-archive/tarfs/extract_test.go
@@ -187,7 +187,7 @@ var _ = Describe("ExtractEntry", func() {
 			By("creating the target of the hard link", func() {
 				root, err := os.OpenRoot(dest)
 				Expect(err).ToNot(HaveOccurred())
-				err = tarfs.RootMkdirAll(root, "absolute/path/", 0755)
+				err = root.MkdirAll("absolute/path/", 0755)
 				Expect(err).ToNot(HaveOccurred())
 				f, err := root.Create("absolute/path/file")
 				Expect(err).ToNot(HaveOccurred())

--- a/go-archive/zipfs/extract.go
+++ b/go-archive/zipfs/extract.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/klauspost/compress/zip"
 )
@@ -60,12 +59,12 @@ func extractZipArchiveFile(root *os.Root, file *zip.File, input io.Reader) error
 	fileInfo := file.FileInfo()
 
 	if fileInfo.IsDir() {
-		err := RootMkdirAll(root, filePath, fileInfo.Mode().Perm())
+		err := root.MkdirAll(filePath, fileInfo.Mode().Perm())
 		if err != nil {
 			return err
 		}
 	} else {
-		err := RootMkdirAll(root, filepath.Dir(filePath), 0755)
+		err := root.MkdirAll(filepath.Dir(filePath), 0755)
 		if err != nil {
 			return err
 		}
@@ -91,9 +90,4 @@ func extractZipArchiveFile(root *os.Root, file *zip.File, input io.Reader) error
 	}
 
 	return nil
-}
-
-// Workaround for https://github.com/golang/go/issues/80308
-func RootMkdirAll(r *os.Root, path string, perm os.FileMode) error {
-	return r.MkdirAll(strings.TrimSuffix(path, "/"), perm)
 }


### PR DESCRIPTION
Revert workarounds for Go bugs

Remove workarounds we put in place due to the Go bugs that are now resolved:
1. https://github.com/golang/go/issues/80308 https://github.com/concourse/concourse/commit/626b7a510437df8b9b76422685319b6bd84f8505
2. https://github.com/golang/go/issues/80073  https://github.com/concourse/concourse/commit/d93aaed76c7491a46cdb00157468f3fbc19ec174

**Note:** Sadly, I don't know how to do stacked PRs from the fork. This PR depends on: https://github.com/concourse/concourse/pull/9701 since first 3 commits are actually arriving from there...