### PR TITLE
fix baggageclaim tests on windows

### DIFF
--- a/worker/baggageclaim/volume/filesystem.go
+++ b/worker/baggageclaim/volume/filesystem.go
@@ -1,7 +1,6 @@
 package volume
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -236,17 +235,6 @@ func (fs *filesystem) volumeExists(handle string) bool {
 		return true
 	}
 	return fs.pathKnown(fs.liveVolumePath(handle))
-}
-
-func pathKnown(path string) bool {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true
-	}
-	if errors.Is(err, os.ErrNotExist) {
-		return false
-	}
-	return true
 }
 
 func (fs *filesystem) initRawVolume(handle string) (*initVolume, error) {

--- a/worker/baggageclaim/volume/filesystem_unix.go
+++ b/worker/baggageclaim/volume/filesystem_unix.go
@@ -1,0 +1,19 @@
+//go:build linux || darwin
+
+package volume
+
+import (
+	"errors"
+	"os"
+)
+
+func pathKnown(path string) bool {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
+}

--- a/worker/baggageclaim/volume/filesystem_windows.go
+++ b/worker/baggageclaim/volume/filesystem_windows.go
@@ -1,0 +1,18 @@
+package volume
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func pathKnown(path string) bool {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
## Changes proposed by this PR

Follow-up fix for https://github.com/concourse/concourse/pull/9695

we needed to fix the specific error from windows. Both `ERROR_FILE_NOT_FOUND` and `ERROR_PATH_NOT_FOUND` fall under Go's generic `os.ErrNotExist` error.

On macOS and Linux, the existing code works as expected.