### PR TITLE
idtoken: advertise exp in the OpenID discovery document

### DIFF
--- a/atc/api/idtokenserver/openid_discovery.go
+++ b/atc/api/idtokenserver/openid_discovery.go
@@ -20,7 +20,7 @@ func (s *Server) OpenIDConfiguration(w http.ResponseWriter, r *http.Request) {
 	}{
 		Issuer:                           s.oidcIssuer,
 		JWKSUri:                          s.oidcIssuer + "/.well-known/jwks.json",
-		ClaimsSupported:                  []string{"aud", "iat", "iss", "jti", "sub"},
+		ClaimsSupported:                  []string{"aud", "exp", "iat", "iss", "jti", "sub"},
 		ResponseTypesSupported:           []string{"idtoken"},
 		IDTokenSigningAlgValuesSupported: []string{string(jose.RS256), string(jose.ES256)},
 		SubjectTypesSupported:            []string{"public"},

--- a/testflight/idtoken_test.go
+++ b/testflight/idtoken_test.go
@@ -90,7 +90,7 @@ var _ = Describe("A pipeline containing idtoken var sources", Ordered, func() {
 
 		// relying parties read this to decide what a token carries, so assert
 		// the whole advertised set rather than any single claim
-		Expect(cfg["claims_supported"]).To(ConsistOf("aud", "iat", "iss", "jti", "sub"))
+		Expect(cfg["claims_supported"]).To(ConsistOf("aud", "exp", "iat", "iss", "jti", "sub"))
 	}, DefaultSpecTimeout)
 })
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #9694

* idtoken: advertise exp in the OpenID discovery document
