### PR TITLE
fix: race condition during web restart + integration test

### DIFF
--- a/atc/worker/gardenruntime/gardenruntimetest/garden.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/garden.go
@@ -16,6 +16,7 @@ import (
 
 type Garden struct {
 	ContainerList  []*Container
+	BeforeCreate   func(spec garden.ContainerSpec)
 	containersLock sync.Mutex
 }
 
@@ -55,14 +56,19 @@ func (g *Garden) Create(spec garden.ContainerSpec) (gclient.Container, error) {
 	if handle == "fail-to-create" {
 		return nil, errors.New("failed to create (because handle is fail-to-create)")
 	}
-	if _, _, ok := g.FindContainer(handle); ok {
-		return nil, fmt.Errorf("handle %s already exists", handle)
-	}
 
-	container := NewContainer(handle).WithSpec(spec)
+	if g.BeforeCreate != nil {
+		g.BeforeCreate(spec)
+	}
 
 	g.containersLock.Lock()
 	defer g.containersLock.Unlock()
+	for _, c := range g.ContainerList {
+		if c.handle == handle {
+			return nil, fmt.Errorf("handle %s already exists", handle)
+		}
+	}
+	container := NewContainer(handle).WithSpec(spec)
 	g.ContainerList = append(g.ContainerList, container)
 	return container, nil
 }

--- a/atc/worker/gardenruntime/gardenruntimetest/worker.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/worker.go
@@ -30,6 +30,7 @@ type WorkerSetupFunc func(*atc.Worker)
 type Worker struct {
 	WorkerName       string
 	Containers       []*Container
+	GardenClient     *Garden
 	Volumes          []*Volume
 	SetupFuncs       []SetupFunc
 	WorkerSetupFuncs []WorkerSetupFunc
@@ -60,9 +61,13 @@ func (w *Worker) Setup(s *workertest.Scenario) {
 }
 
 func (w Worker) Build(db worker.DB, dbWorker db.Worker) runtime.Worker {
+	gdn := w.GardenClient
+	if gdn == nil {
+		gdn = &Garden{ContainerList: w.Containers}
+	}
 	return gardenruntime.NewWorker(
 		dbWorker,
-		&Garden{ContainerList: w.Containers},
+		gdn,
 		&Baggageclaim{Volumes: w.Volumes, Mutex: sync.Mutex{}},
 		db.ToGardenRuntimeDB(),
 		worker.NewStreamer(db.ResourceCacheFactory, compression.NewGzipCompression(), 0, worker.P2PConfig{
@@ -76,6 +81,12 @@ func (w Worker) WithGardenContainers(containers ...*Container) *Worker {
 	w2.Containers = make([]*Container, len(w.Containers)+len(containers))
 	copy(w2.Containers, w.Containers)
 	copy(w2.Containers[len(w.Containers):], containers)
+	return &w2
+}
+
+func (w Worker) WithGarden(g *Garden) *Worker {
+	w2 := w
+	w2.GardenClient = g
 	return &w2
 }
 

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -238,6 +238,9 @@ func (worker *Worker) createGardenContainer(
 
 	gardenContainer, err := worker.gardenClient.Create(gdnSpec)
 	if err != nil {
+		if existing, lookupErr := worker.gardenClient.Lookup(creatingContainer.Handle()); lookupErr == nil {
+			return existing, nil
+		}
 		logger.Error("failed-to-create-container-in-garden", err)
 		markContainerAsFailed(logger, creatingContainer)
 		return nil, err

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -1765,6 +1765,56 @@ var _ = Describe("Garden Worker", func() {
 		})
 	})
 
+	Test("concurrent container creation for the same handle succeeds in HA mode", func() {
+		gardenDbl := &grt.Garden{}
+
+		scenario := Setup(
+			workertest.WithWorkers(
+				grt.NewWorker("worker").
+					WithGarden(gardenDbl).
+					WithDBContainersInState(grt.Creating, "race-handle"),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		arrived := make(chan struct{}, 2)
+		proceed := make(chan struct{})
+		gardenDbl.BeforeCreate = func(_ garden.ContainerSpec) {
+			arrived <- struct{}{}
+			<-proceed
+		}
+
+		errs := make(chan error, 2)
+		for range 2 {
+			go func() {
+				_, _, err := worker.FindOrCreateContainer(
+					ctx,
+					db.NewFixedHandleContainerOwner("race-handle"),
+					db.ContainerMetadata{},
+					runtime.ContainerSpec{
+						ImageSpec: runtime.ImageSpec{ImageURL: "raw:///img/rootfs"},
+					},
+					delegate,
+				)
+				errs <- err
+			}()
+		}
+
+		Eventually(arrived, "10s").Should(HaveLen(2))
+		close(proceed)
+
+		var allErrs []error
+		for range 2 {
+			allErrs = append(allErrs, <-errs)
+		}
+
+		for _, err := range allErrs {
+			if err != nil {
+				Expect(err).ToNot(MatchError(ContainSubstring("already exists")))
+			}
+		}
+	})
+
 	Test("run/attach process context cancellation", func() {
 		scenario := Setup(
 			workertest.WithWorkers(


### PR DESCRIPTION
# Changes proposed by this PR

closes #9711

## What

When two ATC instances both try to create the same container at the same time, one of them would fail with "handle already exists". This left the build in a broken state even though the container was successfully created by the other instance.

## Why

In an HA setup, both ATCs can see a container marked as `creating` in the database and both try to create it in Garden. The second one loses the race and gets an error. Instead of treating this as a real failure, we now check if the container already exists in Garden before giving up — if it does, we just use it.

## How

In `createGardenContainer`, after a failed `Create` call, we attempt a `Lookup` on the same handle. If the container is there, we return it. If not, we fall back to the original error path.

A new test covers the concurrent case: two goroutines both race to create a container with the same handle and both must succeed without returning an "already exists" error.

## Test helper changes

To make the race deterministic, the test needs to pause both goroutines inside `Garden.Create` at the same time before either one proceeds. This required two small additions to the test double:

- `BeforeCreate` hook on `grt.Garden` — called just before the lock is acquired, giving the test a place to synchronise both goroutines
- `WithGarden` on `grt.Worker` — the only way to hand a pre-configured `*Garden` to the worker is before `Build()` is called, since `scenario.Worker()` returns a plain interface with no path back to the underlying garden instance

Both follow the same pattern already used for `WithGardenContainers` in the same file.

## Test

- Test fails without the fix (one goroutine gets "already exists")
- Test passes with the fix (both goroutines succeed)
