### PR TITLE
fix: Vault URL validation scheme broken with placeholder

### DIFF
--- a/atc/creds/vault/manager.go
+++ b/atc/creds/vault/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -144,14 +145,16 @@ func (manager VaultManager) Validate() error {
 		return fmt.Errorf("invalid URL: %s", err)
 	}
 
-	switch u.Scheme {
-	case "http", "https":
-	default:
-		return fmt.Errorf("invalid scheme %q: must be http or https", u.Scheme)
-	}
+	if !strings.Contains(manager.URL, "((") {
+		switch u.Scheme {
+		case "http", "https":
+		default:
+			return fmt.Errorf("invalid scheme %q: must be http or https", u.Scheme)
+		}
 
-	if u.Hostname() == "" {
-		return fmt.Errorf("URL must specify a host")
+		if u.Hostname() == "" {
+			return fmt.Errorf("URL must specify a host")
+		}
 	}
 
 	if manager.PathPrefix == "" {

--- a/atc/creds/vault/manager_test.go
+++ b/atc/creds/vault/manager_test.go
@@ -82,6 +82,16 @@ var _ = Describe("VaultManager", func() {
 			manager.URL = "http:///foobar"
 			Expect(manager.Validate()).To(MatchError(`URL must specify a host`))
 		})
+
+		It("passes when URL is an unresolved variable reference", func() {
+			manager.URL = "((v.vault_addr))"
+			Expect(manager.Validate()).To(BeNil())
+		})
+
+		It("passes when URL contains an unresolved variable reference for the host portion", func() {
+			manager.URL = "https://((v.vault_addr))"
+			Expect(manager.Validate()).To(BeNil())
+		})
 	})
 
 	Describe("Config", func() {


### PR DESCRIPTION
## Changes proposed by this PR

closes #9706

Tested on local Concourse with example pipeline:
```
var_sources:
- name: secrets
  type: vault
  config:
    url: ((v.vault_addr))
    auth_backend: userpass
    auth_params:
      username: ((v.username))
      password: ((v.password))
    path_prefix: /concourse

jobs:
- name: hello
  plan:
  - task: say-hello
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: {repository: alpine}
      run:
        path: echo
        args: ["hello world"]
```

