### PR TITLE
fix(ui): support build shortcuts on non-US keyboards

### DIFF
--- a/web/elm/src/Build/Shortcuts.elm
+++ b/web/elm/src/Build/Shortcuts.elm
@@ -123,8 +123,8 @@ handleKeyPressed : Keyboard.KeyEvent -> ET (ShortcutsModel r)
 handleKeyPressed keyEvent ( model, effects ) =
     let
         newModel =
-            case ( model.previousKeyPress, keyEvent.shiftKey, keyEvent.code ) of
-                ( Nothing, False, Keyboard.G ) ->
+            case ( model.previousKeyPress, keyEvent.key ) of
+                ( Nothing, "g" ) ->
                     { model | previousKeyPress = Just keyEvent }
 
                 _ ->
@@ -134,37 +134,37 @@ handleKeyPressed keyEvent ( model, effects ) =
         ( newModel, effects )
 
     else
-        case ( keyEvent.code, keyEvent.shiftKey ) of
-            ( Keyboard.J, False ) ->
+        case keyEvent.key of
+            "j" ->
                 ( newModel, [ Scroll Down bodyId ] )
 
-            ( Keyboard.K, False ) ->
+            "k" ->
                 ( newModel, [ Scroll Up bodyId ] )
 
-            ( Keyboard.G, True ) ->
+            "G" ->
                 ( { newModel | autoScroll = True }, [ Scroll ToBottom bodyId ] )
 
-            ( Keyboard.G, False ) ->
+            "g" ->
                 if
-                    (model.previousKeyPress |> Maybe.map .code)
-                        == Just Keyboard.G
+                    (model.previousKeyPress |> Maybe.map .key)
+                        == Just "g"
                 then
                     ( { newModel | autoScroll = False }, [ Scroll ToTop bodyId ] )
 
                 else
                     ( newModel, effects )
 
-            ( Keyboard.Slash, True ) ->
+            "?" ->
                 ( { newModel | showHelp = not newModel.showHelp }, effects )
 
-            ( Keyboard.Escape, False ) ->
+            "Escape" ->
                 if model.showHelp then
                     ( { newModel | showHelp = False }, effects )
 
                 else
                     ( newModel, effects )
 
-            ( Keyboard.H, False ) ->
+            "h" ->
                 case nextHistoryItem model.history (historyItem model) of
                     Just item ->
                         ( newModel
@@ -181,7 +181,7 @@ handleKeyPressed keyEvent ( model, effects ) =
                     Nothing ->
                         ( newModel, effects )
 
-            ( Keyboard.L, False ) ->
+            "l" ->
                 case prevHistoryItem newModel.history (historyItem newModel) of
                     Just item ->
                         ( newModel
@@ -198,7 +198,7 @@ handleKeyPressed keyEvent ( model, effects ) =
                     Nothing ->
                         ( newModel, effects )
 
-            ( Keyboard.T, True ) ->
+            "T" ->
                 if not newModel.isTriggerBuildKeyDown then
                     (newModel.job
                         |> Maybe.map (DoTriggerBuild >> (::) >> Tuple.mapSecond)
@@ -209,7 +209,7 @@ handleKeyPressed keyEvent ( model, effects ) =
                 else
                     ( newModel, effects )
 
-            ( Keyboard.R, True ) ->
+            "R" ->
                 ( newModel
                 , effects
                     ++ (if Concourse.BuildStatus.isRunning newModel.status then
@@ -231,7 +231,7 @@ handleKeyPressed keyEvent ( model, effects ) =
                        )
                 )
 
-            ( Keyboard.A, True ) ->
+            "A" ->
                 if Just (historyItem newModel) == List.head newModel.history then
                     ( newModel, DoAbortBuild newModel.id :: effects )
 

--- a/web/elm/src/Keyboard.elm
+++ b/web/elm/src/Keyboard.elm
@@ -16,16 +16,18 @@ type alias KeyEvent =
     , shiftKey : Bool
     , metaKey : Bool
     , code : KeyCode
+    , key : String
     }
 
 
 decodeKeyEvent : Json.Decode.Decoder KeyEvent
 decodeKeyEvent =
-    Json.Decode.map4 KeyEvent
+    Json.Decode.map5 KeyEvent
         (Json.Decode.field "ctrlKey" Json.Decode.bool)
         (Json.Decode.field "shiftKey" Json.Decode.bool)
         (Json.Decode.field "metaKey" Json.Decode.bool)
         (Json.Decode.field "code" decodeKeyCode)
+        (Json.Decode.field "key" Json.Decode.string)
 
 
 type KeyCode

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1128,6 +1128,7 @@ all =
                                 , shiftKey = True
                                 , metaKey = False
                                 , code = Keyboard.T
+                                , key = "T"
                                 }
                         )
                     |> Tuple.first
@@ -1138,6 +1139,7 @@ all =
                                 , shiftKey = False
                                 , metaKey = False
                                 , code = Keyboard.T
+                                , key = "t"
                                 }
                         )
                     |> Tuple.first
@@ -1148,10 +1150,30 @@ all =
                                 , shiftKey = True
                                 , metaKey = False
                                 , code = Keyboard.T
+                                , key = "T"
                                 }
                         )
                     |> Tuple.second
                     |> Expect.equal [ Effects.DoTriggerBuild Data.shortJobId ]
+        , test "pressing 'j' uses the logical key instead of the physical key" <|
+            \_ ->
+                Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
+                    |> Application.handleCallback
+                        (Callback.BuildFetched <| Ok (Data.jobBuild BuildStatusStarted))
+                    |> Tuple.first
+                    |> Application.update
+                        (Msgs.DeliveryReceived <|
+                            KeyDown
+                                { ctrlKey = False
+                                , shiftKey = False
+                                , metaKey = False
+                                , code = Keyboard.K
+                                , key = "j"
+                                }
+                        )
+                    |> Tuple.second
+                    |> Expect.equal
+                        [ Effects.Scroll ScrollDirection.Down "build-body" ]
         , test "pressing 'R' reruns build" <|
             \_ ->
                 Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -1175,6 +1197,7 @@ all =
                                 , shiftKey = True
                                 , metaKey = False
                                 , code = Keyboard.R
+                                , key = "R"
                                 }
                         )
                     |> Tuple.second
@@ -1202,6 +1225,7 @@ all =
                                 , shiftKey = True
                                 , metaKey = False
                                 , code = Keyboard.R
+                                , key = "R"
                                 }
                         )
                     |> Tuple.second
@@ -1219,6 +1243,7 @@ all =
                                 , shiftKey = False
                                 , metaKey = False
                                 , code = Keyboard.G
+                                , key = "g"
                                 }
                         )
                     |> Tuple.first
@@ -1229,6 +1254,7 @@ all =
                                 , shiftKey = False
                                 , metaKey = False
                                 , code = Keyboard.G
+                                , key = "g"
                                 }
                         )
                     |> Tuple.second
@@ -1246,6 +1272,7 @@ all =
                                 , shiftKey = True
                                 , metaKey = False
                                 , code = Keyboard.G
+                                , key = "G"
                                 }
                         )
                     |> Tuple.second
@@ -1263,6 +1290,7 @@ all =
                                 , shiftKey = False
                                 , metaKey = False
                                 , code = Keyboard.G
+                                , key = "g"
                                 }
                         )
                     |> Tuple.second
@@ -1280,6 +1308,7 @@ all =
                                 , shiftKey = True
                                 , metaKey = False
                                 , code = Keyboard.Slash
+                                , key = "?"
                                 }
                         )
                     |> Tuple.first
@@ -1748,6 +1777,7 @@ all =
                                 , shiftKey = False
                                 , metaKey = False
                                 , code = Keyboard.L
+                                , key = "l"
                                 }
                             )
                         >> Tuple.second
@@ -1800,6 +1830,7 @@ all =
                                 , shiftKey = False
                                 , metaKey = False
                                 , code = Keyboard.L
+                                , key = "l"
                                 }
                             )
                         >> Tuple.second
@@ -1878,6 +1909,7 @@ all =
                                 , shiftKey = False
                                 , metaKey = True
                                 , code = Keyboard.L
+                                , key = "l"
                                 }
                             )
                         >> Tuple.second
@@ -1916,6 +1948,7 @@ all =
                                 , shiftKey = False
                                 , metaKey = False
                                 , code = Keyboard.L
+                                , key = "l"
                                 }
                             )
                         >> Tuple.second

--- a/web/elm/tests/DashboardSearchBarTests.elm
+++ b/web/elm/tests/DashboardSearchBarTests.elm
@@ -286,6 +286,16 @@ all =
                                     , shiftKey = False
                                     , metaKey = False
                                     , code = key
+                                    , key =
+                                        case key of
+                                            Keyboard.ArrowDown ->
+                                                "ArrowDown"
+
+                                            Keyboard.ArrowUp ->
+                                                "ArrowUp"
+
+                                            _ ->
+                                                ""
                                     }
                                 )
 
@@ -497,6 +507,7 @@ all =
                             , shiftKey = False
                             , metaKey = False
                             , code = Keyboard.Slash
+                            , key = "/"
                             }
                         )
                     >> Tuple.second
@@ -509,6 +520,7 @@ all =
                             , shiftKey = True
                             , metaKey = False
                             , code = Keyboard.Slash
+                            , key = "?"
                             }
                         )
                     >> Tuple.second
@@ -521,6 +533,7 @@ all =
                             , shiftKey = True
                             , metaKey = False
                             , code = Keyboard.A
+                            , key = "A"
                             }
                         )
                     >> Tuple.second
@@ -533,6 +546,7 @@ all =
                             , shiftKey = False
                             , metaKey = False
                             , code = Keyboard.Escape
+                            , key = "Escape"
                             }
                         )
                     >> Tuple.second

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -826,6 +826,7 @@ all =
                             , shiftKey = True
                             , metaKey = False
                             , code = Keyboard.Slash
+                            , key = "?"
                             }
                         )
                     |> Tuple.first
@@ -880,6 +881,7 @@ all =
                             , shiftKey = True
                             , metaKey = False
                             , code = Keyboard.Slash
+                            , key = "?"
                             }
                         )
                     |> Tuple.first
@@ -1867,6 +1869,7 @@ all =
                                     , shiftKey = True
                                     , metaKey = False
                                     , code = Keyboard.Slash
+                                    , key = "?"
                                     }
                             )
                         |> Tuple.first

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -222,6 +222,7 @@ all =
                                         , shiftKey = False
                                         , metaKey = False
                                         , code = Keyboard.A
+                                        , key = "a"
                                         }
                                 )
                             |> Tuple.second
@@ -236,6 +237,7 @@ all =
                                         , shiftKey = False
                                         , metaKey = False
                                         , code = Keyboard.F
+                                        , key = "f"
                                         }
                                 )
                             |> Tuple.second
@@ -250,6 +252,7 @@ all =
                                         , shiftKey = True
                                         , metaKey = False
                                         , code = Keyboard.F
+                                        , key = "F"
                                         }
                                 )
                             |> Tuple.second

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -3824,6 +3824,7 @@ pressEnterKey =
                 , shiftKey = False
                 , metaKey = False
                 , code = Keyboard.Enter
+                , key = "Enter"
                 }
         )
 
@@ -3839,6 +3840,7 @@ pressControlEnter =
                 , shiftKey = False
                 , metaKey = False
                 , code = Keyboard.Enter
+                , key = "Enter"
                 }
         )
 
@@ -3854,6 +3856,7 @@ pressMetaEnter =
                 , shiftKey = False
                 , metaKey = True
                 , code = Keyboard.Enter
+                , key = "Enter"
                 }
         )
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #9687

- Fix build-page keyboard shortcuts for non-US keyboard layouts.
- Add the layout-aware `KeyboardEvent.key` value to `Keyboard.KeyEvent` while retaining the physical `code` value.
- Update build-page shortcuts to use the semantic `key` value for shortcuts such as `j`, `k`, `g`, `G`, `?`, `h`, `l`, `T`, `R`, and `A`.
- Keep the physical `code` value for key-up handling where physical-key tracking is required, avoiding regressions in existing shortcut behavior.
- Add regression coverage that verifies shortcut handling is based on the logical key rather than the physical US-keyboard position.
- Update affected keyboard-event test fixtures to include the new `key` field.

### Validation

- `npm test` passes.
- `npm run format` passes.
- `npm run build-elm` passes.
- `git diff --check` passes.

## Notes to reviewer

The key design decision is to use `KeyboardEvent.key` only for build-page shortcut semantics. `KeyboardEvent.code` remains available and is intentionally retained for physical-key state handling.

This means a shortcut such as `j` is recognized based on the character produced by the user's keyboard layout rather than assuming the physical position of the US `J` key.

The regression test intentionally uses a different physical `code` with `key = "j"` to verify that shortcut behavior is driven by the logical key value.

No UI layout/visual changes were made, so there are no before/after screenshots to include.